### PR TITLE
feat: v1.1 — new HTML elements, advanced CSS, PDF bookmarks, remote resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --verbose
+      - run: cargo test --verbose --features remote
 
   clippy:
     runs-on: ubuntu-latest
@@ -113,7 +114,7 @@ jobs:
           path: ~/.cargo/bin/cargo-tarpaulin
           key: tarpaulin-${{ runner.os }}-v2
       - run: command -v cargo-tarpaulin || cargo install cargo-tarpaulin
-      - run: cargo tarpaulin --out xml --output-dir . --skip-clean
+      - run: cargo tarpaulin --out xml --output-dir . --skip-clean --features remote
       - uses: codecov/codecov-action@v5
         with:
           files: ./cobertura.xml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = []
 async = ["tokio"]
+remote = ["ureq"]
 wasm = ["wasm-bindgen", "js-sys"]
 
 [dependencies]
@@ -25,6 +26,7 @@ html5ever = "0.27"
 markup5ever_rcdom = "0.3"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "rt"], optional = true }
+ureq = { version = "3", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -250,11 +250,14 @@ Supported values: `A4`, `letter`, `legal`, `landscape`, custom dimensions (`210m
 
 ## Images
 
-JPEG and PNG images are supported via data URIs and local file paths.
+JPEG and PNG images are supported via data URIs, local file paths, and remote URLs.
 
 ```html
 <!-- Data URI -->
 <img src="data:image/jpeg;base64,/9j/4AAQ..." width="200" height="150">
+
+<!-- Remote URL (requires "remote" feature) -->
+<img src="https://example.com/photo.jpg" width="300" height="200">
 
 <!-- Local file -->
 <img src="photo.jpg" width="300" height="200">
@@ -395,13 +398,34 @@ ironpress::convert_markdown_file_async("input.md", "output.pdf").await.unwrap();
 
 The HTML parsing, layout, and rendering remain synchronous (CPU-bound). Async is used for file reads and writes via tokio.
 
+## Remote Resources
+
+Enable the `remote` feature to load images and fonts from HTTP/HTTPS URLs:
+
+```toml
+ironpress = { version = "1.0", features = ["remote"] }
+```
+
+```html
+<img src="https://example.com/logo.png" width="200" height="100">
+
+<style>
+  @font-face {
+    font-family: "RemoteFont";
+    src: url("https://example.com/font.ttf");
+  }
+</style>
+```
+
+Remote resources are capped at 10 MB each. Without the `remote` feature, remote URLs are silently ignored (no network requests are made).
+
 ## Security
 
 HTML is sanitized by default before conversion:
 
 - `<script>`, `<iframe>`, `<object>`, `<embed>`, `<form>` tags are stripped
 - `<style>` tags are preserved but dangerous CSS (external `url()`, `expression()`) is removed
-- `@import` and `@font-face` only load local files (remote URLs are blocked, paths sandboxed in `base_dir`)
+- `@import` and `@font-face` load local files only by default (paths sandboxed in `base_dir`); remote URLs require the `remote` feature
 - Event handlers (`onclick`, `onload`, etc.) are removed
 - `javascript:` URLs are neutralized
 - Input size (10 MB) and nesting depth (100 levels) are limited
@@ -475,7 +499,7 @@ Three functions are exported: `htmlToPdf(html)`, `markdownToPdf(md)`, and `htmlT
 
 ironpress uses three layers of testing:
 
-- **Unit tests**: 1610+ tests covering parsing, style computation, layout, and rendering
+- **Unit tests**: 1620+ tests covering parsing, style computation, layout, and rendering
 - **Property-based tests**: [proptest](https://crates.io/crates/proptest) verifies invariants across thousands of random inputs (no panics on arbitrary HTML/CSS/Markdown, valid PDF output, correct page structure)
 - **Fuzz targets**: 6 [cargo-fuzz](https://rust-fuzz.github.io/book/cargo-fuzz.html) targets — HTML parser, CSS parser, Markdown parser, full pipeline, SVG, and table/flex layout (`cargo +nightly fuzz run fuzz_html`). All targets run in CI on every push.
 
@@ -497,8 +521,8 @@ ironpress uses three layers of testing:
 
 - [x] Auto-generated PDF bookmarks/outlines from headings (h1-h6)
 - [x] Page headers and footers with page numbering (`{page}` / `{pages}` placeholders)
-- [ ] Remote images (`<img src="https://...">`)
-- [ ] Remote fonts (Google Fonts URLs)
+- [x] Remote images (`<img src="https://...">`) via `remote` feature
+- [x] Remote fonts (`@font-face src: url("https://...")`) via `remote` feature
 
 ### Future
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Other Rust PDF crates shell out to headless Chrome or wkhtmltopdf. ironpress doe
 - [How It Works](#how-it-works)
 - [WASM](#wasm)
 - [Testing](#testing)
+- [Roadmap](#roadmap)
 - [License](#license)
 
 ## Quick Start
@@ -74,9 +75,13 @@ let pdf = HtmlConverter::new()
     .page_size(PageSize::LETTER)        // default: A4
     .margin(Margin::uniform(54.0))      // default: 72pt (1 inch)
     .sanitize(false)                    // default: true
+    .header("My Document")              // optional page header
+    .footer("Page {page} of {pages}")   // optional page footer
     .convert("<h1>Custom page</h1>")
     .unwrap();
 ```
+
+Headings (`<h1>` through `<h6>`) are automatically added as PDF bookmarks/outlines, visible in the sidebar of most PDF readers.
 
 ### Custom fonts
 
@@ -149,6 +154,9 @@ Supported Markdown syntax: headings (`#` to `######`), bold (`**`), italic (`*`)
 | Semantic sections | `<section>`, `<article>`, `<nav>`, `<header>`, `<footer>`, `<main>`, `<aside>`, `<details>`, `<summary>` |
 | Inline formatting | `<strong>`, `<b>`, `<em>`, `<i>`, `<u>`, `<small>`, `<sub>`, `<sup>`, `<code>`, `<abbr>`, `<span>` |
 | Text decoration | `<del>`, `<s>` (strikethrough), `<ins>` (underline), `<mark>` (highlight) |
+| Form controls | `<input>`, `<select>`, `<textarea>` with static visual rendering (borders, value/placeholder text) |
+| Media | `<video>`, `<audio>` rendered as placeholder rectangles with play icon |
+| Gauges | `<progress>`, `<meter>` with filled bar (meter supports `low`/`high` color thresholds) |
 | Links | `<a>` with clickable PDF link annotations |
 | Images | `<img>` with JPEG and PNG support (data URIs and local files) |
 | SVG | Inline `<svg>` with `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polyline>`, `<polygon>`, `<path>`, `<g>`, transforms, viewBox |
@@ -167,7 +175,8 @@ Supported Markdown syntax: headings (`#` to `######`), bold (`**`), italic (`*`)
 | Box model | `margin` (including `auto`), `padding`, `border`, `border-top/right/bottom/left`, `border-width`, `border-color`, `border-radius`, `outline`, `outline-width`, `outline-color`, `box-sizing`, `width`, `height`, `min-width`, `min-height`, `max-width`, `max-height` |
 | Layout | `text-align` (left, center, right, justify), `line-height`, `display` (none, block, inline, flex, grid), `float` (left, right), `clear`, `position` (static, relative, absolute), `z-index` |
 | Flexbox | `flex-direction`, `justify-content`, `align-items`, `flex-wrap`, `flex-grow`, `flex-shrink`, `flex-basis`, `flex` (shorthand), `gap` |
-| Grid | `grid-template-columns` (fixed, `fr`, `auto`), `grid-gap` |
+| Grid | `grid-template-columns` (fixed, `fr`, `auto`, `repeat()`, `minmax()`, `auto-fill`, `auto-fit`), `grid-gap` |
+| Multi-column | `column-count`, `columns`, `column-gap` |
 | Positioning | `top`, `left`, `z-index` |
 | Visual effects | `box-shadow`, `transform` (rotate, scale, translate), `overflow` (visible, hidden), `visibility` |
 | Backgrounds | `background-color`, `background-position`, `background-size`, `background-repeat`, `linear-gradient()`, `radial-gradient()` |
@@ -466,9 +475,39 @@ Three functions are exported: `htmlToPdf(html)`, `markdownToPdf(md)`, and `htmlT
 
 ironpress uses three layers of testing:
 
-- **Unit tests**: 1580+ tests covering parsing, style computation, layout, and rendering
+- **Unit tests**: 1610+ tests covering parsing, style computation, layout, and rendering
 - **Property-based tests**: [proptest](https://crates.io/crates/proptest) verifies invariants across thousands of random inputs (no panics on arbitrary HTML/CSS/Markdown, valid PDF output, correct page structure)
 - **Fuzz targets**: 6 [cargo-fuzz](https://rust-fuzz.github.io/book/cargo-fuzz.html) targets — HTML parser, CSS parser, Markdown parser, full pipeline, SVG, and table/flex layout (`cargo +nightly fuzz run fuzz_html`). All targets run in CI on every push.
+
+## Roadmap
+
+### v1.1 — More HTML elements
+
+- [x] `<input>`, `<select>`, `<textarea>` — static visual rendering for PDF forms (invoices, contracts)
+- [x] `<video>`, `<audio>` — placeholder with play icon
+- [x] `<progress>`, `<meter>` — visual bars with color thresholds
+
+### v1.2 — Advanced CSS
+
+- [x] CSS Grid: `repeat()`, `minmax()`, `auto-fill`, `auto-fit`
+- [x] `columns` / `column-count` / `column-gap` (multi-column layout)
+- [ ] `@media` queries beyond print/screen
+
+### v1.3 — PDF features
+
+- [x] Auto-generated PDF bookmarks/outlines from headings (h1-h6)
+- [x] Page headers and footers with page numbering (`{page}` / `{pages}` placeholders)
+- [ ] Remote images (`<img src="https://...">`)
+- [ ] Remote fonts (Google Fonts URLs)
+
+### Future
+
+- [ ] CLI tool (`ironpress convert input.html output.pdf`)
+- [ ] Python bindings (PyO3)
+- [ ] Node.js native addon
+- [ ] Online playground (WASM-powered live preview)
+- [ ] Visual examples and screenshots in README
+- [ ] Ready-to-use templates (invoice, resume, report, letter)
 
 ## License
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -8547,4 +8547,162 @@ mod _removed {
             "Expected 2 rows from 4 items in 2-column layout"
         );
     }
+
+    #[test]
+    fn layout_input_empty_no_value() {
+        let html = r#"<input type="text">"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn layout_select_empty_options() {
+        let html = r#"<select></select>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn layout_textarea_empty() {
+        let html = r#"<textarea></textarea>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn layout_video_with_css_dimensions() {
+        let html = r#"<video style="width: 400px; height: 300px"></video>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty());
+    }
+
+    #[test]
+    fn layout_audio_with_css_dimensions() {
+        let html = r#"<audio style="width: 250px"></audio>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn layout_progress_no_value_attr() {
+        let html = r#"<progress></progress>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        let bar = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { fraction, .. } = el {
+                Some(*fraction)
+            } else {
+                None
+            }
+        });
+        assert_eq!(bar, Some(0.0));
+    }
+
+    #[test]
+    fn layout_meter_no_thresholds() {
+        let html = r#"<meter value="50" max="100"></meter>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let fill = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { fill_color, .. } = el {
+                Some(*fill_color)
+            } else {
+                None
+            }
+        });
+        // 50/100 = 0.5, between default low (25) and high (75) → yellow
+        assert!(fill.is_some());
+        let (r, _, _) = fill.unwrap();
+        assert!(r > 0.9, "Expected yellow fill for mid-range meter");
+    }
+
+    #[test]
+    fn layout_meter_zero_max() {
+        let html = r#"<meter value="5" max="0"></meter>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let bar = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { fraction, .. } = el {
+                Some(*fraction)
+            } else {
+                None
+            }
+        });
+        assert_eq!(bar, Some(0.0), "Zero max should produce 0 fraction");
+    }
+
+    #[test]
+    fn heading_level_returns_correct_values() {
+        assert_eq!(heading_level(HtmlTag::H1), Some(1));
+        assert_eq!(heading_level(HtmlTag::H2), Some(2));
+        assert_eq!(heading_level(HtmlTag::H3), Some(3));
+        assert_eq!(heading_level(HtmlTag::H4), Some(4));
+        assert_eq!(heading_level(HtmlTag::H5), Some(5));
+        assert_eq!(heading_level(HtmlTag::H6), Some(6));
+        assert_eq!(heading_level(HtmlTag::P), None);
+        assert_eq!(heading_level(HtmlTag::Div), None);
+    }
+
+    #[test]
+    fn layout_heading_has_level_in_textblock() {
+        let html = "<h2>Section Title</h2>";
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let has_heading = pages[0].elements.iter().any(|(_, el)| {
+            matches!(
+                el,
+                LayoutElement::TextBlock {
+                    heading_level: Some(2),
+                    ..
+                }
+            )
+        });
+        assert!(
+            has_heading,
+            "h2 should produce TextBlock with heading_level=2"
+        );
+    }
+
+    #[test]
+    fn layout_paragraph_has_no_heading_level() {
+        let html = "<p>Just text</p>";
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let has_heading = pages[0].elements.iter().any(|(_, el)| {
+            matches!(
+                el,
+                LayoutElement::TextBlock {
+                    heading_level: Some(_),
+                    ..
+                }
+            )
+        });
+        assert!(!has_heading, "p should not have a heading_level");
+    }
+
+    #[test]
+    fn column_count_1_not_grid() {
+        // column-count: 1 should not trigger grid layout
+        let css = ".cols { column-count: 1; }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<div class="cols"><p>Single column</p></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+        let grid_rows: Vec<_> = pages[0]
+            .elements
+            .iter()
+            .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
+            .collect();
+        assert!(
+            grid_rows.is_empty(),
+            "column-count: 1 should not produce grid rows"
+        );
+    }
 }

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -366,6 +366,8 @@ pub enum LayoutElement {
         background_gradient: Option<LinearGradient>,
         background_radial_gradient: Option<RadialGradient>,
         z_index: i32,
+        /// Heading level (1-6) if this block is an h1-h6, used for PDF bookmarks.
+        heading_level: Option<u8>,
     },
     /// A table row with cells.
     TableRow {
@@ -429,6 +431,21 @@ pub enum LayoutElement {
         box_shadow: Option<BoxShadow>,
         background_gradient: Option<LinearGradient>,
         background_radial_gradient: Option<RadialGradient>,
+    },
+    /// A progress bar or meter element.
+    ProgressBar {
+        /// Fraction filled (0.0 to 1.0).
+        fraction: f32,
+        /// Total width in points.
+        width: f32,
+        /// Total height in points.
+        height: f32,
+        /// Fill color (r, g, b).
+        fill_color: (f32, f32, f32),
+        /// Track color (r, g, b).
+        track_color: (f32, f32, f32),
+        margin_top: f32,
+        margin_bottom: f32,
     },
     /// A page break.
     PageBreak,
@@ -574,6 +591,7 @@ fn flatten_nodes(
                             background_gradient: None,
                             background_radial_gradient: None,
                             z_index: 0,
+                            heading_level: None,
                         });
                     }
                 }
@@ -604,6 +622,19 @@ fn flatten_nodes(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Returns the heading level (1-6) for a tag, or None if not a heading.
+fn heading_level(tag: HtmlTag) -> Option<u8> {
+    match tag {
+        HtmlTag::H1 => Some(1),
+        HtmlTag::H2 => Some(2),
+        HtmlTag::H3 => Some(3),
+        HtmlTag::H4 => Some(4),
+        HtmlTag::H5 => Some(5),
+        HtmlTag::H6 => Some(6),
+        _ => None,
+    }
+}
+
 fn flatten_element(
     el: &ElementNode,
     parent_style: &ComputedStyle,
@@ -692,6 +723,7 @@ fn flatten_element(
             background_gradient: None,
             background_radial_gradient: None,
             z_index: 0,
+            heading_level: None,
         });
         return;
     }
@@ -723,6 +755,216 @@ fn flatten_element(
                 margin_bottom: style.margin.bottom,
             });
         }
+        return;
+    }
+
+    // Form control elements — render as styled boxes with placeholder text
+    if el.tag == HtmlTag::Input || el.tag == HtmlTag::Select || el.tag == HtmlTag::Textarea {
+        let ctrl_width = style.width.unwrap_or(if el.tag == HtmlTag::Textarea {
+            available_width.min(300.0)
+        } else {
+            150.0
+        }).min(available_width);
+        let ctrl_height = style.height.unwrap_or(if el.tag == HtmlTag::Textarea {
+            80.0
+        } else {
+            20.0
+        });
+
+        let label = if el.tag == HtmlTag::Select {
+            el.children.iter().find_map(|c| {
+                if let DomNode::Element(opt) = c {
+                    opt.children.iter().find_map(|t| {
+                        if let DomNode::Text(s) = t { Some(s.trim().to_string()) } else { None }
+                    })
+                } else {
+                    None
+                }
+            }).unwrap_or_default()
+        } else if el.tag == HtmlTag::Textarea {
+            el.children.iter().find_map(|c| {
+                if let DomNode::Text(s) = c { Some(s.trim().to_string()) } else { None }
+            }).unwrap_or_default()
+        } else {
+            el.attributes.get("value")
+                .or(el.attributes.get("placeholder"))
+                .cloned()
+                .unwrap_or_default()
+        };
+
+        let mut lines = Vec::new();
+        if !label.is_empty() {
+            let runs = vec![TextRun {
+                text: label,
+                font_size: style.font_size,
+                bold: false,
+                italic: false,
+                underline: false,
+                line_through: false,
+                color: style.color.to_f32_rgb(),
+                link_url: None,
+                font_family: style.font_family.clone(),
+                background_color: None,
+                padding: (0.0, 0.0),
+                border_radius: 0.0,
+            }];
+            let inner_w = ctrl_width - style.padding.left - style.padding.right;
+            lines = wrap_text_runs(runs, inner_w, style.font_size, fonts);
+        }
+
+        let bg = style.background_color.map(|c| c.to_f32_rgb()).unwrap_or((1.0, 1.0, 1.0));
+
+        output.push(LayoutElement::TextBlock {
+            lines,
+            margin_top: style.margin.top,
+            margin_bottom: style.margin.bottom,
+            text_align: style.text_align,
+            background_color: Some(bg),
+            padding_top: style.padding.top,
+            padding_bottom: style.padding.bottom,
+            padding_left: style.padding.left,
+            padding_right: style.padding.right,
+            border: LayoutBorder::from_computed(&style.border),
+            block_width: Some(ctrl_width),
+            block_height: Some(ctrl_height),
+            opacity: style.opacity,
+            float: style.float,
+            clear: style.clear,
+            position: style.position,
+            offset_top: style.top.unwrap_or(0.0),
+            offset_left: style.left.unwrap_or(0.0),
+            box_shadow: style.box_shadow,
+            visible: style.visibility == Visibility::Visible,
+            clip_rect: None,
+            transform: style.transform,
+            border_radius: style.border_radius,
+            outline_width: style.outline_width,
+            outline_color: style.outline_color.map(|c| c.to_f32_rgb()),
+            text_indent: 0.0,
+            letter_spacing: style.letter_spacing,
+            word_spacing: style.word_spacing,
+            vertical_align: style.vertical_align,
+            background_gradient: style.background_gradient.clone(),
+            background_radial_gradient: style.background_radial_gradient.clone(),
+            z_index: style.z_index,
+            heading_level: None,
+        });
+        return;
+    }
+
+    // Media elements — render as placeholder rectangles
+    if el.tag == HtmlTag::Video || el.tag == HtmlTag::Audio {
+        let media_width = style.width.or_else(|| {
+            el.attributes.get("width").and_then(|v| v.trim_end_matches("px").parse::<f32>().ok())
+        }).unwrap_or(if el.tag == HtmlTag::Video { 300.0 } else { 200.0 }).min(available_width);
+        let media_height = style.height.or_else(|| {
+            el.attributes.get("height").and_then(|v| v.trim_end_matches("px").parse::<f32>().ok())
+        }).unwrap_or(if el.tag == HtmlTag::Video { 150.0 } else { 24.0 });
+
+        let label = if el.tag == HtmlTag::Video {
+            "\u{25B6} Video".to_string()
+        } else {
+            "\u{25B6} Audio".to_string()
+        };
+
+        let bg = style.background_color.map(|c| c.to_f32_rgb()).unwrap_or(
+            if el.tag == HtmlTag::Video { (0.0, 0.0, 0.0) } else { (0.94, 0.94, 0.94) }
+        );
+        let text_color = if el.tag == HtmlTag::Video { (1.0, 1.0, 1.0) } else { (0.3, 0.3, 0.3) };
+
+        let runs = vec![TextRun {
+            text: label,
+            font_size: style.font_size,
+            bold: false,
+            italic: false,
+            underline: false,
+            line_through: false,
+            color: text_color,
+            link_url: None,
+            font_family: style.font_family.clone(),
+            background_color: None,
+            padding: (0.0, 0.0),
+            border_radius: 0.0,
+        }];
+        let lines = wrap_text_runs(runs, media_width, style.font_size, fonts);
+
+        output.push(LayoutElement::TextBlock {
+            lines,
+            margin_top: style.margin.top,
+            margin_bottom: style.margin.bottom,
+            text_align: TextAlign::Center,
+            background_color: Some(bg),
+            padding_top: if el.tag == HtmlTag::Video { (media_height - style.font_size) / 2.0 } else { 4.0 },
+            padding_bottom: if el.tag == HtmlTag::Video { (media_height - style.font_size) / 2.0 } else { 4.0 },
+            padding_left: 4.0,
+            padding_right: 4.0,
+            border: LayoutBorder::from_computed(&style.border),
+            block_width: Some(media_width),
+            block_height: Some(media_height),
+            opacity: style.opacity,
+            float: style.float,
+            clear: style.clear,
+            position: style.position,
+            offset_top: style.top.unwrap_or(0.0),
+            offset_left: style.left.unwrap_or(0.0),
+            box_shadow: style.box_shadow,
+            visible: style.visibility == Visibility::Visible,
+            clip_rect: None,
+            transform: style.transform,
+            border_radius: style.border_radius,
+            outline_width: style.outline_width,
+            outline_color: style.outline_color.map(|c| c.to_f32_rgb()),
+            text_indent: 0.0,
+            letter_spacing: style.letter_spacing,
+            word_spacing: style.word_spacing,
+            vertical_align: style.vertical_align,
+            background_gradient: style.background_gradient.clone(),
+            background_radial_gradient: style.background_radial_gradient.clone(),
+            z_index: style.z_index,
+            heading_level: None,
+        });
+        return;
+    }
+
+    // Progress and meter elements — render as a horizontal bar
+    if el.tag == HtmlTag::Progress || el.tag == HtmlTag::Meter {
+        let bar_width = style.width.unwrap_or(150.0).min(available_width);
+        let bar_height = style.height.unwrap_or(12.0);
+        let value: f32 = el.attributes.get("value")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.0);
+        let max: f32 = el.attributes.get("max")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1.0);
+        let fraction = if max > 0.0 { (value / max).clamp(0.0, 1.0) } else { 0.0 };
+
+        let fill_color = if el.tag == HtmlTag::Progress {
+            (0.12, 0.53, 0.90)
+        } else {
+            let low: f32 = el.attributes.get("low")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(max * 0.25);
+            let high: f32 = el.attributes.get("high")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(max * 0.75);
+            if value <= low {
+                (0.90, 0.20, 0.20)
+            } else if value >= high {
+                (0.20, 0.78, 0.35)
+            } else {
+                (0.95, 0.77, 0.06)
+            }
+        };
+
+        output.push(LayoutElement::ProgressBar {
+            fraction,
+            width: bar_width,
+            height: bar_height,
+            fill_color,
+            track_color: (0.88, 0.88, 0.88),
+            margin_top: style.margin.top,
+            margin_bottom: style.margin.bottom,
+        });
         return;
     }
 
@@ -866,6 +1108,8 @@ fn flatten_element(
 
         collect_text_runs(&el.children, &style, &mut runs, None, rules, ancestors);
 
+        let block_heading_level = heading_level(el.tag);
+
         if !runs.is_empty() {
             let lines = wrap_text_runs(runs, inner_width, style.font_size, fonts);
             output.push(LayoutElement::TextBlock {
@@ -901,6 +1145,7 @@ fn flatten_element(
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
                 z_index: style.z_index,
+                heading_level: block_heading_level,
             });
         }
 
@@ -982,6 +1227,31 @@ fn flatten_element(
             output.push(LayoutElement::PageBreak);
         }
         return;
+    }
+
+    // Multi-column layout: treat as implicit grid with equal columns
+    if let Some(col_count) = style.column_count {
+        if col_count >= 2 {
+            let gap = style.column_gap;
+            let tracks: Vec<GridTrack> = (0..col_count).map(|_| GridTrack::Fr(1.0)).collect();
+            let mut col_style = style.clone();
+            col_style.grid_template_columns = tracks;
+            col_style.grid_gap = gap;
+            flatten_grid_container(
+                el,
+                &col_style,
+                available_width,
+                output,
+                rules,
+                &child_ancestors,
+                fonts,
+            );
+
+            if style.page_break_after {
+                output.push(LayoutElement::PageBreak);
+            }
+            return;
+        }
     }
 
     if style.display == Display::Block {
@@ -1158,6 +1428,7 @@ fn flatten_element(
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
                 z_index: style.z_index,
+                heading_level: heading_level(el.tag),
             });
         }
 
@@ -1254,6 +1525,7 @@ fn flatten_element(
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
                 z_index: style.z_index,
+                heading_level: None,
             });
             // Pull y back so children flow inside the wrapper, starting
             // after the top padding.  The wrapper advanced y by its full
@@ -1293,6 +1565,7 @@ fn flatten_element(
                 background_gradient: None,
                 background_radial_gradient: None,
                 z_index: 0,
+                heading_level: None,
             });
             // Add the parent's left/right padding to children so they render
             // inside the padded area, not at the page left margin.
@@ -1347,6 +1620,7 @@ fn flatten_element(
                     background_gradient: None,
                     background_radial_gradient: None,
                     z_index: 0,
+                    heading_level: None,
                 });
             }
         } else {
@@ -1576,6 +1850,7 @@ fn flatten_flex_container(
             background_gradient: child_style.background_gradient.clone(),
             background_radial_gradient: child_style.background_radial_gradient.clone(),
             z_index: child_style.z_index,
+            heading_level: None,
         };
 
         items.push(FlexItem {
@@ -1747,6 +2022,7 @@ fn flatten_flex_container(
             background_gradient: style.background_gradient.clone(),
             background_radial_gradient: style.background_radial_gradient.clone(),
             z_index: 0,
+            heading_level: None,
         });
         // Pull y back so children flow inside the container background
         output.push(LayoutElement::TextBlock {
@@ -1782,6 +2058,7 @@ fn flatten_flex_container(
             background_gradient: None,
             background_radial_gradient: None,
             z_index: 0,
+            heading_level: None,
         });
     }
 
@@ -2037,6 +2314,7 @@ fn flatten_flex_container(
                                 background_gradient: tb_grad.clone(),
                                 background_radial_gradient: tb_rgrad.clone(),
                                 z_index: 0,
+                                heading_level: None,
                             });
                         }
                     }
@@ -2089,6 +2367,7 @@ fn flatten_flex_container(
             background_gradient: None,
             background_radial_gradient: None,
             z_index: 0,
+            heading_level: None,
         });
     }
 }
@@ -2110,19 +2389,21 @@ fn resolve_grid_columns(tracks: &[GridTrack], available_width: f32, gap: f32) ->
     let mut fixed_total: f32 = 0.0;
     let mut fr_total: f32 = 0.0;
     let mut auto_count: usize = 0;
+    let mut minmax_count: usize = 0;
 
     for track in tracks {
         match track {
             GridTrack::Fixed(v) => fixed_total += *v,
             GridTrack::Fr(v) => fr_total += *v,
             GridTrack::Auto => auto_count += 1,
+            GridTrack::Minmax(min, _) => { fixed_total += min; minmax_count += 1; }
         }
     }
 
     let remaining = (space - fixed_total).max(0.0);
 
     // Auto columns are treated like 1fr each for distribution purposes
-    let effective_fr_total = fr_total + auto_count as f32;
+    let effective_fr_total = fr_total + auto_count as f32 + minmax_count as f32;
     let per_fr = if effective_fr_total > 0.0 {
         remaining / effective_fr_total
     } else {
@@ -2135,6 +2416,7 @@ fn resolve_grid_columns(tracks: &[GridTrack], available_width: f32, gap: f32) ->
             GridTrack::Fixed(v) => *v,
             GridTrack::Fr(v) => per_fr * *v,
             GridTrack::Auto => per_fr,
+            GridTrack::Minmax(min, max) => { let desired = min + per_fr; if *max < f32::MAX { desired.clamp(*min, *max) } else { desired } }
         })
         .collect()
 }
@@ -3252,6 +3534,12 @@ fn estimate_element_height(element: &LayoutElement) -> f32 {
             margin_top,
             margin_bottom,
         } => margin_top + 1.0 + margin_bottom,
+        LayoutElement::ProgressBar {
+            height,
+            margin_top,
+            margin_bottom,
+            ..
+        } => margin_top + height + margin_bottom,
         _ => 0.0,
     }
 }
@@ -3393,6 +3681,12 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
                 ..
             } => (*height, *margin_top, *margin_bottom),
             LayoutElement::Svg {
+                height,
+                margin_top,
+                margin_bottom,
+                ..
+            } => (*height, *margin_top, *margin_bottom),
+            LayoutElement::ProgressBar {
                 height,
                 margin_top,
                 margin_bottom,
@@ -7788,5 +8082,314 @@ mod _removed {
             "Expected at least 3 pages, got {}",
             pages.len()
         );
+    }
+
+    #[test]
+    fn layout_input_element() {
+        let html = r#"<input type="text" value="Hello">"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty());
+    }
+
+    #[test]
+    fn layout_input_with_placeholder() {
+        let html = r#"<input type="text" placeholder="Enter name...">"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty());
+    }
+
+    #[test]
+    fn layout_select_element() {
+        let html = r#"<select><option>One</option><option>Two</option></select>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty());
+    }
+
+    #[test]
+    fn layout_textarea_element() {
+        let html = r#"<textarea>Some text content</textarea>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty());
+    }
+
+    #[test]
+    fn layout_textarea_with_custom_size() {
+        let html = r#"<textarea style="width: 200px; height: 100px">Content</textarea>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn layout_video_element() {
+        let html = r#"<video width="320" height="240"></video>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty());
+    }
+
+    #[test]
+    fn layout_video_default_size() {
+        let html = r#"<video></video>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn layout_audio_element() {
+        let html = r#"<audio></audio>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty());
+    }
+
+    #[test]
+    fn layout_progress_element() {
+        let html = r#"<progress value="0.7" max="1"></progress>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        let has_bar = pages[0]
+            .elements
+            .iter()
+            .any(|(_, el)| matches!(el, LayoutElement::ProgressBar { .. }));
+        assert!(has_bar, "Expected a ProgressBar element");
+    }
+
+    #[test]
+    fn layout_progress_zero_value() {
+        let html = r#"<progress value="0" max="100"></progress>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        let bar = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { fraction, .. } = el {
+                Some(*fraction)
+            } else {
+                None
+            }
+        });
+        assert_eq!(bar, Some(0.0));
+    }
+
+    #[test]
+    fn layout_progress_full_value() {
+        let html = r#"<progress value="100" max="100"></progress>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let bar = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { fraction, .. } = el {
+                Some(*fraction)
+            } else {
+                None
+            }
+        });
+        assert_eq!(bar, Some(1.0));
+    }
+
+    #[test]
+    fn layout_progress_over_max_clamped() {
+        let html = r#"<progress value="200" max="100"></progress>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let bar = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { fraction, .. } = el {
+                Some(*fraction)
+            } else {
+                None
+            }
+        });
+        assert_eq!(bar, Some(1.0));
+    }
+
+    #[test]
+    fn layout_meter_element() {
+        let html = r#"<meter value="0.6" max="1"></meter>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        let has_bar = pages[0]
+            .elements
+            .iter()
+            .any(|(_, el)| matches!(el, LayoutElement::ProgressBar { .. }));
+        assert!(has_bar, "Expected a ProgressBar element for meter");
+    }
+
+    #[test]
+    fn layout_meter_low_high_thresholds() {
+        let html = r#"<meter value="10" max="100" low="25" high="75"></meter>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let fill = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { fill_color, .. } = el {
+                Some(*fill_color)
+            } else {
+                None
+            }
+        });
+        assert!(fill.is_some());
+        let (r, _, _) = fill.unwrap();
+        assert!(r > 0.8, "Expected red fill for low meter value");
+    }
+
+    #[test]
+    fn layout_meter_high_value_green() {
+        let html = r#"<meter value="90" max="100" low="25" high="75"></meter>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let fill = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { fill_color, .. } = el {
+                Some(*fill_color)
+            } else {
+                None
+            }
+        });
+        assert!(fill.is_some());
+        let (_, g, _) = fill.unwrap();
+        assert!(g > 0.7, "Expected green fill for high meter value");
+    }
+
+    #[test]
+    fn layout_form_elements_in_context() {
+        let html = r#"
+            <div>
+                <p>Name:</p>
+                <input type="text" value="John">
+                <p>Country:</p>
+                <select><option>France</option><option>USA</option></select>
+                <p>Bio:</p>
+                <textarea>Some biography text here</textarea>
+            </div>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert!(pages[0].elements.len() >= 3);
+    }
+
+    #[test]
+    fn layout_progress_custom_width() {
+        let html = r#"<progress value="50" max="100" style="width: 200px"></progress>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let width = pages[0].elements.iter().find_map(|(_, el)| {
+            if let LayoutElement::ProgressBar { width, .. } = el {
+                Some(*width)
+            } else {
+                None
+            }
+        });
+        assert_eq!(width, Some(200.0));
+    }
+
+    #[test]
+    fn grid_layout_repeat() {
+        let css = ".grid { display: grid; grid-template-columns: repeat(3, 1fr); }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<div class="grid"><div>A</div><div>B</div><div>C</div></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+        let grid_rows: Vec<_> = pages[0]
+            .elements
+            .iter()
+            .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
+            .collect();
+        assert_eq!(grid_rows.len(), 1, "Expected 1 grid row with 3 columns from repeat(3, 1fr)");
+    }
+
+    #[test]
+    fn grid_layout_minmax() {
+        let css = ".grid { display: grid; grid-template-columns: minmax(50pt, 200pt) 1fr; }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<div class="grid"><div>A</div><div>B</div></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+        let grid_rows: Vec<_> = pages[0]
+            .elements
+            .iter()
+            .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
+            .collect();
+        assert!(!grid_rows.is_empty(), "Expected GridRow from minmax grid");
+    }
+
+    #[test]
+    fn grid_layout_auto_fill() {
+        let css = ".grid { display: grid; grid-template-columns: repeat(auto-fill, 100px); }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<div class="grid"><div>A</div><div>B</div><div>C</div></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn grid_layout_repeat_with_minmax() {
+        let css = ".grid { display: grid; grid-template-columns: repeat(3, minmax(50px, 1fr)); }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<div class="grid"><div>A</div><div>B</div><div>C</div></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+        let grid_rows: Vec<_> = pages[0]
+            .elements
+            .iter()
+            .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
+            .collect();
+        assert_eq!(grid_rows.len(), 1);
+    }
+
+    #[test]
+    fn multi_column_layout() {
+        let css = ".cols { column-count: 2; }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<div class="cols"><div>Col 1</div><div>Col 2</div></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+        let grid_rows: Vec<_> = pages[0]
+            .elements
+            .iter()
+            .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
+            .collect();
+        assert_eq!(grid_rows.len(), 1, "Expected 1 row from 2-column layout");
+    }
+
+    #[test]
+    fn multi_column_three_cols() {
+        let css = ".cols { column-count: 3; column-gap: 10pt; }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<div class="cols"><div>A</div><div>B</div><div>C</div></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+        let grid_rows: Vec<_> = pages[0]
+            .elements
+            .iter()
+            .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
+            .collect();
+        assert_eq!(grid_rows.len(), 1);
+    }
+
+    #[test]
+    fn multi_column_wraps_rows() {
+        let css = ".cols { column-count: 2; }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<div class="cols"><div>A</div><div>B</div><div>C</div><div>D</div></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+        let grid_rows: Vec<_> = pages[0]
+            .elements
+            .iter()
+            .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
+            .collect();
+        assert_eq!(grid_rows.len(), 2, "Expected 2 rows from 4 items in 2-column layout");
     }
 }

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -635,6 +635,7 @@ fn heading_level(tag: HtmlTag) -> Option<u8> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn flatten_element(
     el: &ElementNode,
     parent_style: &ComputedStyle,
@@ -760,11 +761,14 @@ fn flatten_element(
 
     // Form control elements — render as styled boxes with placeholder text
     if el.tag == HtmlTag::Input || el.tag == HtmlTag::Select || el.tag == HtmlTag::Textarea {
-        let ctrl_width = style.width.unwrap_or(if el.tag == HtmlTag::Textarea {
-            available_width.min(300.0)
-        } else {
-            150.0
-        }).min(available_width);
+        let ctrl_width = style
+            .width
+            .unwrap_or(if el.tag == HtmlTag::Textarea {
+                available_width.min(300.0)
+            } else {
+                150.0
+            })
+            .min(available_width);
         let ctrl_height = style.height.unwrap_or(if el.tag == HtmlTag::Textarea {
             80.0
         } else {
@@ -772,21 +776,36 @@ fn flatten_element(
         });
 
         let label = if el.tag == HtmlTag::Select {
-            el.children.iter().find_map(|c| {
-                if let DomNode::Element(opt) = c {
-                    opt.children.iter().find_map(|t| {
-                        if let DomNode::Text(s) = t { Some(s.trim().to_string()) } else { None }
-                    })
-                } else {
-                    None
-                }
-            }).unwrap_or_default()
+            el.children
+                .iter()
+                .find_map(|c| {
+                    if let DomNode::Element(opt) = c {
+                        opt.children.iter().find_map(|t| {
+                            if let DomNode::Text(s) = t {
+                                Some(s.trim().to_string())
+                            } else {
+                                None
+                            }
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default()
         } else if el.tag == HtmlTag::Textarea {
-            el.children.iter().find_map(|c| {
-                if let DomNode::Text(s) = c { Some(s.trim().to_string()) } else { None }
-            }).unwrap_or_default()
+            el.children
+                .iter()
+                .find_map(|c| {
+                    if let DomNode::Text(s) = c {
+                        Some(s.trim().to_string())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default()
         } else {
-            el.attributes.get("value")
+            el.attributes
+                .get("value")
                 .or(el.attributes.get("placeholder"))
                 .cloned()
                 .unwrap_or_default()
@@ -812,7 +831,10 @@ fn flatten_element(
             lines = wrap_text_runs(runs, inner_w, style.font_size, fonts);
         }
 
-        let bg = style.background_color.map(|c| c.to_f32_rgb()).unwrap_or((1.0, 1.0, 1.0));
+        let bg = style
+            .background_color
+            .map(|c| c.to_f32_rgb())
+            .unwrap_or((1.0, 1.0, 1.0));
 
         output.push(LayoutElement::TextBlock {
             lines,
@@ -854,12 +876,31 @@ fn flatten_element(
 
     // Media elements — render as placeholder rectangles
     if el.tag == HtmlTag::Video || el.tag == HtmlTag::Audio {
-        let media_width = style.width.or_else(|| {
-            el.attributes.get("width").and_then(|v| v.trim_end_matches("px").parse::<f32>().ok())
-        }).unwrap_or(if el.tag == HtmlTag::Video { 300.0 } else { 200.0 }).min(available_width);
-        let media_height = style.height.or_else(|| {
-            el.attributes.get("height").and_then(|v| v.trim_end_matches("px").parse::<f32>().ok())
-        }).unwrap_or(if el.tag == HtmlTag::Video { 150.0 } else { 24.0 });
+        let media_width = style
+            .width
+            .or_else(|| {
+                el.attributes
+                    .get("width")
+                    .and_then(|v| v.trim_end_matches("px").parse::<f32>().ok())
+            })
+            .unwrap_or(if el.tag == HtmlTag::Video {
+                300.0
+            } else {
+                200.0
+            })
+            .min(available_width);
+        let media_height = style
+            .height
+            .or_else(|| {
+                el.attributes
+                    .get("height")
+                    .and_then(|v| v.trim_end_matches("px").parse::<f32>().ok())
+            })
+            .unwrap_or(if el.tag == HtmlTag::Video {
+                150.0
+            } else {
+                24.0
+            });
 
         let label = if el.tag == HtmlTag::Video {
             "\u{25B6} Video".to_string()
@@ -867,10 +908,20 @@ fn flatten_element(
             "\u{25B6} Audio".to_string()
         };
 
-        let bg = style.background_color.map(|c| c.to_f32_rgb()).unwrap_or(
-            if el.tag == HtmlTag::Video { (0.0, 0.0, 0.0) } else { (0.94, 0.94, 0.94) }
-        );
-        let text_color = if el.tag == HtmlTag::Video { (1.0, 1.0, 1.0) } else { (0.3, 0.3, 0.3) };
+        let bg =
+            style
+                .background_color
+                .map(|c| c.to_f32_rgb())
+                .unwrap_or(if el.tag == HtmlTag::Video {
+                    (0.0, 0.0, 0.0)
+                } else {
+                    (0.94, 0.94, 0.94)
+                });
+        let text_color = if el.tag == HtmlTag::Video {
+            (1.0, 1.0, 1.0)
+        } else {
+            (0.3, 0.3, 0.3)
+        };
 
         let runs = vec![TextRun {
             text: label,
@@ -894,8 +945,16 @@ fn flatten_element(
             margin_bottom: style.margin.bottom,
             text_align: TextAlign::Center,
             background_color: Some(bg),
-            padding_top: if el.tag == HtmlTag::Video { (media_height - style.font_size) / 2.0 } else { 4.0 },
-            padding_bottom: if el.tag == HtmlTag::Video { (media_height - style.font_size) / 2.0 } else { 4.0 },
+            padding_top: if el.tag == HtmlTag::Video {
+                (media_height - style.font_size) / 2.0
+            } else {
+                4.0
+            },
+            padding_bottom: if el.tag == HtmlTag::Video {
+                (media_height - style.font_size) / 2.0
+            } else {
+                4.0
+            },
             padding_left: 4.0,
             padding_right: 4.0,
             border: LayoutBorder::from_computed(&style.border),
@@ -930,21 +989,33 @@ fn flatten_element(
     if el.tag == HtmlTag::Progress || el.tag == HtmlTag::Meter {
         let bar_width = style.width.unwrap_or(150.0).min(available_width);
         let bar_height = style.height.unwrap_or(12.0);
-        let value: f32 = el.attributes.get("value")
+        let value: f32 = el
+            .attributes
+            .get("value")
             .and_then(|s| s.parse().ok())
             .unwrap_or(0.0);
-        let max: f32 = el.attributes.get("max")
+        let max: f32 = el
+            .attributes
+            .get("max")
             .and_then(|s| s.parse().ok())
             .unwrap_or(1.0);
-        let fraction = if max > 0.0 { (value / max).clamp(0.0, 1.0) } else { 0.0 };
+        let fraction = if max > 0.0 {
+            (value / max).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
 
         let fill_color = if el.tag == HtmlTag::Progress {
             (0.12, 0.53, 0.90)
         } else {
-            let low: f32 = el.attributes.get("low")
+            let low: f32 = el
+                .attributes
+                .get("low")
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(max * 0.25);
-            let high: f32 = el.attributes.get("high")
+            let high: f32 = el
+                .attributes
+                .get("high")
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(max * 0.75);
             if value <= low {
@@ -2396,7 +2467,10 @@ fn resolve_grid_columns(tracks: &[GridTrack], available_width: f32, gap: f32) ->
             GridTrack::Fixed(v) => fixed_total += *v,
             GridTrack::Fr(v) => fr_total += *v,
             GridTrack::Auto => auto_count += 1,
-            GridTrack::Minmax(min, _) => { fixed_total += min; minmax_count += 1; }
+            GridTrack::Minmax(min, _) => {
+                fixed_total += min;
+                minmax_count += 1;
+            }
         }
     }
 
@@ -2416,7 +2490,14 @@ fn resolve_grid_columns(tracks: &[GridTrack], available_width: f32, gap: f32) ->
             GridTrack::Fixed(v) => *v,
             GridTrack::Fr(v) => per_fr * *v,
             GridTrack::Auto => per_fr,
-            GridTrack::Minmax(min, max) => { let desired = min + per_fr; if *max < f32::MAX { desired.clamp(*min, *max) } else { desired } }
+            GridTrack::Minmax(min, max) => {
+                let desired = min + per_fr;
+                if *max < f32::MAX {
+                    desired.clamp(*min, *max)
+                } else {
+                    desired
+                }
+            }
         })
         .collect()
 }
@@ -3835,7 +3916,41 @@ fn load_image_from_element(
     })
 }
 
-/// Load image data from a src attribute (supports data: URIs and local file paths).
+/// Maximum size for remote resources (10 MB).
+#[cfg(feature = "remote")]
+const MAX_REMOTE_SIZE: usize = 10 * 1024 * 1024;
+
+/// Fetch bytes from an HTTP/HTTPS URL (requires the `remote` feature).
+/// Returns `None` if the feature is disabled, the request fails, or the response exceeds 10 MB.
+fn fetch_remote_url(url: &str) -> Option<Vec<u8>> {
+    #[cfg(feature = "remote")]
+    {
+        let resp = ureq::get(url).call().ok()?;
+        let len = resp
+            .headers()
+            .get("content-length")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(0);
+        if len > MAX_REMOTE_SIZE {
+            return None;
+        }
+        let buf = resp
+            .into_body()
+            .with_config()
+            .limit(MAX_REMOTE_SIZE as u64)
+            .read_to_vec()
+            .ok()?;
+        Some(buf)
+    }
+    #[cfg(not(feature = "remote"))]
+    {
+        let _ = url;
+        None
+    }
+}
+
+/// Load image data from a src attribute (supports data: URIs, local files, and remote URLs).
 /// Returns (raw_bytes, format, optional_png_metadata).
 fn load_image_data(src: &str) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadata>)> {
     let raw = if let Some(rest) = src.strip_prefix("data:") {
@@ -3844,8 +3959,7 @@ fn load_image_data(src: &str) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadat
         // Only support base64 for now
         base64_decode(encoded)?
     } else if src.starts_with("http://") || src.starts_with("https://") {
-        // Remote URLs are not supported (SSRF risk)
-        return None;
+        fetch_remote_url(src)?
     } else {
         // Treat as local file path
         std::fs::read(src).ok()?
@@ -4414,6 +4528,39 @@ mod tests {
             pages[0].elements.is_empty()
                 || !matches!(&pages[0].elements[0].1, LayoutElement::Image { .. })
         );
+    }
+
+    #[test]
+    fn fetch_remote_url_returns_none_without_feature() {
+        // Without the "remote" feature, fetch_remote_url always returns None
+        let result = fetch_remote_url("https://example.com/image.png");
+        #[cfg(not(feature = "remote"))]
+        assert!(result.is_none());
+        // With the feature enabled, it would attempt a real HTTP request
+        // (which may or may not succeed depending on network)
+        let _ = result;
+    }
+
+    #[test]
+    fn load_image_data_http_without_feature() {
+        let result = load_image_data("http://example.com/test.jpg");
+        #[cfg(not(feature = "remote"))]
+        assert!(
+            result.is_none(),
+            "HTTP images should be None without remote feature"
+        );
+        let _ = result;
+    }
+
+    #[test]
+    fn load_image_data_https_without_feature() {
+        let result = load_image_data("https://example.com/test.png");
+        #[cfg(not(feature = "remote"))]
+        assert!(
+            result.is_none(),
+            "HTTPS images should be None without remote feature"
+        );
+        let _ = result;
     }
 
     #[test]
@@ -8305,7 +8452,11 @@ mod _removed {
             .iter()
             .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
             .collect();
-        assert_eq!(grid_rows.len(), 1, "Expected 1 grid row with 3 columns from repeat(3, 1fr)");
+        assert_eq!(
+            grid_rows.len(),
+            1,
+            "Expected 1 grid row with 3 columns from repeat(3, 1fr)"
+        );
     }
 
     #[test]
@@ -8390,6 +8541,10 @@ mod _removed {
             .iter()
             .filter(|(_, el)| matches!(el, LayoutElement::GridRow { .. }))
             .collect();
-        assert_eq!(grid_rows.len(), 2, "Expected 2 rows from 4 items in 2-column layout");
+        assert_eq!(
+            grid_rows.len(),
+            2,
+            "Expected 2 rows from 4 items in 2-column layout"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1108,6 +1108,71 @@ fn main() {
         assert!(fetch_remote_bytes("https://example.com/test").is_none());
     }
 
+    #[test]
+    fn remote_image_produces_valid_pdf() {
+        // Remote images are silently ignored without the "remote" feature
+        let html =
+            r#"<img src="https://example.com/test.png" width="100" height="100"><p>Text</p>"#;
+        let pdf = html_to_pdf(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("Text"));
+    }
+
+    #[test]
+    fn remote_font_face_produces_valid_pdf() {
+        // Remote font-face URLs are parsed but font loading is skipped without "remote" feature
+        let html = r#"
+            <style>
+                @font-face { font-family: "RemoteFont"; src: url("https://example.com/font.ttf"); }
+                p { font-family: RemoteFont; }
+            </style>
+            <p>Fallback to Helvetica</p>
+        "#;
+        let pdf = html_to_pdf(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn header_footer_with_special_chars() {
+        let pdf = HtmlConverter::new()
+            .header("Report (Draft)")
+            .footer("Page {page} / {pages}")
+            .convert("<p>Content</p>")
+            .unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn multi_column_full_pipeline() {
+        let html = r#"
+            <style>.cols { column-count: 2; column-gap: 10pt; }</style>
+            <div class="cols"><div>Left</div><div>Right</div></div>
+        "#;
+        let pdf = html_to_pdf(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn grid_repeat_full_pipeline() {
+        let html = r#"
+            <style>.g { display: grid; grid-template-columns: repeat(3, 1fr); gap: 5pt; }</style>
+            <div class="g"><div>A</div><div>B</div><div>C</div></div>
+        "#;
+        let pdf = html_to_pdf(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn grid_minmax_full_pipeline() {
+        let html = r#"
+            <style>.g { display: grid; grid-template-columns: minmax(50px, 1fr) 2fr; }</style>
+            <div class="g"><div>A</div><div>B</div></div>
+        "#;
+        let pdf = html_to_pdf(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
     // --- Async tests (feature-gated) ---
 
     #[cfg(feature = "async")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,25 @@ pub(crate) mod style;
 /// Public types: page size, margins, and colors.
 pub mod types;
 
+/// Fetch bytes from a remote URL (requires the `remote` feature).
+/// Returns `None` when the feature is disabled or the request fails.
+#[allow(unused_variables)]
+fn fetch_remote_bytes(url: &str) -> Option<Vec<u8>> {
+    #[cfg(feature = "remote")]
+    {
+        let resp = ureq::get(url).call().ok()?;
+        resp.into_body()
+            .with_config()
+            .limit(10 * 1024 * 1024)
+            .read_to_vec()
+            .ok()
+    }
+    #[cfg(not(feature = "remote"))]
+    {
+        None
+    }
+}
+
 pub use error::IronpressError;
 pub use types::{Margin, PageSize};
 
@@ -404,17 +423,26 @@ impl HtmlConverter {
         // Step 4: Parse custom fonts (API-registered + @font-face from CSS)
         let mut parsed_fonts = self.parse_custom_fonts();
 
-        // Step 4b: Load fonts from @font-face rules
-        if let Some(ref base) = self.base_path {
-            for ff_rule in &font_face_rules {
+        // Step 4b: Load fonts from @font-face rules (local files + remote URLs)
+        for ff_rule in &font_face_rules {
+            let is_remote =
+                ff_rule.src_path.starts_with("http://") || ff_rule.src_path.starts_with("https://");
+
+            let ttf_data = if is_remote {
+                fetch_remote_bytes(&ff_rule.src_path)
+            } else if let Some(ref base) = self.base_path {
                 let font_path = base.join(&ff_rule.src_path);
                 if !parser::css::is_path_within(&font_path, base) {
                     continue;
                 }
-                if let Ok(ttf_data) = std::fs::read(&font_path) {
-                    if let Ok(font) = parser::ttf::parse_ttf(ttf_data) {
-                        parsed_fonts.insert(ff_rule.font_family.to_ascii_lowercase(), font);
-                    }
+                std::fs::read(&font_path).ok()
+            } else {
+                None
+            };
+
+            if let Some(data) = ttf_data {
+                if let Ok(font) = parser::ttf::parse_ttf(data) {
+                    parsed_fonts.insert(ff_rule.font_family.to_ascii_lowercase(), font);
                 }
             }
         }
@@ -1067,11 +1095,17 @@ fn main() {
     }
 
     #[test]
-    fn url_image_ignored_for_security() {
-        // Remote URLs are not loaded (SSRF risk). The PDF is generated without the image.
+    fn url_image_ignored_without_remote_feature() {
+        // Without the "remote" feature, remote URLs produce no image
         let html = r#"<img src="https://example.com/image.png" width="100" height="100">"#;
         let pdf = html_to_pdf(html).unwrap();
         assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn fetch_remote_bytes_returns_none_without_feature() {
+        #[cfg(not(feature = "remote"))]
+        assert!(fetch_remote_bytes("https://example.com/test").is_none());
     }
 
     // --- Async tests (feature-gated) ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,11 @@ pub struct HtmlConverter {
     custom_fonts: std::collections::HashMap<String, Vec<u8>>,
     /// Base directory for resolving relative paths in `@import` and `@font-face` rules.
     base_path: Option<std::path::PathBuf>,
+    /// Optional header text rendered at the top of each page.
+    header: Option<String>,
+    /// Optional footer text rendered at the bottom of each page.
+    /// Use `{page}` for current page number and `{pages}` for total page count.
+    footer: Option<String>,
 }
 
 impl HtmlConverter {
@@ -223,6 +228,8 @@ impl HtmlConverter {
             sanitize: true,
             custom_fonts: std::collections::HashMap::new(),
             base_path: None,
+            header: None,
+            footer: None,
         }
     }
 
@@ -289,6 +296,21 @@ impl HtmlConverter {
     /// ```
     pub fn base_path(mut self, path: &std::path::Path) -> Self {
         self.base_path = Some(path.to_path_buf());
+        self
+    }
+
+    /// Set a header text rendered at the top of each page (in the top margin area).
+    pub fn header(mut self, text: impl Into<String>) -> Self {
+        self.header = Some(text.into());
+        self
+    }
+
+    /// Set a footer text rendered at the bottom of each page (in the bottom margin area).
+    ///
+    /// Use `{page}` for the current page number and `{pages}` for the total page count.
+    /// For example: `"Page {page} of {pages}"`.
+    pub fn footer(mut self, text: impl Into<String>) -> Self {
+        self.footer = Some(text.into());
         self
     }
 
@@ -407,19 +429,23 @@ impl HtmlConverter {
         );
 
         // Step 6: Render PDF
-        if parsed_fonts.is_empty() {
-            render::pdf::render_pdf_to_writer(&pages, effective_page_size, effective_margin, writer)
+        let decoration = if self.header.is_some() || self.footer.is_some() {
+            Some(render::pdf::PageDecoration {
+                header: self.header.clone(),
+                footer: self.footer.clone(),
+            })
         } else {
-            let pdf_bytes = render::pdf::render_pdf_with_fonts(
-                &pages,
-                effective_page_size,
-                effective_margin,
-                &parsed_fonts,
-            )?;
-            writer
-                .write_all(&pdf_bytes)
-                .map_err(|e| IronpressError::RenderError(format!("write error: {e}")))
-        }
+            None
+        };
+
+        render::pdf::render_pdf_to_writer_full(
+            &pages,
+            effective_page_size,
+            effective_margin,
+            writer,
+            &parsed_fonts,
+            decoration.as_ref(),
+        )
     }
 
     /// Convert a Markdown string to PDF, writing directly to any `std::io::Write` implementation.

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -886,10 +886,7 @@ fn parse_font_face_declarations(decls: &str) -> Option<FontFaceRule> {
                 "src" => {
                     // Parse url("path") or url('path') or url(path)
                     if let Some(path) = extract_url_path(val) {
-                        // Security: reject remote URLs
-                        if !path.starts_with("http://") && !path.starts_with("https://") {
-                            src_path = Some(path);
-                        }
+                        src_path = Some(path);
                     }
                 }
                 _ => {}
@@ -3878,7 +3875,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_font_face_rejects_http_url() {
+    fn parse_font_face_accepts_https_url() {
         let css = r#"
             @font-face {
                 font-family: "Remote";
@@ -3886,11 +3883,12 @@ mod tests {
             }
         "#;
         let rules = parse_font_face_rules(css);
-        assert_eq!(rules.len(), 0, "Remote URLs should be rejected");
+        assert_eq!(rules.len(), 1, "Remote HTTPS URLs should be parsed");
+        assert_eq!(rules[0].src_path, "https://example.com/font.ttf");
     }
 
     #[test]
-    fn parse_font_face_rejects_http_url_no_s() {
+    fn parse_font_face_accepts_http_url() {
         let css = r#"
             @font-face {
                 font-family: "Remote";
@@ -3898,7 +3896,8 @@ mod tests {
             }
         "#;
         let rules = parse_font_face_rules(css);
-        assert_eq!(rules.len(), 0, "Remote HTTP URLs should be rejected");
+        assert_eq!(rules.len(), 1, "Remote HTTP URLs should be parsed");
+        assert_eq!(rules[0].src_path, "http://example.com/font.ttf");
     }
 
     #[test]

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -348,6 +348,17 @@ fn parse_value(property: &str, val: &str) -> Option<CssValue> {
         return Some(CssValue::Keyword(val.to_string()));
     }
 
+    // Multi-column layout
+    if property == "column-count" || property == "columns" {
+        if let Some(v) = parse_length(val) {
+            return Some(v);
+        }
+        return Some(CssValue::Keyword(val.to_string()));
+    }
+    if property == "column-gap" {
+        return parse_length(val);
+    }
+
     // Border-radius — parse as length (single value shorthand)
     if property == "border-radius" {
         return parse_length(val);

--- a/src/parser/dom.rs
+++ b/src/parser/dom.rs
@@ -62,6 +62,13 @@ pub enum HtmlTag {
     Details,
     Summary,
     Svg,
+    Input,
+    Select,
+    Textarea,
+    Video,
+    Audio,
+    Progress,
+    Meter,
     Unknown,
 }
 
@@ -127,6 +134,13 @@ impl HtmlTag {
             "details" => Self::Details,
             "summary" => Self::Summary,
             "svg" => Self::Svg,
+            "input" => Self::Input,
+            "select" => Self::Select,
+            "textarea" => Self::Textarea,
+            "video" => Self::Video,
+            "audio" => Self::Audio,
+            "progress" => Self::Progress,
+            "meter" => Self::Meter,
             _ => Self::Unknown,
         }
     }
@@ -172,6 +186,8 @@ impl HtmlTag {
                 | Self::Details
                 | Self::Summary
                 | Self::Svg
+                | Self::Video
+                | Self::Textarea
         )
     }
 
@@ -194,6 +210,11 @@ impl HtmlTag {
                 | Self::Ins
                 | Self::Mark
                 | Self::Abbr
+                | Self::Input
+                | Self::Select
+                | Self::Audio
+                | Self::Progress
+                | Self::Meter
         )
     }
 }
@@ -311,6 +332,13 @@ impl ElementNode {
             HtmlTag::Details => "details",
             HtmlTag::Summary => "summary",
             HtmlTag::Svg => "svg",
+            HtmlTag::Input => "input",
+            HtmlTag::Select => "select",
+            HtmlTag::Textarea => "textarea",
+            HtmlTag::Video => "video",
+            HtmlTag::Audio => "audio",
+            HtmlTag::Progress => "progress",
+            HtmlTag::Meter => "meter",
             HtmlTag::Unknown => "unknown",
         }
     }
@@ -357,6 +385,13 @@ mod tests {
         assert_eq!(HtmlTag::from_tag_name("dd"), HtmlTag::Dd);
         assert_eq!(HtmlTag::from_tag_name("img"), HtmlTag::Img);
         assert_eq!(HtmlTag::from_tag_name("table"), HtmlTag::Table);
+        assert_eq!(HtmlTag::from_tag_name("input"), HtmlTag::Input);
+        assert_eq!(HtmlTag::from_tag_name("select"), HtmlTag::Select);
+        assert_eq!(HtmlTag::from_tag_name("textarea"), HtmlTag::Textarea);
+        assert_eq!(HtmlTag::from_tag_name("video"), HtmlTag::Video);
+        assert_eq!(HtmlTag::from_tag_name("audio"), HtmlTag::Audio);
+        assert_eq!(HtmlTag::from_tag_name("progress"), HtmlTag::Progress);
+        assert_eq!(HtmlTag::from_tag_name("meter"), HtmlTag::Meter);
         assert_eq!(HtmlTag::from_tag_name("nonsense"), HtmlTag::Unknown);
     }
 
@@ -372,6 +407,12 @@ mod tests {
         assert!(HtmlTag::Dl.is_block());
         assert!(!HtmlTag::Span.is_inline() || HtmlTag::Span.is_inline());
         assert!(!HtmlTag::Code.is_block());
+        assert!(HtmlTag::Video.is_block());
+        assert!(HtmlTag::Textarea.is_block());
+        assert!(!HtmlTag::Input.is_block());
+        assert!(!HtmlTag::Audio.is_block());
+        assert!(!HtmlTag::Progress.is_block());
+        assert!(!HtmlTag::Meter.is_block());
     }
 
     #[test]
@@ -388,6 +429,13 @@ mod tests {
         assert!(HtmlTag::Mark.is_inline());
         assert!(HtmlTag::Abbr.is_inline());
         assert!(!HtmlTag::P.is_inline());
+        assert!(HtmlTag::Input.is_inline());
+        assert!(HtmlTag::Select.is_inline());
+        assert!(HtmlTag::Audio.is_inline());
+        assert!(HtmlTag::Progress.is_inline());
+        assert!(HtmlTag::Meter.is_inline());
+        assert!(!HtmlTag::Video.is_inline());
+        assert!(!HtmlTag::Textarea.is_inline());
     }
 
     #[test]
@@ -470,6 +518,13 @@ mod tests {
             (HtmlTag::Details, "details"),
             (HtmlTag::Summary, "summary"),
             (HtmlTag::Svg, "svg"),
+            (HtmlTag::Input, "input"),
+            (HtmlTag::Select, "select"),
+            (HtmlTag::Textarea, "textarea"),
+            (HtmlTag::Video, "video"),
+            (HtmlTag::Audio, "audio"),
+            (HtmlTag::Progress, "progress"),
+            (HtmlTag::Meter, "meter"),
             (HtmlTag::Unknown, "unknown"),
         ];
         for (tag, expected_name) in cases {

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1417,28 +1417,24 @@ fn render_cell_text(
     custom_fonts: &HashMap<String, TtfFont>,
 ) {
     let cell_inner_w = col_width - cell.padding_left - cell.padding_right;
-    // Vertical centering using font metrics: place glyphs so the visual
-    // midpoint between ascender top and descender bottom sits at the row's
-    // vertical center.
+    // Vertical centering: place text block so its visual center aligns with
+    // the row's vertical center.  In PDF, the baseline is where we position
+    // text — glyphs extend upward by ascender and downward by descender.
     let text_h: f32 = cell.lines.iter().map(|l| l.height).sum();
-    let font_size = cell
-        .lines
-        .first()
-        .and_then(|l| l.runs.first())
-        .map_or(12.0, |r| r.font_size);
-    let font_family = cell
-        .lines
-        .first()
-        .and_then(|l| l.runs.first())
-        .map_or(FontFamily::Helvetica, |r| r.font_family.clone());
-    let ascender = crate::fonts::ascender_ratio(&font_family) * font_size;
-    let descender = crate::fonts::descender_ratio(&font_family) * font_size;
-    let visual_center = row_y - row_height / 2.0;
-    let mut text_y = visual_center + text_h / 2.0 + (ascender - descender) / 2.0 - ascender;
+
+    // Top of the text block, centered in the row
+    let text_block_top = row_y - (row_height - text_h) / 2.0;
+    let mut text_y = text_block_top;
     for line in &cell.lines {
         let line_font_size = line.runs.iter().map(|r| r.font_size).fold(0.0f32, f32::max);
+        let line_family = line
+            .runs
+            .first()
+            .map_or(FontFamily::Helvetica, |r| r.font_family.clone());
+        let line_ascender = crate::fonts::ascender_ratio(&line_family) * line_font_size;
         let half_leading = (line.height - line_font_size) / 2.0;
-        text_y -= line_font_size + half_leading;
+        // Baseline sits at: top of line - half_leading - ascender
+        text_y -= half_leading + line_ascender;
         let text_content: String = line.runs.iter().map(|r| r.text.as_str()).collect();
         if text_content.is_empty() {
             continue;
@@ -1513,6 +1509,8 @@ fn render_cell_text(
 
             x += rw;
         }
+        // Move past the rest of the line (descender + bottom half-leading)
+        text_y -= line.height - half_leading - line_ascender;
     }
 }
 
@@ -2780,6 +2778,61 @@ mod tests {
         let pdf = crate::html_to_pdf("<p>Test</p>").unwrap();
         let content = String::from_utf8_lossy(&pdf);
         assert!(!content.contains("Page 1 of"));
+    }
+
+    #[test]
+    fn render_header_only_no_footer() {
+        let pdf = crate::HtmlConverter::new()
+            .header("Header Only")
+            .convert("<p>Content</p>")
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("Header Only"));
+        assert!(!content.contains("Page 1"));
+    }
+
+    #[test]
+    fn render_footer_only_no_header() {
+        let pdf = crate::HtmlConverter::new()
+            .footer("{page}/{pages}")
+            .convert("<p>Content</p>")
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("1/1"));
+    }
+
+    #[test]
+    fn render_progress_bar_zero_fraction() {
+        let html = r#"<progress value="0" max="1"></progress>"#;
+        let pdf = crate::html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        // Track is drawn but fill is skipped when fraction=0
+        assert!(content.contains("re\nf\n")); // track rect
+        assert!(content.contains("re\nS\n")); // border stroke
+    }
+
+    #[test]
+    fn render_progress_bar_full_fraction() {
+        let html = r#"<progress value="1" max="1"></progress>"#;
+        let pdf = crate::html_to_pdf(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_bookmark_special_chars() {
+        let html = r#"<h1>Title with (parens) &amp; "quotes"</h1>"#;
+        let pdf = crate::html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("/Type /Outlines"));
+    }
+
+    #[test]
+    fn render_single_heading_bookmark() {
+        let html = "<h1>Only One</h1><p>Text</p>";
+        let pdf = crate::html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("/Count 1"));
+        assert!(content.contains("Only One"));
     }
 
     #[test]

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -26,6 +26,15 @@ struct LinkAnnotation {
     url: String,
 }
 
+/// A bookmark entry for PDF outline (table of contents).
+#[allow(dead_code)]
+struct BookmarkEntry {
+    title: String,
+    level: u8,
+    page_index: usize,
+    y_pos: f32,
+}
+
 /// Render laid-out pages into a PDF byte buffer.
 ///
 /// Uses the PDF built-in Helvetica font family (one of the 14 standard fonts)
@@ -51,10 +60,20 @@ pub fn render_pdf_with_fonts(
     Ok(buf)
 }
 
+/// Header and footer text for page decoration.
+pub struct PageDecoration {
+    /// Header text rendered top-center of each page.
+    pub header: Option<String>,
+    /// Footer text rendered bottom-center of each page.
+    /// `{page}` and `{pages}` are replaced with page number and total count.
+    pub footer: Option<String>,
+}
+
 /// Render laid-out pages as PDF, writing directly to any `std::io::Write` implementation.
 ///
 /// This is the streaming variant of [`render_pdf`]. It writes PDF content incrementally
 /// to the provided writer instead of building an in-memory buffer.
+#[allow(dead_code)]
 pub fn render_pdf_to_writer<W: std::io::Write>(
     pages: &[Page],
     page_size: PageSize,
@@ -72,15 +91,28 @@ fn render_pdf_to_writer_with_fonts<W: std::io::Write>(
     writer: &mut W,
     custom_fonts: &HashMap<String, TtfFont>,
 ) -> Result<(), IronpressError> {
+    render_pdf_to_writer_full(pages, page_size, margin, writer, custom_fonts, None)
+}
+
+/// Full render function with optional page decoration (headers/footers).
+pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
+    pages: &[Page],
+    page_size: PageSize,
+    margin: Margin,
+    writer: &mut W,
+    custom_fonts: &HashMap<String, TtfFont>,
+    decoration: Option<&PageDecoration>,
+) -> Result<(), IronpressError> {
     let mut pdf_writer = PdfWriter::new();
     let available_width = page_size.width - margin.left - margin.right;
+    let mut bookmarks: Vec<BookmarkEntry> = Vec::new();
 
     // Register custom TrueType fonts
     for (name, ttf) in custom_fonts {
         pdf_writer.add_ttf_font(name, ttf);
     }
 
-    for page in pages {
+    for (page_idx, page) in pages.iter().enumerate() {
         let mut content = String::new();
         let mut annotations: Vec<LinkAnnotation> = Vec::new();
         let mut page_images: Vec<ImageRef> = Vec::new();
@@ -116,11 +148,29 @@ fn render_pdf_to_writer_with_fonts<W: std::io::Write>(
                     outline_color,
                     letter_spacing,
                     word_spacing: css_word_spacing,
+                    heading_level,
                     ..
                 } => {
                     // Skip rendering if visibility: hidden (but space is preserved)
                     if !visible {
                         continue;
+                    }
+
+                    // Collect heading bookmark for PDF outlines
+                    if let Some(level) = heading_level {
+                        let title: String = lines
+                            .iter()
+                            .flat_map(|l| l.runs.iter().map(|r| r.text.as_str()))
+                            .collect::<Vec<_>>()
+                            .join("");
+                        if !title.trim().is_empty() {
+                            bookmarks.push(BookmarkEntry {
+                                title: title.trim().to_string(),
+                                level: *level,
+                                page_index: page_idx,
+                                y_pos: *y_pos,
+                            });
+                        }
                     }
 
                     // Compute block_x with float/position offsets
@@ -1246,7 +1296,89 @@ fn render_pdf_to_writer_with_fonts<W: std::io::Write>(
                         y = rule_y,
                     ));
                 }
+                LayoutElement::ProgressBar {
+                    fraction,
+                    width,
+                    height,
+                    fill_color,
+                    track_color,
+                    ..
+                } => {
+                    let bar_x = margin.left;
+                    let bar_y = page_size.height - margin.top - y_pos - height;
+
+                    // Draw track background
+                    content.push_str(&format!(
+                        "{r} {g} {b} rg\n{x} {y} {w} {h} re\nf\n",
+                        r = track_color.0,
+                        g = track_color.1,
+                        b = track_color.2,
+                        x = bar_x,
+                        y = bar_y,
+                        w = width,
+                        h = height,
+                    ));
+
+                    // Draw filled portion
+                    if *fraction > 0.0 {
+                        let fill_w = width * fraction;
+                        content.push_str(&format!(
+                            "{r} {g} {b} rg\n{x} {y} {w} {h} re\nf\n",
+                            r = fill_color.0,
+                            g = fill_color.1,
+                            b = fill_color.2,
+                            x = bar_x,
+                            y = bar_y,
+                            w = fill_w,
+                            h = height,
+                        ));
+                    }
+
+                    // Draw border
+                    content.push_str(&format!(
+                        "0.5 w\n0.6 0.6 0.6 RG\n{x} {y} {w} {h} re\nS\n",
+                        x = bar_x,
+                        y = bar_y,
+                        w = width,
+                        h = height,
+                    ));
+                }
                 LayoutElement::PageBreak => {}
+            }
+        }
+
+        // Render page header/footer in margin area
+        if let Some(dec) = decoration {
+            let total_pages = pages.len();
+            let page_num = page_idx + 1;
+            let center_x = page_size.width / 2.0;
+
+            if let Some(ref header_text) = dec.header {
+                let text = header_text
+                    .replace("{page}", &page_num.to_string())
+                    .replace("{pages}", &total_pages.to_string());
+                let encoded = encode_pdf_text(&text);
+                let header_y = page_size.height - margin.top / 2.0;
+                content.push_str("BT\n");
+                content.push_str(&format!("/Helvetica 9 Tf\n"));
+                content.push_str("0.4 0.4 0.4 rg\n");
+                content.push_str(&format!("{center_x} {header_y} Td\n"));
+                content.push_str(&format!("({encoded}) Tj\n"));
+                content.push_str("ET\n");
+            }
+
+            if let Some(ref footer_text) = dec.footer {
+                let text = footer_text
+                    .replace("{page}", &page_num.to_string())
+                    .replace("{pages}", &total_pages.to_string());
+                let encoded = encode_pdf_text(&text);
+                let footer_y = margin.bottom / 2.0;
+                content.push_str("BT\n");
+                content.push_str(&format!("/Helvetica 9 Tf\n"));
+                content.push_str("0.4 0.4 0.4 rg\n");
+                content.push_str(&format!("{center_x} {footer_y} Td\n"));
+                content.push_str(&format!("({encoded}) Tj\n"));
+                content.push_str("ET\n");
             }
         }
 
@@ -1261,7 +1393,7 @@ fn render_pdf_to_writer_with_fonts<W: std::io::Write>(
         );
     }
 
-    pdf_writer.finish_to_writer(writer)
+    pdf_writer.finish_to_writer(writer, &bookmarks)
 }
 
 /// Compute the height of a table row from its cells.
@@ -1956,7 +2088,11 @@ impl PdfWriter {
         self.page_shadings.push(shadings);
     }
 
-    fn finish_to_writer<W: std::io::Write>(self, out: &mut W) -> Result<(), IronpressError> {
+    fn finish_to_writer<W: std::io::Write>(
+        self,
+        out: &mut W,
+        bookmarks: &[BookmarkEntry],
+    ) -> Result<(), IronpressError> {
         let mut bytes_written: usize = 0;
         out.write_all(b"%PDF-1.4\n")?;
         bytes_written += b"%PDF-1.4\n".len();
@@ -2143,10 +2279,46 @@ impl PdfWriter {
             self.page_ids.len(),
         ));
 
+        // Outlines (PDF bookmarks from headings)
+        let outlines_ref = if bookmarks.is_empty() {
+            String::new()
+        } else {
+            let count = bookmarks.len();
+            // Outline root object
+            let root_id = all_objects.len() + 1;
+            let first_entry_id = root_id + 1;
+            let last_entry_id = first_entry_id + count - 1;
+            all_objects.push(format!(
+                "{root_id} 0 obj\n<< /Type /Outlines /First {first_entry_id} 0 R /Last {last_entry_id} 0 R /Count {count} >>\nendobj",
+            ));
+
+            // Outline entry objects (flat list, linked via Prev/Next)
+            for (i, bm) in bookmarks.iter().enumerate() {
+                let entry_id = first_entry_id + i;
+                let page_obj_id = self.page_ids.get(bm.page_index).copied().unwrap_or(1);
+
+                let mut entry = format!(
+                    "{entry_id} 0 obj\n<< /Title ({title}) /Parent {root_id} 0 R /Dest [{page_obj_id} 0 R /XYZ 0 {dest_y} 0]",
+                    title = escape_pdf_string(&bm.title),
+                    dest_y = bm.y_pos,
+                );
+                if i > 0 {
+                    entry.push_str(&format!(" /Prev {} 0 R", first_entry_id + i - 1));
+                }
+                if i + 1 < count {
+                    entry.push_str(&format!(" /Next {} 0 R", first_entry_id + i + 1));
+                }
+                entry.push_str(" >>\nendobj");
+                all_objects.push(entry);
+            }
+
+            format!(" /Outlines {root_id} 0 R /PageMode /UseOutlines")
+        };
+
         // Catalog
-        let catalog_id = pages_id + 1;
+        let catalog_id = all_objects.len() + 1;
         all_objects.push(format!(
-            "{catalog_id} 0 obj\n<< /Type /Catalog /Pages {pages_id} 0 R >>\nendobj",
+            "{catalog_id} 0 obj\n<< /Type /Catalog /Pages {pages_id} 0 R{outlines_ref} >>\nendobj",
         ));
 
         // Write objects and track offsets for xref
@@ -2391,6 +2563,205 @@ mod tests {
         let content = String::from_utf8_lossy(&pdf);
         // HR draws a line with stroke
         assert!(content.contains(" l\nS\n"));
+    }
+
+    #[test]
+    fn render_input_element() {
+        let pdf = crate::html_to_pdf(r#"<input type="text" value="Hello">"#).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(pdf.len() > 100);
+    }
+
+    #[test]
+    fn render_input_with_placeholder() {
+        let pdf = crate::html_to_pdf(r#"<input placeholder="Type here...">"#).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_select_element() {
+        let pdf =
+            crate::html_to_pdf(r#"<select><option>A</option><option>B</option></select>"#)
+                .unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(pdf.len() > 100);
+    }
+
+    #[test]
+    fn render_textarea_element() {
+        let pdf = crate::html_to_pdf(r#"<textarea>Hello World</textarea>"#).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(pdf.len() > 100);
+    }
+
+    #[test]
+    fn render_video_element() {
+        let pdf = crate::html_to_pdf(r#"<video width="320" height="240"></video>"#).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(pdf.len() > 100);
+    }
+
+    #[test]
+    fn render_audio_element() {
+        let pdf = crate::html_to_pdf(r#"<audio></audio>"#).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(pdf.len() > 100);
+    }
+
+    #[test]
+    fn render_progress_element() {
+        let pdf = crate::html_to_pdf(r#"<progress value="0.7" max="1"></progress>"#).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        let content = String::from_utf8_lossy(&pdf);
+        // Progress bar draws rectangles (track + fill + border)
+        assert!(content.contains("re\nf\n"), "Expected filled rectangles for progress bar");
+    }
+
+    #[test]
+    fn render_progress_empty() {
+        let pdf = crate::html_to_pdf(r#"<progress value="0" max="1"></progress>"#).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_meter_element() {
+        let pdf = crate::html_to_pdf(r#"<meter value="0.5" max="1"></meter>"#).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("re\nf\n"), "Expected filled rectangles for meter bar");
+    }
+
+    #[test]
+    fn render_meter_low_value() {
+        let pdf = crate::html_to_pdf(
+            r#"<meter value="5" max="100" low="25" high="75"></meter>"#,
+        )
+        .unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_form_controls_styled() {
+        let html = r#"
+            <input type="text" value="styled" style="width: 200px; border: 2px solid blue; background-color: #eee">
+        "#;
+        let pdf = crate::html_to_pdf(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_mixed_form_and_text() {
+        let html = r#"
+            <p>Fill in the form:</p>
+            <input type="text" value="John">
+            <p>Select country:</p>
+            <select><option>France</option></select>
+            <p>Comments:</p>
+            <textarea>Great product!</textarea>
+            <p>Rating:</p>
+            <progress value="80" max="100"></progress>
+        "#;
+        let pdf = crate::html_to_pdf(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(pdf.len() > 500);
+    }
+
+    #[test]
+    fn render_pdf_bookmarks_from_headings() {
+        let html = "<h1>Chapter 1</h1><p>Content</p><h2>Section 1.1</h2><p>More</p>";
+        let pdf = crate::html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("/Type /Outlines"), "Expected PDF outlines");
+        assert!(content.contains("Chapter 1"), "Expected heading text in bookmark");
+        assert!(content.contains("Section 1.1"), "Expected h2 heading in bookmark");
+    }
+
+    #[test]
+    fn render_pdf_no_bookmarks_without_headings() {
+        let html = "<p>No headings here</p>";
+        let pdf = crate::html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(!content.contains("/Type /Outlines"), "Should not have outlines without headings");
+    }
+
+    #[test]
+    fn render_pdf_bookmarks_multi_page() {
+        let html = r#"
+            <h1>Page 1 Title</h1>
+            <p>Content</p>
+            <div style="page-break-before: always">
+                <h1>Page 2 Title</h1>
+                <p>More content</p>
+            </div>
+        "#;
+        let pdf = crate::html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("Page 1 Title"));
+        assert!(content.contains("Page 2 Title"));
+        assert!(content.contains("/Type /Outlines"));
+    }
+
+    #[test]
+    fn render_pdf_bookmarks_all_levels() {
+        let html = "<h1>H1</h1><h2>H2</h2><h3>H3</h3><h4>H4</h4><h5>H5</h5><h6>H6</h6>";
+        let pdf = crate::html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("/Count 6"), "Expected 6 outline entries");
+    }
+
+    #[test]
+    fn render_page_footer() {
+        let pdf = crate::HtmlConverter::new()
+            .footer("Page {page} of {pages}")
+            .convert("<h1>Title</h1><p>Content</p>")
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("Page 1 of 1"), "Expected footer with page numbers");
+    }
+
+    #[test]
+    fn render_page_header() {
+        let pdf = crate::HtmlConverter::new()
+            .header("My Document")
+            .convert("<p>Content</p>")
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("My Document"), "Expected header text in PDF");
+    }
+
+    #[test]
+    fn render_header_and_footer() {
+        let pdf = crate::HtmlConverter::new()
+            .header("Report Title")
+            .footer("Page {page} of {pages}")
+            .convert("<p>Page 1</p>")
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("Report Title"));
+        assert!(content.contains("Page 1 of 1"));
+    }
+
+    #[test]
+    fn render_footer_multi_page() {
+        let html = r#"
+            <p>First page</p>
+            <div style="page-break-before: always"><p>Second page</p></div>
+        "#;
+        let pdf = crate::HtmlConverter::new()
+            .footer("Page {page} of {pages}")
+            .convert(html)
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        // Verify page number substitution works (at least page 1 and last page are present)
+        assert!(content.contains("Page 1 of"), "Expected footer with page 1");
+        assert!(content.contains("Page 2 of"), "Expected footer with page 2");
+    }
+
+    #[test]
+    fn render_no_header_footer_by_default() {
+        let pdf = crate::html_to_pdf("<p>Test</p>").unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(!content.contains("Page 1 of"));
     }
 
     #[test]
@@ -3267,6 +3638,7 @@ mod tests {
                     word_spacing: 0.0,
                     vertical_align: crate::style::computed::VerticalAlign::Baseline,
                     z_index: 0,
+                    heading_level: None,
                 },
             )],
         };
@@ -3331,6 +3703,7 @@ mod tests {
                         word_spacing: 0.0,
                         vertical_align: crate::style::computed::VerticalAlign::Baseline,
                         z_index: 0,
+                        heading_level: None,
                     },
                 ),
                 (20.0, LayoutElement::PageBreak),
@@ -4433,6 +4806,7 @@ mod tests {
                     word_spacing: 0.0,
                     vertical_align: crate::style::computed::VerticalAlign::Baseline,
                     z_index: 0,
+                    heading_level: None,
                 },
             )],
         };

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1360,7 +1360,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                 let encoded = encode_pdf_text(&text);
                 let header_y = page_size.height - margin.top / 2.0;
                 content.push_str("BT\n");
-                content.push_str(&format!("/Helvetica 9 Tf\n"));
+                content.push_str("/Helvetica 9 Tf\n");
                 content.push_str("0.4 0.4 0.4 rg\n");
                 content.push_str(&format!("{center_x} {header_y} Td\n"));
                 content.push_str(&format!("({encoded}) Tj\n"));
@@ -1374,7 +1374,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                 let encoded = encode_pdf_text(&text);
                 let footer_y = margin.bottom / 2.0;
                 content.push_str("BT\n");
-                content.push_str(&format!("/Helvetica 9 Tf\n"));
+                content.push_str("/Helvetica 9 Tf\n");
                 content.push_str("0.4 0.4 0.4 rg\n");
                 content.push_str(&format!("{center_x} {footer_y} Td\n"));
                 content.push_str(&format!("({encoded}) Tj\n"));
@@ -2581,8 +2581,7 @@ mod tests {
     #[test]
     fn render_select_element() {
         let pdf =
-            crate::html_to_pdf(r#"<select><option>A</option><option>B</option></select>"#)
-                .unwrap();
+            crate::html_to_pdf(r#"<select><option>A</option><option>B</option></select>"#).unwrap();
         assert!(pdf.starts_with(b"%PDF"));
         assert!(pdf.len() > 100);
     }
@@ -2614,7 +2613,10 @@ mod tests {
         assert!(pdf.starts_with(b"%PDF"));
         let content = String::from_utf8_lossy(&pdf);
         // Progress bar draws rectangles (track + fill + border)
-        assert!(content.contains("re\nf\n"), "Expected filled rectangles for progress bar");
+        assert!(
+            content.contains("re\nf\n"),
+            "Expected filled rectangles for progress bar"
+        );
     }
 
     #[test]
@@ -2628,15 +2630,16 @@ mod tests {
         let pdf = crate::html_to_pdf(r#"<meter value="0.5" max="1"></meter>"#).unwrap();
         assert!(pdf.starts_with(b"%PDF"));
         let content = String::from_utf8_lossy(&pdf);
-        assert!(content.contains("re\nf\n"), "Expected filled rectangles for meter bar");
+        assert!(
+            content.contains("re\nf\n"),
+            "Expected filled rectangles for meter bar"
+        );
     }
 
     #[test]
     fn render_meter_low_value() {
-        let pdf = crate::html_to_pdf(
-            r#"<meter value="5" max="100" low="25" high="75"></meter>"#,
-        )
-        .unwrap();
+        let pdf = crate::html_to_pdf(r#"<meter value="5" max="100" low="25" high="75"></meter>"#)
+            .unwrap();
         assert!(pdf.starts_with(b"%PDF"));
     }
 
@@ -2672,8 +2675,14 @@ mod tests {
         let pdf = crate::html_to_pdf(html).unwrap();
         let content = String::from_utf8_lossy(&pdf);
         assert!(content.contains("/Type /Outlines"), "Expected PDF outlines");
-        assert!(content.contains("Chapter 1"), "Expected heading text in bookmark");
-        assert!(content.contains("Section 1.1"), "Expected h2 heading in bookmark");
+        assert!(
+            content.contains("Chapter 1"),
+            "Expected heading text in bookmark"
+        );
+        assert!(
+            content.contains("Section 1.1"),
+            "Expected h2 heading in bookmark"
+        );
     }
 
     #[test]
@@ -2681,7 +2690,10 @@ mod tests {
         let html = "<p>No headings here</p>";
         let pdf = crate::html_to_pdf(html).unwrap();
         let content = String::from_utf8_lossy(&pdf);
-        assert!(!content.contains("/Type /Outlines"), "Should not have outlines without headings");
+        assert!(
+            !content.contains("/Type /Outlines"),
+            "Should not have outlines without headings"
+        );
     }
 
     #[test]
@@ -2716,7 +2728,10 @@ mod tests {
             .convert("<h1>Title</h1><p>Content</p>")
             .unwrap();
         let content = String::from_utf8_lossy(&pdf);
-        assert!(content.contains("Page 1 of 1"), "Expected footer with page numbers");
+        assert!(
+            content.contains("Page 1 of 1"),
+            "Expected footer with page numbers"
+        );
     }
 
     #[test]
@@ -2726,7 +2741,10 @@ mod tests {
             .convert("<p>Content</p>")
             .unwrap();
         let content = String::from_utf8_lossy(&pdf);
-        assert!(content.contains("My Document"), "Expected header text in PDF");
+        assert!(
+            content.contains("My Document"),
+            "Expected header text in PDF"
+        );
     }
 
     #[test]

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -4708,6 +4708,56 @@ mod tests {
         assert_eq!(style.column_count, Some(2));
     }
 
+    #[test]
+    fn column_count_initial_resets() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("column-count: initial"), &parent);
+        assert_eq!(style.column_count, None);
+    }
+
+    #[test]
+    fn column_count_inherit_from_parent() {
+        let mut parent = ComputedStyle::default();
+        parent.column_count = Some(3);
+        let style = compute_style(HtmlTag::Div, Some("column-count: inherit"), &parent);
+        assert_eq!(style.column_count, Some(3));
+    }
+
+    #[test]
+    fn column_gap_initial_resets() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("column-gap: initial"), &parent);
+        assert!((style.column_gap - 0.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn column_count_invalid_value_ignored() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("column-count: auto"), &parent);
+        assert_eq!(style.column_count, None);
+    }
+
+    #[test]
+    fn grid_template_columns_repeat_single() {
+        let tracks = parse_grid_template_columns("repeat(1, 100pt)");
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0], GridTrack::Fixed(100.0));
+    }
+
+    #[test]
+    fn grid_minmax_auto_min() {
+        let tracks = parse_grid_template_columns("minmax(auto, 200pt)");
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0], GridTrack::Minmax(0.0, 200.0));
+    }
+
+    #[test]
+    fn grid_minmax_auto_max() {
+        let tracks = parse_grid_template_columns("minmax(50pt, auto)");
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0], GridTrack::Minmax(50.0, f32::MAX));
+    }
+
     // --- parse_hex_to_color invalid length (line 1313) ---
 
     #[test]

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -4692,7 +4692,11 @@ mod tests {
     #[test]
     fn column_gap_parsed() {
         let parent = ComputedStyle::default();
-        let style = compute_style(HtmlTag::Div, Some("column-count: 2; column-gap: 15pt"), &parent);
+        let style = compute_style(
+            HtmlTag::Div,
+            Some("column-count: 2; column-gap: 15pt"),
+            &parent,
+        );
         assert_eq!(style.column_count, Some(2));
         assert!((style.column_gap - 15.0).abs() < 0.1);
     }

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -63,6 +63,8 @@ pub enum GridTrack {
     Fr(f32),
     /// Automatic sizing (equal share of remaining space).
     Auto,
+    /// `minmax(min, max)` — the track is at least `min` and at most `max`.
+    Minmax(f32, f32),
 }
 
 /// Text alignment.
@@ -439,6 +441,8 @@ pub struct ComputedStyle {
     pub content: Vec<ContentItem>,
     pub counter_reset: Vec<(String, i32)>,
     pub counter_increment: Vec<(String, i32)>,
+    pub column_count: Option<u32>,
+    pub column_gap: f32,
 }
 
 impl Default for ComputedStyle {
@@ -513,6 +517,8 @@ impl Default for ComputedStyle {
             content: Vec::new(),
             counter_reset: Vec::new(),
             counter_increment: Vec::new(),
+            column_count: None,
+            column_gap: 0.0,
         }
     }
 }
@@ -765,6 +771,8 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
         "content" => style.content = default.content,
         "counter-reset" => style.counter_reset = default.counter_reset,
         "counter-increment" => style.counter_increment = default.counter_increment,
+        "column-count" | "columns" => style.column_count = default.column_count,
+        "column-gap" => style.column_gap = default.column_gap,
         _ => {}
     }
 }
@@ -842,6 +850,8 @@ fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &Compu
         "content" => style.content = parent.content.clone(),
         "counter-reset" => style.counter_reset = parent.counter_reset.clone(),
         "counter-increment" => style.counter_increment = parent.counter_increment.clone(),
+        "column-count" | "columns" => style.column_count = parent.column_count,
+        "column-gap" => style.column_gap = parent.column_gap,
         _ => {}
     }
 }
@@ -1292,6 +1302,33 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
         if let Some(shadow) = parse_box_shadow(k) {
             style.box_shadow = Some(shadow);
         }
+    }
+
+    // Multi-column layout
+    if let Some(val) = get_non_special(map, "column-count") {
+        match val {
+            CssValue::Length(n) => style.column_count = Some(*n as u32),
+            CssValue::Keyword(k) => {
+                if let Ok(n) = k.parse::<u32>() {
+                    style.column_count = Some(n);
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(val) = get_non_special(map, "columns") {
+        match val {
+            CssValue::Length(n) => style.column_count = Some(*n as u32),
+            CssValue::Keyword(k) => {
+                if let Ok(n) = k.parse::<u32>() {
+                    style.column_count = Some(n);
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(CssValue::Length(v)) = get_non_special(map, "column-gap") {
+        style.column_gap = *v;
     }
 
     // Overflow
@@ -1959,26 +1996,137 @@ fn parse_transform_length(val: &str) -> Option<f32> {
     }
 }
 
+/// Parse a single grid track token (e.g. `1fr`, `200pt`, `100px`, `auto`).
+fn parse_single_track(token: &str) -> Option<GridTrack> {
+    let token = token.trim();
+    if let Some(n) = token.strip_suffix("fr") {
+        n.parse::<f32>().ok().map(GridTrack::Fr)
+    } else if token == "auto" || token == "auto-fill" || token == "auto-fit" {
+        Some(GridTrack::Auto)
+    } else if let Some(n) = token.strip_suffix("pt") {
+        n.parse::<f32>().ok().map(GridTrack::Fixed)
+    } else if let Some(n) = token.strip_suffix("px") {
+        n.parse::<f32>().ok().map(|v| GridTrack::Fixed(v * 0.75))
+    } else {
+        token.parse::<f32>().ok().map(GridTrack::Fixed)
+    }
+}
+
+/// Parse a `minmax(min, max)` expression.
+fn parse_minmax(val: &str) -> Option<GridTrack> {
+    let inner = val.strip_prefix("minmax(")?.strip_suffix(')')?;
+    let mut parts = inner.splitn(2, ',');
+    let min_s = parts.next()?.trim();
+    let max_s = parts.next()?.trim();
+
+    let min_val = if min_s == "auto" || min_s == "0" {
+        0.0
+    } else if let Some(n) = min_s.strip_suffix("px") {
+        n.parse::<f32>().ok()? * 0.75
+    } else if let Some(n) = min_s.strip_suffix("pt") {
+        n.parse::<f32>().ok()?
+    } else {
+        min_s.parse::<f32>().ok().unwrap_or(0.0)
+    };
+
+    // If max is `1fr` or `auto`, treat as flexible — use Minmax with a large max
+    let max_val = if max_s.ends_with("fr") || max_s == "auto" {
+        f32::MAX
+    } else if let Some(n) = max_s.strip_suffix("px") {
+        n.parse::<f32>().ok()? * 0.75
+    } else if let Some(n) = max_s.strip_suffix("pt") {
+        n.parse::<f32>().ok()?
+    } else {
+        max_s.parse::<f32>().ok().unwrap_or(f32::MAX)
+    };
+
+    Some(GridTrack::Minmax(min_val, max_val))
+}
+
 /// Parse a `grid-template-columns` value string into a list of `GridTrack` values.
 ///
-/// Supports tokens like `1fr`, `200pt`, `100px`, and `auto`.
+/// Supports tokens like `1fr`, `200pt`, `100px`, `auto`, `repeat(3, 1fr)`,
+/// `minmax(100px, 1fr)`, `auto-fill`, and `auto-fit`.
 fn parse_grid_template_columns(val: &str) -> Vec<GridTrack> {
-    val.split_whitespace()
-        .filter_map(|token| {
-            if let Some(n) = token.strip_suffix("fr") {
-                n.parse::<f32>().ok().map(GridTrack::Fr)
-            } else if token == "auto" {
-                Some(GridTrack::Auto)
-            } else if let Some(n) = token.strip_suffix("pt") {
-                n.parse::<f32>().ok().map(GridTrack::Fixed)
-            } else if let Some(n) = token.strip_suffix("px") {
-                n.parse::<f32>().ok().map(|v| GridTrack::Fixed(v * 0.75))
-            } else {
-                // Try bare number as pt
-                token.parse::<f32>().ok().map(GridTrack::Fixed)
+    let mut result = Vec::new();
+    let mut remaining = val.trim();
+
+    while !remaining.is_empty() {
+        remaining = remaining.trim_start();
+        if remaining.is_empty() {
+            break;
+        }
+
+        // Handle repeat(...)
+        if remaining.starts_with("repeat(") {
+            if let Some(close) = find_matching_paren(remaining, 7) {
+                let inner = &remaining[7..close];
+                let rest = &remaining[close + 1..];
+
+                // Parse repeat(count, track_pattern)
+                if let Some(comma) = inner.find(',') {
+                    let count_str = inner[..comma].trim();
+                    let pattern = inner[comma + 1..].trim();
+
+                    // auto-fill and auto-fit: default to 3 columns for PDF (no viewport)
+                    let count: usize = if count_str == "auto-fill" || count_str == "auto-fit" {
+                        3
+                    } else {
+                        count_str.parse().unwrap_or(1)
+                    };
+
+                    let track_list = parse_grid_template_columns(pattern);
+                    for _ in 0..count {
+                        result.extend(track_list.clone());
+                    }
+                }
+                remaining = rest;
+                continue;
             }
-        })
-        .collect()
+        }
+
+        // Handle minmax(...)
+        if remaining.starts_with("minmax(") {
+            if let Some(close) = find_matching_paren(remaining, 7) {
+                let expr = &remaining[..close + 1];
+                if let Some(track) = parse_minmax(expr) {
+                    result.push(track);
+                }
+                remaining = &remaining[close + 1..];
+                continue;
+            }
+        }
+
+        // Regular token — read until next whitespace or function start
+        let end = remaining
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or(remaining.len());
+        let token = &remaining[..end];
+        if let Some(track) = parse_single_track(token) {
+            result.push(track);
+        }
+        remaining = &remaining[end..];
+    }
+
+    result
+}
+
+/// Find the closing `)` matching an opening `(` at `start` in `s`.
+fn find_matching_paren(s: &str, start: usize) -> Option<usize> {
+    let mut depth = 1;
+    for (i, c) in s[start..].char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(start + i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Parse a border shorthand string like "1px solid black" into (width_pt, Option<Color>).
@@ -4459,6 +4607,101 @@ mod tests {
         assert_eq!(tracks.len(), 2);
         assert_eq!(tracks[0], GridTrack::Fixed(100.0));
         assert_eq!(tracks[1], GridTrack::Fixed(200.0));
+    }
+
+    #[test]
+    fn grid_template_columns_repeat() {
+        let tracks = parse_grid_template_columns("repeat(3, 1fr)");
+        assert_eq!(tracks.len(), 3);
+        assert_eq!(tracks[0], GridTrack::Fr(1.0));
+        assert_eq!(tracks[1], GridTrack::Fr(1.0));
+        assert_eq!(tracks[2], GridTrack::Fr(1.0));
+    }
+
+    #[test]
+    fn grid_template_columns_repeat_fixed() {
+        let tracks = parse_grid_template_columns("repeat(2, 100px)");
+        assert_eq!(tracks.len(), 2);
+        assert_eq!(tracks[0], GridTrack::Fixed(75.0));
+        assert_eq!(tracks[1], GridTrack::Fixed(75.0));
+    }
+
+    #[test]
+    fn grid_template_columns_repeat_multi_track() {
+        let tracks = parse_grid_template_columns("repeat(2, 1fr 2fr)");
+        assert_eq!(tracks.len(), 4);
+        assert_eq!(tracks[0], GridTrack::Fr(1.0));
+        assert_eq!(tracks[1], GridTrack::Fr(2.0));
+        assert_eq!(tracks[2], GridTrack::Fr(1.0));
+        assert_eq!(tracks[3], GridTrack::Fr(2.0));
+    }
+
+    #[test]
+    fn grid_template_columns_repeat_auto_fill() {
+        let tracks = parse_grid_template_columns("repeat(auto-fill, 100px)");
+        // auto-fill defaults to 3 columns for PDF
+        assert_eq!(tracks.len(), 3);
+        assert_eq!(tracks[0], GridTrack::Fixed(75.0));
+    }
+
+    #[test]
+    fn grid_template_columns_repeat_auto_fit() {
+        let tracks = parse_grid_template_columns("repeat(auto-fit, 1fr)");
+        assert_eq!(tracks.len(), 3);
+        assert_eq!(tracks[0], GridTrack::Fr(1.0));
+    }
+
+    #[test]
+    fn grid_template_columns_minmax() {
+        let tracks = parse_grid_template_columns("minmax(100px, 1fr)");
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0], GridTrack::Minmax(75.0, f32::MAX));
+    }
+
+    #[test]
+    fn grid_template_columns_minmax_fixed() {
+        let tracks = parse_grid_template_columns("minmax(50pt, 200pt)");
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0], GridTrack::Minmax(50.0, 200.0));
+    }
+
+    #[test]
+    fn grid_template_columns_mixed_with_repeat() {
+        let tracks = parse_grid_template_columns("100pt repeat(2, 1fr) auto");
+        assert_eq!(tracks.len(), 4);
+        assert_eq!(tracks[0], GridTrack::Fixed(100.0));
+        assert_eq!(tracks[1], GridTrack::Fr(1.0));
+        assert_eq!(tracks[2], GridTrack::Fr(1.0));
+        assert_eq!(tracks[3], GridTrack::Auto);
+    }
+
+    #[test]
+    fn grid_template_columns_repeat_with_minmax() {
+        let tracks = parse_grid_template_columns("repeat(3, minmax(100px, 1fr))");
+        assert_eq!(tracks.len(), 3);
+        assert_eq!(tracks[0], GridTrack::Minmax(75.0, f32::MAX));
+    }
+
+    #[test]
+    fn column_count_parsed() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("column-count: 3"), &parent);
+        assert_eq!(style.column_count, Some(3));
+    }
+
+    #[test]
+    fn column_gap_parsed() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("column-count: 2; column-gap: 15pt"), &parent);
+        assert_eq!(style.column_count, Some(2));
+        assert!((style.column_gap - 15.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn columns_shorthand_parsed() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("columns: 2"), &parent);
+        assert_eq!(style.column_count, Some(2));
     }
 
     // --- parse_hex_to_color invalid length (line 1313) ---

--- a/src/style/defaults.rs
+++ b/src/style/defaults.rs
@@ -182,10 +182,7 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
         HtmlTag::Video => {
             style.set("margin-top", CssValue::Length(4.0));
             style.set("margin-bottom", CssValue::Length(4.0));
-            style.set(
-                "background-color",
-                CssValue::Color(Color::rgb(0, 0, 0)),
-            );
+            style.set("background-color", CssValue::Color(Color::rgb(0, 0, 0)));
         }
         HtmlTag::Audio => {
             style.set("margin-top", CssValue::Length(2.0));

--- a/src/style/defaults.rs
+++ b/src/style/defaults.rs
@@ -154,6 +154,55 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
         HtmlTag::Summary => {
             style.set("font-weight", CssValue::Keyword("bold".into()));
         }
+        HtmlTag::Input => {
+            style.set("padding-top", CssValue::Length(2.0));
+            style.set("padding-right", CssValue::Length(4.0));
+            style.set("padding-bottom", CssValue::Length(2.0));
+            style.set("padding-left", CssValue::Length(4.0));
+            style.set("border-width", CssValue::Length(1.0));
+            style.set("border-color", CssValue::Color(Color::rgb(169, 169, 169)));
+        }
+        HtmlTag::Select => {
+            style.set("padding-top", CssValue::Length(2.0));
+            style.set("padding-right", CssValue::Length(4.0));
+            style.set("padding-bottom", CssValue::Length(2.0));
+            style.set("padding-left", CssValue::Length(4.0));
+            style.set("border-width", CssValue::Length(1.0));
+            style.set("border-color", CssValue::Color(Color::rgb(169, 169, 169)));
+        }
+        HtmlTag::Textarea => {
+            style.set("padding-top", CssValue::Length(4.0));
+            style.set("padding-right", CssValue::Length(4.0));
+            style.set("padding-bottom", CssValue::Length(4.0));
+            style.set("padding-left", CssValue::Length(4.0));
+            style.set("border-width", CssValue::Length(1.0));
+            style.set("border-color", CssValue::Color(Color::rgb(169, 169, 169)));
+            style.set("font-size", CssValue::Length(10.0));
+        }
+        HtmlTag::Video => {
+            style.set("margin-top", CssValue::Length(4.0));
+            style.set("margin-bottom", CssValue::Length(4.0));
+            style.set(
+                "background-color",
+                CssValue::Color(Color::rgb(0, 0, 0)),
+            );
+        }
+        HtmlTag::Audio => {
+            style.set("margin-top", CssValue::Length(2.0));
+            style.set("margin-bottom", CssValue::Length(2.0));
+            style.set(
+                "background-color",
+                CssValue::Color(Color::rgb(240, 240, 240)),
+            );
+        }
+        HtmlTag::Progress => {
+            style.set("margin-top", CssValue::Length(2.0));
+            style.set("margin-bottom", CssValue::Length(2.0));
+        }
+        HtmlTag::Meter => {
+            style.set("margin-top", CssValue::Length(2.0));
+            style.set("margin-bottom", CssValue::Length(2.0));
+        }
         _ => {}
     }
 
@@ -245,6 +294,43 @@ mod tests {
                 .is_some()
         );
         assert!(default_style(HtmlTag::Summary).get("font-weight").is_some());
+    }
+
+    #[test]
+    fn form_element_defaults() {
+        let input = default_style(HtmlTag::Input);
+        assert!(input.get("padding-top").is_some());
+        assert!(input.get("border-width").is_some());
+        assert!(input.get("border-color").is_some());
+
+        let select = default_style(HtmlTag::Select);
+        assert!(select.get("padding-top").is_some());
+        assert!(select.get("border-width").is_some());
+
+        let textarea = default_style(HtmlTag::Textarea);
+        assert!(textarea.get("padding-top").is_some());
+        assert!(textarea.get("font-size").is_some());
+        assert!(textarea.get("border-width").is_some());
+    }
+
+    #[test]
+    fn media_element_defaults() {
+        let video = default_style(HtmlTag::Video);
+        assert!(video.get("background-color").is_some());
+        assert!(video.get("margin-top").is_some());
+
+        let audio = default_style(HtmlTag::Audio);
+        assert!(audio.get("background-color").is_some());
+        assert!(audio.get("margin-top").is_some());
+    }
+
+    #[test]
+    fn progress_meter_defaults() {
+        let progress = default_style(HtmlTag::Progress);
+        assert!(progress.get("margin-top").is_some());
+
+        let meter = default_style(HtmlTag::Meter);
+        assert!(meter.get("margin-top").is_some());
     }
 
     #[test]

--- a/tests/pdf_smoke_tests.rs
+++ b/tests/pdf_smoke_tests.rs
@@ -1,0 +1,304 @@
+/// Smoke tests: generate PDFs for all major features and verify structural integrity.
+/// These tests ensure no feature addition breaks existing PDF generation.
+
+fn pdf_is_valid(pdf: &[u8]) -> bool {
+    let s = String::from_utf8_lossy(pdf);
+    pdf.starts_with(b"%PDF-1.4")
+        && s.contains("/Type /Catalog")
+        && s.contains("/Type /Pages")
+        && s.contains("%%EOF")
+        && s.contains("xref")
+}
+
+fn pdf_has_text(pdf: &[u8], text: &str) -> bool {
+    String::from_utf8_lossy(pdf).contains(text)
+}
+
+fn pdf_page_count(pdf: &[u8]) -> usize {
+    let s = String::from_utf8_lossy(pdf);
+    // Extract /Count N from /Type /Pages
+    if let Some(pos) = s.find("/Type /Pages") {
+        let after = &s[pos..];
+        if let Some(count_pos) = after.find("/Count ") {
+            let num_start = count_pos + 7;
+            let num_end = after[num_start..]
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(0)
+                + num_start;
+            return after[num_start..num_end].parse().unwrap_or(0);
+        }
+    }
+    0
+}
+
+// === Basic rendering ===
+
+#[test]
+fn smoke_simple_html() {
+    let pdf = ironpress::html_to_pdf("<h1>Hello</h1><p>World</p>").unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Hello"));
+    assert!(pdf_has_text(&pdf, "World"));
+}
+
+#[test]
+fn smoke_markdown() {
+    let pdf =
+        ironpress::markdown_to_pdf("# Title\n\nParagraph with **bold** and *italic*.").unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Title"));
+}
+
+// === Headings & bookmarks ===
+
+#[test]
+fn smoke_headings_produce_bookmarks() {
+    let html = "<h1>Ch1</h1><h2>Sec1</h2><h3>Sub1</h3><p>Content</p>";
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "/Type /Outlines"));
+    assert!(pdf_has_text(&pdf, "Ch1"));
+    assert!(pdf_has_text(&pdf, "Sec1"));
+    assert!(pdf_has_text(&pdf, "Sub1"));
+}
+
+// === Inline formatting ===
+
+#[test]
+fn smoke_inline_formatting() {
+    let html = r#"
+        <p><strong>Bold</strong> <em>Italic</em> <u>Underline</u></p>
+        <p><del>Deleted</del> <code>Code</code> <mark>Highlighted</mark></p>
+        <p><a href="https://example.com">Link</a></p>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Bold"));
+    assert!(pdf_has_text(&pdf, "/Subtype /Link"));
+}
+
+// === Tables ===
+
+#[test]
+fn smoke_table() {
+    let html = r#"
+        <table>
+            <thead><tr><th>Name</th><th>Age</th></tr></thead>
+            <tbody>
+                <tr><td>Alice</td><td>30</td></tr>
+                <tr><td colspan="2">Footer row</td></tr>
+            </tbody>
+        </table>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Alice"));
+}
+
+// === Lists ===
+
+#[test]
+fn smoke_lists() {
+    let html = r#"
+        <ul><li>Item A</li><li>Item B</li></ul>
+        <ol><li>First</li><li>Second</li></ol>
+        <dl><dt>Term</dt><dd>Definition</dd></dl>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Item A"));
+}
+
+// === Images (data URI) ===
+
+#[test]
+fn smoke_image_png() {
+    let html = r#"<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==" width="50" height="50">"#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "/Subtype /Image"));
+}
+
+// === CSS features ===
+
+#[test]
+fn smoke_css_styling() {
+    let html = r#"
+        <style>
+            .box { background-color: #336699; color: white; padding: 10pt; border: 2pt solid black; border-radius: 4pt; }
+            .center { text-align: center; }
+        </style>
+        <div class="box"><p class="center">Styled box</p></div>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Styled box"));
+}
+
+#[test]
+fn smoke_flexbox() {
+    let html = r#"
+        <style>.flex { display: flex; gap: 10pt; }</style>
+        <div class="flex"><div>A</div><div>B</div><div>C</div></div>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+}
+
+#[test]
+fn smoke_grid() {
+    let html = r#"
+        <style>.grid { display: grid; grid-template-columns: repeat(3, 1fr); grid-gap: 5pt; }</style>
+        <div class="grid"><div>1</div><div>2</div><div>3</div></div>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+}
+
+#[test]
+fn smoke_grid_minmax() {
+    let html = r#"
+        <style>.grid { display: grid; grid-template-columns: minmax(100px, 1fr) 2fr; }</style>
+        <div class="grid"><div>Left</div><div>Right</div></div>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+}
+
+#[test]
+fn smoke_multi_column() {
+    let html = r#"
+        <style>.cols { column-count: 3; column-gap: 10pt; }</style>
+        <div class="cols"><div>A</div><div>B</div><div>C</div></div>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+}
+
+// === v1.1: New HTML elements ===
+
+#[test]
+fn smoke_form_controls() {
+    let html = r#"
+        <input type="text" value="John Doe">
+        <select><option>France</option><option>USA</option></select>
+        <textarea>Some text here</textarea>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "John Doe"));
+}
+
+#[test]
+fn smoke_media_elements() {
+    let html = r#"
+        <video width="320" height="240"></video>
+        <audio></audio>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+}
+
+#[test]
+fn smoke_progress_meter() {
+    let html = r#"
+        <progress value="70" max="100"></progress>
+        <meter value="0.6" max="1" low="0.25" high="0.75"></meter>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+}
+
+// === v1.3: Page features ===
+
+#[test]
+fn smoke_page_break() {
+    let html = r#"<p>Page 1</p><div style="page-break-before: always"><p>Page 2</p></div>"#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_page_count(&pdf) >= 2);
+}
+
+#[test]
+fn smoke_header_footer() {
+    let pdf = ironpress::HtmlConverter::new()
+        .header("My Report")
+        .footer("Page {page} of {pages}")
+        .convert("<h1>Title</h1><p>Content</p>")
+        .unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "My Report"));
+    assert!(pdf_has_text(&pdf, "Page 1 of 1"));
+}
+
+#[test]
+fn smoke_custom_page_size() {
+    let pdf = ironpress::HtmlConverter::new()
+        .page_size(ironpress::PageSize::LETTER)
+        .margin(ironpress::Margin::uniform(36.0))
+        .convert("<p>Letter size</p>")
+        .unwrap();
+    assert!(pdf_is_valid(&pdf));
+}
+
+// === SVG ===
+
+#[test]
+fn smoke_inline_svg() {
+    let html = r#"
+        <svg width="100" height="100" viewBox="0 0 100 100">
+            <rect x="10" y="10" width="80" height="80" fill="blue" />
+            <circle cx="50" cy="50" r="20" fill="red" />
+        </svg>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+}
+
+// === Complex document ===
+
+#[test]
+fn smoke_full_document() {
+    let html = r#"
+        <style>
+            body { font-size: 11pt; }
+            h1 { color: navy; }
+            .highlight { background-color: yellow; }
+            table { border-collapse: collapse; }
+            td, th { border: 1pt solid #ccc; padding: 4pt; }
+        </style>
+        <h1>Annual Report</h1>
+        <p>This is a <strong>comprehensive</strong> test of <em>all</em> features.</p>
+        <h2>Section 1: Data</h2>
+        <table>
+            <thead><tr><th>Metric</th><th>Value</th></tr></thead>
+            <tbody>
+                <tr><td>Revenue</td><td>$1.2M</td></tr>
+                <tr><td>Growth</td><td>15%</td></tr>
+            </tbody>
+        </table>
+        <h2>Section 2: Progress</h2>
+        <p>Project completion: <progress value="85" max="100"></progress></p>
+        <h2>Section 3: Form</h2>
+        <p>Name: <input type="text" value="Alice"></p>
+        <p>Notes:</p>
+        <textarea>Quarterly review complete.</textarea>
+        <ul>
+            <li>Item one</li>
+            <li>Item two with <span class="highlight">highlight</span></li>
+        </ul>
+        <blockquote>A wise quote about testing.</blockquote>
+        <hr>
+        <p><a href="https://example.com">More details</a></p>
+    "#;
+    let pdf = ironpress::HtmlConverter::new()
+        .header("Confidential")
+        .footer("Page {page} of {pages}")
+        .convert(html)
+        .unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Annual Report"));
+    assert!(pdf_has_text(&pdf, "/Type /Outlines"));
+    assert!(pdf_has_text(&pdf, "Confidential"));
+    assert!(pdf_page_count(&pdf) >= 1);
+}


### PR DESCRIPTION
## Summary

### v1.1 — New HTML elements
- `<input>`, `<select>`, `<textarea>` — static visual rendering (borders, value/placeholder)
- `<video>`, `<audio>` — placeholder rectangles with play icon
- `<progress>`, `<meter>` — filled bar with color thresholds (meter: green/yellow/red based on low/high)

### v1.2 — Advanced CSS
- CSS Grid: `repeat()`, `minmax()`, `auto-fill`, `auto-fit`
- Multi-column layout: `column-count`, `columns`, `column-gap`

### v1.3 — PDF features
- Auto-generated PDF bookmarks/outlines from `<h1>`–`<h6>` headings
- Page headers and footers via `.header()` / `.footer()` builder methods (`{page}` / `{pages}` placeholders)
- Remote images and fonts via `remote` feature flag (opt-in, uses `ureq`, 10 MB limit)

### Bug fix
- Fixed vertical centering of text in table cells (was aligned to bottom)

### Testing
- +60 new unit tests (1640 total), 20 integration smoke tests
- Coverage: 97.6%
- fmt + clippy clean

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (1684 tests across 4 suites)
- [x] `cargo test --features remote`
- [x] Visual inspection of example PDFs (invoice, report, multipage)
- [x] Coverage ≥ 97%

🤖 Generated with [Claude Code](https://claude.com/claude-code)