### PR TITLE
feat: support CSS background-image with SVG data URIs

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -5,11 +5,11 @@ use crate::parser::dom::{DomNode, ElementNode, HtmlTag};
 use crate::parser::png;
 use crate::parser::ttf::TtfFont;
 use crate::style::computed::{
-    AlignItems, BorderCollapse, BorderSides, BoxShadow, BoxSizing, Clear, ComputedStyle,
-    ContentItem, Display, FlexDirection, FlexWrap, Float, FontFamily, FontStyle, FontWeight,
-    GridTrack, JustifyContent, LinearGradient, ListStylePosition, ListStyleType, Overflow,
-    Position, RadialGradient, TextAlign, TextOverflow, Transform, VerticalAlign, Visibility,
-    WhiteSpace, compute_style_with_context,
+    AlignItems, BackgroundPosition, BackgroundRepeat, BackgroundSize, BorderCollapse, BorderSides,
+    BoxShadow, BoxSizing, Clear, ComputedStyle, ContentItem, Display, FlexDirection, FlexWrap,
+    Float, FontFamily, FontStyle, FontWeight, GridTrack, JustifyContent, LinearGradient,
+    ListStylePosition, ListStyleType, Overflow, Position, RadialGradient, TextAlign, TextOverflow,
+    Transform, VerticalAlign, Visibility, WhiteSpace, compute_style_with_context,
 };
 use crate::types::{Margin, PageSize};
 use std::collections::HashMap;
@@ -366,6 +366,9 @@ pub enum LayoutElement {
         background_gradient: Option<LinearGradient>,
         background_radial_gradient: Option<RadialGradient>,
         background_svg: Option<crate::parser::svg::SvgTree>,
+        background_size: BackgroundSize,
+        background_position: BackgroundPosition,
+        background_repeat: BackgroundRepeat,
         z_index: i32,
         /// Heading level (1-6) if this block is an h1-h6, used for PDF bookmarks.
         heading_level: Option<u8>,
@@ -433,6 +436,9 @@ pub enum LayoutElement {
         background_gradient: Option<LinearGradient>,
         background_radial_gradient: Option<RadialGradient>,
         background_svg: Option<crate::parser::svg::SvgTree>,
+        background_size: BackgroundSize,
+        background_position: BackgroundPosition,
+        background_repeat: BackgroundRepeat,
     },
     /// A progress bar or meter element.
     ProgressBar {
@@ -543,6 +549,9 @@ pub fn layout_with_rules_and_fonts(
             background_gradient: parent_style.background_gradient.clone(),
             background_radial_gradient: parent_style.background_radial_gradient.clone(),
             background_svg: parent_style.background_svg.clone(),
+            background_size: parent_style.background_size,
+            background_position: parent_style.background_position,
+            background_repeat: parent_style.background_repeat,
             z_index: -1,
             heading_level: None,
         });
@@ -638,6 +647,9 @@ fn flatten_nodes(
                             background_gradient: None,
                             background_radial_gradient: None,
                             background_svg: None,
+                            background_size: BackgroundSize::Auto,
+                            background_position: BackgroundPosition::default(),
+                            background_repeat: BackgroundRepeat::Repeat,
                             z_index: 0,
                             heading_level: None,
                         });
@@ -772,6 +784,9 @@ fn flatten_element(
             background_gradient: None,
             background_radial_gradient: None,
             background_svg: None,
+            background_size: BackgroundSize::Auto,
+            background_position: BackgroundPosition::default(),
+            background_repeat: BackgroundRepeat::Repeat,
             z_index: 0,
             heading_level: None,
         });
@@ -918,6 +933,9 @@ fn flatten_element(
             background_gradient: style.background_gradient.clone(),
             background_radial_gradient: style.background_radial_gradient.clone(),
             background_svg: style.background_svg.clone(),
+            background_size: style.background_size,
+            background_position: style.background_position,
+            background_repeat: style.background_repeat,
             z_index: style.z_index,
             heading_level: None,
         });
@@ -1030,6 +1048,9 @@ fn flatten_element(
             background_gradient: style.background_gradient.clone(),
             background_radial_gradient: style.background_radial_gradient.clone(),
             background_svg: style.background_svg.clone(),
+            background_size: style.background_size,
+            background_position: style.background_position,
+            background_repeat: style.background_repeat,
             z_index: style.z_index,
             heading_level: None,
         });
@@ -1267,6 +1288,9 @@ fn flatten_element(
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
                 background_svg: style.background_svg.clone(),
+                background_size: style.background_size,
+                background_position: style.background_position,
+                background_repeat: style.background_repeat,
                 z_index: style.z_index,
                 heading_level: block_heading_level,
             });
@@ -1551,6 +1575,9 @@ fn flatten_element(
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
                 background_svg: style.background_svg.clone(),
+                background_size: style.background_size,
+                background_position: style.background_position,
+                background_repeat: style.background_repeat,
                 z_index: style.z_index,
                 heading_level: heading_level(el.tag),
             });
@@ -1649,6 +1676,9 @@ fn flatten_element(
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
                 background_svg: style.background_svg.clone(),
+                background_size: style.background_size,
+                background_position: style.background_position,
+                background_repeat: style.background_repeat,
                 z_index: style.z_index,
                 heading_level: None,
             });
@@ -1690,6 +1720,9 @@ fn flatten_element(
                 background_gradient: None,
                 background_radial_gradient: None,
                 background_svg: None,
+                background_size: BackgroundSize::Auto,
+                background_position: BackgroundPosition::default(),
+                background_repeat: BackgroundRepeat::Repeat,
                 z_index: 0,
                 heading_level: None,
             });
@@ -1746,6 +1779,9 @@ fn flatten_element(
                     background_gradient: None,
                     background_radial_gradient: None,
                     background_svg: None,
+                    background_size: BackgroundSize::Auto,
+                    background_position: BackgroundPosition::default(),
+                    background_repeat: BackgroundRepeat::Repeat,
                     z_index: 0,
                     heading_level: None,
                 });
@@ -1977,6 +2013,9 @@ fn flatten_flex_container(
             background_gradient: child_style.background_gradient.clone(),
             background_radial_gradient: child_style.background_radial_gradient.clone(),
             background_svg: style.background_svg.clone(),
+            background_size: style.background_size,
+            background_position: style.background_position,
+            background_repeat: style.background_repeat,
             z_index: child_style.z_index,
             heading_level: None,
         };
@@ -2150,6 +2189,9 @@ fn flatten_flex_container(
             background_gradient: style.background_gradient.clone(),
             background_radial_gradient: style.background_radial_gradient.clone(),
             background_svg: style.background_svg.clone(),
+            background_size: style.background_size,
+            background_position: style.background_position,
+            background_repeat: style.background_repeat,
             z_index: 0,
             heading_level: None,
         });
@@ -2187,6 +2229,9 @@ fn flatten_flex_container(
             background_gradient: None,
             background_radial_gradient: None,
             background_svg: None,
+            background_size: BackgroundSize::Auto,
+            background_position: BackgroundPosition::default(),
+            background_repeat: BackgroundRepeat::Repeat,
             z_index: 0,
             heading_level: None,
         });
@@ -2342,6 +2387,21 @@ fn flatten_flex_container(
                     } else {
                         None
                     },
+                    background_size: if cross_offset == 0.0 {
+                        style.background_size
+                    } else {
+                        BackgroundSize::Auto
+                    },
+                    background_position: if cross_offset == 0.0 {
+                        style.background_position
+                    } else {
+                        BackgroundPosition::default()
+                    },
+                    background_repeat: if cross_offset == 0.0 {
+                        style.background_repeat
+                    } else {
+                        BackgroundRepeat::Repeat
+                    },
                 });
             }
             FlexDirection::Column => {
@@ -2449,6 +2509,9 @@ fn flatten_flex_container(
                                 background_gradient: tb_grad.clone(),
                                 background_radial_gradient: tb_rgrad.clone(),
                                 background_svg: None,
+                                background_size: BackgroundSize::Auto,
+                                background_position: BackgroundPosition::default(),
+                                background_repeat: BackgroundRepeat::Repeat,
                                 z_index: 0,
                                 heading_level: None,
                             });
@@ -2503,6 +2566,9 @@ fn flatten_flex_container(
             background_gradient: None,
             background_radial_gradient: None,
             background_svg: None,
+            background_size: BackgroundSize::Auto,
+            background_position: BackgroundPosition::default(),
+            background_repeat: BackgroundRepeat::Repeat,
             z_index: 0,
             heading_level: None,
         });

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -249,7 +249,7 @@ enum ListContext {
 }
 
 /// A table cell ready for rendering.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct TableCell {
     pub lines: Vec<TextLine>,
@@ -329,7 +329,7 @@ pub struct PngMetadata {
 }
 
 /// A layout element ready for rendering.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum LayoutElement {
     /// A block of text lines with optional background.
@@ -2461,6 +2461,10 @@ fn flatten_flex_container(
                             vertical_align: tb_va,
                             background_gradient: tb_grad,
                             background_radial_gradient: tb_rgrad,
+                            background_svg: tb_bg_svg,
+                            background_size: tb_bg_size,
+                            background_position: tb_bg_pos,
+                            background_repeat: tb_bg_repeat,
                             ..
                         } = elem
                         {
@@ -2508,10 +2512,10 @@ fn flatten_flex_container(
                                 vertical_align: *tb_va,
                                 background_gradient: tb_grad.clone(),
                                 background_radial_gradient: tb_rgrad.clone(),
-                                background_svg: None,
-                                background_size: BackgroundSize::Auto,
-                                background_position: BackgroundPosition::default(),
-                                background_repeat: BackgroundRepeat::Repeat,
+                                background_svg: tb_bg_svg.clone(),
+                                background_size: *tb_bg_size,
+                                background_position: *tb_bg_pos,
+                                background_repeat: *tb_bg_repeat,
                                 z_index: 0,
                                 heading_level: None,
                             });
@@ -3793,6 +3797,10 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
     let mut right_floats: Vec<FloatRegion> = Vec::new();
     let mut prev_margin_bottom: f32 = 0.0;
 
+    // Collect absolute background elements (z_index < 0) so they can be
+    // duplicated onto every page during pagination.
+    let mut absolute_backgrounds: Vec<(f32, LayoutElement)> = Vec::new();
+
     for element in elements {
         // Extract float/clear/position info from TextBlock elements
         let (elem_float, elem_clear, elem_position, elem_offset_top) = match &element {
@@ -3838,6 +3846,10 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
                 pages.push(Page {
                     elements: std::mem::take(&mut current_elements),
                 });
+                // Duplicate root background onto the new page.
+                for bg in &absolute_backgrounds {
+                    current_elements.push(bg.clone());
+                }
                 y = 0.0;
                 prev_margin_bottom = 0.0;
                 left_floats.clear();
@@ -3948,6 +3960,15 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
         // Handle position: absolute -- place at fixed position, don't affect flow
         if elem_position == Position::Absolute {
             let abs_y = elem_offset_top;
+            // Track absolute background elements (z_index < 0) for duplication
+            // across all pages.
+            let is_bg = match &element {
+                LayoutElement::TextBlock { z_index, .. } => *z_index < 0,
+                _ => false,
+            };
+            if is_bg {
+                absolute_backgrounds.push((abs_y, element.clone()));
+            }
             current_elements.push((abs_y, element));
             continue;
         }
@@ -3956,6 +3977,10 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
             pages.push(Page {
                 elements: std::mem::take(&mut current_elements),
             });
+            // Duplicate root background onto the new page.
+            for bg in &absolute_backgrounds {
+                current_elements.push(bg.clone());
+            }
             y = 0.0;
             prev_margin_bottom = 0.0;
             left_floats.clear();

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -4101,8 +4101,12 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
     // with higher z_index are moved later so they render on top.
     for page in &mut pages {
         page.elements.sort_by_key(|(_, el)| match el {
-            LayoutElement::TextBlock { z_index, .. } => *z_index,
-            _ => 0,
+            LayoutElement::TextBlock {
+                repeat_on_each_page: true,
+                ..
+            } => (i32::MIN, 0),
+            LayoutElement::TextBlock { z_index, .. } => (0, *z_index),
+            _ => (0, 0),
         });
     }
 
@@ -6616,6 +6620,63 @@ mod tests {
                 z_indices[0] <= z_indices[1],
                 "Elements should be sorted by z_index"
             );
+        }
+    }
+
+    #[test]
+    fn synthetic_page_background_sorts_before_more_negative_layers() {
+        let make_block = |z_index, repeat_on_each_page| LayoutElement::TextBlock {
+            lines: Vec::new(),
+            margin_top: 0.0,
+            margin_bottom: 0.0,
+            text_align: TextAlign::Left,
+            background_color: None,
+            padding_top: 0.0,
+            padding_bottom: 0.0,
+            padding_left: 0.0,
+            padding_right: 0.0,
+            border: LayoutBorder::default(),
+            block_width: Some(100.0),
+            block_height: Some(40.0),
+            opacity: 1.0,
+            float: Float::None,
+            clear: Clear::None,
+            position: Position::Absolute,
+            offset_top: 0.0,
+            offset_left: 0.0,
+            box_shadow: None,
+            visible: true,
+            clip_rect: None,
+            transform: None,
+            border_radius: 0.0,
+            outline_width: 0.0,
+            outline_color: None,
+            text_indent: 0.0,
+            letter_spacing: 0.0,
+            word_spacing: 0.0,
+            vertical_align: VerticalAlign::Baseline,
+            background_gradient: None,
+            background_radial_gradient: None,
+            background_svg: None,
+            background_size: BackgroundSize::Auto,
+            background_position: BackgroundPosition::default(),
+            background_repeat: BackgroundRepeat::Repeat,
+            background_origin: BackgroundOrigin::PaddingBox,
+            z_index,
+            repeat_on_each_page,
+            heading_level: None,
+        };
+
+        let pages = paginate(
+            vec![make_block(-1, true), make_block(-2, false)],
+            200.0,
+        );
+
+        match &pages[0].elements[0].1 {
+            LayoutElement::TextBlock {
+                repeat_on_each_page, ..
+            } => assert!(*repeat_on_each_page, "synthetic background should render first"),
+            other => panic!("expected text block, got {other:?}"),
         }
     }
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -365,6 +365,7 @@ pub enum LayoutElement {
         vertical_align: VerticalAlign,
         background_gradient: Option<LinearGradient>,
         background_radial_gradient: Option<RadialGradient>,
+        background_svg: Option<crate::parser::svg::SvgTree>,
         z_index: i32,
         /// Heading level (1-6) if this block is an h1-h6, used for PDF bookmarks.
         heading_level: Option<u8>,
@@ -431,6 +432,7 @@ pub enum LayoutElement {
         box_shadow: Option<BoxShadow>,
         background_gradient: Option<LinearGradient>,
         background_radial_gradient: Option<RadialGradient>,
+        background_svg: Option<crate::parser::svg::SvgTree>,
     },
     /// A progress bar or meter element.
     ProgressBar {
@@ -501,6 +503,51 @@ pub fn layout_with_rules_and_fonts(
 
     // First, flatten DOM into layout elements
     let mut elements = Vec::new();
+
+    // If the body/html has a background SVG (or gradient/color), emit a full-content-area
+    // background block at the very start so it renders behind all content.
+    let has_body_bg = parent_style.background_svg.is_some()
+        || parent_style.background_gradient.is_some()
+        || parent_style.background_radial_gradient.is_some();
+    if has_body_bg {
+        elements.push(LayoutElement::TextBlock {
+            lines: vec![],
+            margin_top: 0.0,
+            margin_bottom: 0.0,
+            text_align: TextAlign::Left,
+            background_color: parent_style.background_color.map(|c| c.to_f32_rgb()),
+            padding_top: 0.0,
+            padding_bottom: 0.0,
+            padding_left: 0.0,
+            padding_right: 0.0,
+            border: LayoutBorder::default(),
+            block_width: Some(available_width),
+            block_height: Some(content_height),
+            opacity: 1.0,
+            float: Float::None,
+            clear: Clear::None,
+            position: Position::Absolute,
+            offset_top: 0.0,
+            offset_left: 0.0,
+            box_shadow: None,
+            visible: true,
+            clip_rect: None,
+            transform: None,
+            border_radius: 0.0,
+            outline_width: 0.0,
+            outline_color: None,
+            text_indent: 0.0,
+            letter_spacing: 0.0,
+            word_spacing: 0.0,
+            vertical_align: VerticalAlign::Baseline,
+            background_gradient: parent_style.background_gradient.clone(),
+            background_radial_gradient: parent_style.background_radial_gradient.clone(),
+            background_svg: parent_style.background_svg.clone(),
+            z_index: -1,
+            heading_level: None,
+        });
+    }
+
     let ancestors: Vec<AncestorInfo> = Vec::new();
     flatten_nodes(
         nodes,
@@ -590,6 +637,7 @@ fn flatten_nodes(
                             vertical_align: VerticalAlign::Baseline,
                             background_gradient: None,
                             background_radial_gradient: None,
+                            background_svg: None,
                             z_index: 0,
                             heading_level: None,
                         });
@@ -723,6 +771,7 @@ fn flatten_element(
             vertical_align: VerticalAlign::Baseline,
             background_gradient: None,
             background_radial_gradient: None,
+            background_svg: None,
             z_index: 0,
             heading_level: None,
         });
@@ -868,6 +917,7 @@ fn flatten_element(
             vertical_align: style.vertical_align,
             background_gradient: style.background_gradient.clone(),
             background_radial_gradient: style.background_radial_gradient.clone(),
+            background_svg: style.background_svg.clone(),
             z_index: style.z_index,
             heading_level: None,
         });
@@ -979,6 +1029,7 @@ fn flatten_element(
             vertical_align: style.vertical_align,
             background_gradient: style.background_gradient.clone(),
             background_radial_gradient: style.background_radial_gradient.clone(),
+            background_svg: style.background_svg.clone(),
             z_index: style.z_index,
             heading_level: None,
         });
@@ -1215,6 +1266,7 @@ fn flatten_element(
                 vertical_align: style.vertical_align,
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
+                background_svg: style.background_svg.clone(),
                 z_index: style.z_index,
                 heading_level: block_heading_level,
             });
@@ -1498,6 +1550,7 @@ fn flatten_element(
                 vertical_align: style.vertical_align,
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
+                background_svg: style.background_svg.clone(),
                 z_index: style.z_index,
                 heading_level: heading_level(el.tag),
             });
@@ -1595,6 +1648,7 @@ fn flatten_element(
                 vertical_align: VerticalAlign::Baseline,
                 background_gradient: style.background_gradient.clone(),
                 background_radial_gradient: style.background_radial_gradient.clone(),
+                background_svg: style.background_svg.clone(),
                 z_index: style.z_index,
                 heading_level: None,
             });
@@ -1635,6 +1689,7 @@ fn flatten_element(
                 vertical_align: VerticalAlign::Baseline,
                 background_gradient: None,
                 background_radial_gradient: None,
+                background_svg: None,
                 z_index: 0,
                 heading_level: None,
             });
@@ -1690,6 +1745,7 @@ fn flatten_element(
                     vertical_align: VerticalAlign::Baseline,
                     background_gradient: None,
                     background_radial_gradient: None,
+                    background_svg: None,
                     z_index: 0,
                     heading_level: None,
                 });
@@ -1920,6 +1976,7 @@ fn flatten_flex_container(
             vertical_align: child_style.vertical_align,
             background_gradient: child_style.background_gradient.clone(),
             background_radial_gradient: child_style.background_radial_gradient.clone(),
+            background_svg: style.background_svg.clone(),
             z_index: child_style.z_index,
             heading_level: None,
         };
@@ -2092,6 +2149,7 @@ fn flatten_flex_container(
             vertical_align: VerticalAlign::Baseline,
             background_gradient: style.background_gradient.clone(),
             background_radial_gradient: style.background_radial_gradient.clone(),
+            background_svg: style.background_svg.clone(),
             z_index: 0,
             heading_level: None,
         });
@@ -2128,6 +2186,7 @@ fn flatten_flex_container(
             vertical_align: VerticalAlign::Baseline,
             background_gradient: None,
             background_radial_gradient: None,
+            background_svg: None,
             z_index: 0,
             heading_level: None,
         });
@@ -2278,6 +2337,11 @@ fn flatten_flex_container(
                     } else {
                         None
                     },
+                    background_svg: if cross_offset == 0.0 {
+                        style.background_svg.clone()
+                    } else {
+                        None
+                    },
                 });
             }
             FlexDirection::Column => {
@@ -2384,6 +2448,7 @@ fn flatten_flex_container(
                                 vertical_align: *tb_va,
                                 background_gradient: tb_grad.clone(),
                                 background_radial_gradient: tb_rgrad.clone(),
+                                background_svg: None,
                                 z_index: 0,
                                 heading_level: None,
                             });
@@ -2437,6 +2502,7 @@ fn flatten_flex_container(
             vertical_align: VerticalAlign::Baseline,
             background_gradient: None,
             background_radial_gradient: None,
+            background_svg: None,
             z_index: 0,
             heading_level: None,
         });

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -13,6 +13,7 @@ use crate::style::computed::{
     compute_style_with_context,
 };
 use crate::types::{Margin, PageSize};
+use crate::util::decode_base64;
 use std::collections::HashMap;
 
 /// A single border side for layout rendering.
@@ -293,6 +294,50 @@ pub struct FlexCell {
     pub background_origin: BackgroundOrigin,
 }
 
+#[derive(Debug, Clone)]
+struct BackgroundFields {
+    gradient: Option<LinearGradient>,
+    radial_gradient: Option<RadialGradient>,
+    svg: Option<crate::parser::svg::SvgTree>,
+    size: BackgroundSize,
+    position: BackgroundPosition,
+    repeat: BackgroundRepeat,
+    origin: BackgroundOrigin,
+}
+
+impl BackgroundFields {
+    fn from_style(style: &ComputedStyle) -> Self {
+        Self {
+            gradient: style.background_gradient.clone(),
+            radial_gradient: style.background_radial_gradient.clone(),
+            svg: style.background_svg.clone(),
+            size: style.background_size,
+            position: style.background_position,
+            repeat: style.background_repeat,
+            origin: style.background_origin,
+        }
+    }
+
+    fn none() -> Self {
+        Self {
+            gradient: None,
+            radial_gradient: None,
+            svg: None,
+            size: BackgroundSize::Auto,
+            position: BackgroundPosition::default(),
+            repeat: BackgroundRepeat::Repeat,
+            origin: BackgroundOrigin::PaddingBox,
+        }
+    }
+}
+
+fn has_background_paint(style: &ComputedStyle) -> bool {
+    style.background_color.is_some()
+        || style.background_gradient.is_some()
+        || style.background_radial_gradient.is_some()
+        || style.background_svg.is_some()
+}
+
 /// A styled text run (a piece of text with uniform style).
 #[derive(Debug, Clone)]
 pub struct TextRun {
@@ -521,10 +566,17 @@ pub fn layout_with_rules_and_fonts(
 
     // If the body/html has a background SVG (or gradient/color), emit a full-content-area
     // background block at the very start so it renders behind all content.
-    let has_body_bg = parent_style.background_svg.is_some()
-        || parent_style.background_gradient.is_some()
-        || parent_style.background_radial_gradient.is_some();
+    let has_body_bg = has_background_paint(&parent_style);
     if has_body_bg {
+        let BackgroundFields {
+            gradient: background_gradient,
+            radial_gradient: background_radial_gradient,
+            svg: background_svg,
+            size: background_size,
+            position: background_position,
+            repeat: background_repeat,
+            origin: background_origin,
+        } = BackgroundFields::from_style(&parent_style);
         elements.push(LayoutElement::TextBlock {
             lines: vec![],
             margin_top: 0.0,
@@ -555,13 +607,13 @@ pub fn layout_with_rules_and_fonts(
             letter_spacing: 0.0,
             word_spacing: 0.0,
             vertical_align: VerticalAlign::Baseline,
-            background_gradient: parent_style.background_gradient.clone(),
-            background_radial_gradient: parent_style.background_radial_gradient.clone(),
-            background_svg: parent_style.background_svg.clone(),
-            background_size: parent_style.background_size,
-            background_position: parent_style.background_position,
-            background_repeat: parent_style.background_repeat,
-            background_origin: parent_style.background_origin,
+            background_gradient,
+            background_radial_gradient,
+            background_svg,
+            background_size,
+            background_position,
+            background_repeat,
+            background_origin,
             z_index: -1,
             repeat_on_each_page: true,
             heading_level: None,
@@ -747,6 +799,15 @@ fn flatten_element(
     }
 
     if el.tag == HtmlTag::Br {
+        let BackgroundFields {
+            gradient: background_gradient,
+            radial_gradient: background_radial_gradient,
+            svg: background_svg,
+            size: background_size,
+            position: background_position,
+            repeat: background_repeat,
+            origin: background_origin,
+        } = BackgroundFields::none();
         let line = TextLine {
             runs: vec![TextRun {
                 text: String::new(),
@@ -794,13 +855,13 @@ fn flatten_element(
             letter_spacing: 0.0,
             word_spacing: 0.0,
             vertical_align: VerticalAlign::Baseline,
-            background_gradient: None,
-            background_radial_gradient: None,
-            background_svg: None,
-            background_size: BackgroundSize::Auto,
-            background_position: BackgroundPosition::default(),
-            background_repeat: BackgroundRepeat::Repeat,
-            background_origin: BackgroundOrigin::PaddingBox,
+            background_gradient,
+            background_radial_gradient,
+            background_svg,
+            background_size,
+            background_position,
+            background_repeat,
+            background_origin,
             z_index: 0,
             repeat_on_each_page: false,
             heading_level: None,
@@ -914,6 +975,15 @@ fn flatten_element(
             .background_color
             .map(|c| c.to_f32_rgb())
             .unwrap_or((1.0, 1.0, 1.0));
+        let BackgroundFields {
+            gradient: background_gradient,
+            radial_gradient: background_radial_gradient,
+            svg: background_svg,
+            size: background_size,
+            position: background_position,
+            repeat: background_repeat,
+            origin: background_origin,
+        } = BackgroundFields::from_style(&style);
 
         output.push(LayoutElement::TextBlock {
             lines,
@@ -945,13 +1015,13 @@ fn flatten_element(
             letter_spacing: style.letter_spacing,
             word_spacing: style.word_spacing,
             vertical_align: style.vertical_align,
-            background_gradient: style.background_gradient.clone(),
-            background_radial_gradient: style.background_radial_gradient.clone(),
-            background_svg: style.background_svg.clone(),
-            background_size: style.background_size,
-            background_position: style.background_position,
-            background_repeat: style.background_repeat,
-            background_origin: style.background_origin,
+            background_gradient,
+            background_radial_gradient,
+            background_svg,
+            background_size,
+            background_position,
+            background_repeat,
+            background_origin,
             z_index: style.z_index,
             repeat_on_each_page: false,
             heading_level: None,
@@ -1007,6 +1077,15 @@ fn flatten_element(
         } else {
             (0.3, 0.3, 0.3)
         };
+        let BackgroundFields {
+            gradient: background_gradient,
+            radial_gradient: background_radial_gradient,
+            svg: background_svg,
+            size: background_size,
+            position: background_position,
+            repeat: background_repeat,
+            origin: background_origin,
+        } = BackgroundFields::from_style(&style);
 
         let runs = vec![TextRun {
             text: label,
@@ -1062,13 +1141,13 @@ fn flatten_element(
             letter_spacing: style.letter_spacing,
             word_spacing: style.word_spacing,
             vertical_align: style.vertical_align,
-            background_gradient: style.background_gradient.clone(),
-            background_radial_gradient: style.background_radial_gradient.clone(),
-            background_svg: style.background_svg.clone(),
-            background_size: style.background_size,
-            background_position: style.background_position,
-            background_repeat: style.background_repeat,
-            background_origin: style.background_origin,
+            background_gradient,
+            background_radial_gradient,
+            background_svg,
+            background_size,
+            background_position,
+            background_repeat,
+            background_origin,
             z_index: style.z_index,
             repeat_on_each_page: false,
             heading_level: None,
@@ -1274,6 +1353,15 @@ fn flatten_element(
 
         if !runs.is_empty() {
             let lines = wrap_text_runs(runs, inner_width, style.font_size, fonts);
+            let BackgroundFields {
+                gradient: background_gradient,
+                radial_gradient: background_radial_gradient,
+                svg: background_svg,
+                size: background_size,
+                position: background_position,
+                repeat: background_repeat,
+                origin: background_origin,
+            } = BackgroundFields::from_style(&style);
             output.push(LayoutElement::TextBlock {
                 lines,
                 margin_top: style.margin.top,
@@ -1304,13 +1392,13 @@ fn flatten_element(
                 letter_spacing: style.letter_spacing,
                 word_spacing: style.word_spacing,
                 vertical_align: style.vertical_align,
-                background_gradient: style.background_gradient.clone(),
-                background_radial_gradient: style.background_radial_gradient.clone(),
-                background_svg: style.background_svg.clone(),
-                background_size: style.background_size,
-                background_position: style.background_position,
-                background_repeat: style.background_repeat,
-                background_origin: style.background_origin,
+                background_gradient,
+                background_radial_gradient,
+                background_svg,
+                background_size,
+                background_position,
+                background_repeat,
+                background_origin,
                 z_index: style.z_index,
                 repeat_on_each_page: false,
                 heading_level: block_heading_level,
@@ -1562,6 +1650,15 @@ fn flatten_element(
             } else {
                 None
             };
+            let BackgroundFields {
+                gradient: background_gradient,
+                radial_gradient: background_radial_gradient,
+                svg: background_svg,
+                size: background_size,
+                position: background_position,
+                repeat: background_repeat,
+                origin: background_origin,
+            } = BackgroundFields::from_style(&style);
 
             output.push(LayoutElement::TextBlock {
                 lines,
@@ -1593,13 +1690,13 @@ fn flatten_element(
                 letter_spacing: style.letter_spacing,
                 word_spacing: style.word_spacing,
                 vertical_align: style.vertical_align,
-                background_gradient: style.background_gradient.clone(),
-                background_radial_gradient: style.background_radial_gradient.clone(),
-                background_svg: style.background_svg.clone(),
-                background_size: style.background_size,
-                background_position: style.background_position,
-                background_repeat: style.background_repeat,
-                background_origin: style.background_origin,
+                background_gradient,
+                background_radial_gradient,
+                background_svg,
+                background_size,
+                background_position,
+                background_repeat,
+                background_origin,
                 z_index: style.z_index,
                 repeat_on_each_page: false,
                 heading_level: heading_level(el.tag),
@@ -1619,9 +1716,7 @@ fn flatten_element(
         // are rendered.  Children are then pulled back inside via a negative-margin
         // spacer (same technique as flex column containers).
         // NB: check before runs is moved into wrap_text_runs above.
-        let has_visual = style.background_color.is_some()
-            || style.background_gradient.is_some()
-            || style.background_radial_gradient.is_some()
+        let has_visual = has_background_paint(&style)
             || style.border.has_any()
             || style.border_radius > 0.0
             || style.box_shadow.is_some();
@@ -2170,19 +2265,28 @@ fn flatten_flex_container(
         Some(h) => container_h.max(h),
         None => container_h,
     };
-
     let bg = style
         .background_color
-        .map(|c: crate::types::Color| c.to_f32_rgb());
+        .map(|color: crate::types::Color| color.to_f32_rgb());
+
     // For column direction, emit container background separately
     let emitted_column_bg = direction == FlexDirection::Column
-        && (bg.is_some() || style.border.has_any() || style.box_shadow.is_some());
+        && (has_background_paint(&style) || style.border.has_any() || style.box_shadow.is_some());
     if emitted_column_bg {
         // Emit the container background/border as a visual element.
         // It advances y by its full height in paginate.  We then emit a
         // negative-margin spacer to pull y back so children flow *inside*
         // the background rather than after it.
         let bg_flow_height = container_h + style.border.vertical_width();
+        let BackgroundFields {
+            gradient: background_gradient,
+            radial_gradient: background_radial_gradient,
+            svg: background_svg,
+            size: background_size,
+            position: background_position,
+            repeat: background_repeat,
+            origin: background_origin,
+        } = BackgroundFields::from_style(&style);
         output.push(LayoutElement::TextBlock {
             lines: Vec::new(),
             margin_top: style.margin.top,
@@ -2217,18 +2321,27 @@ fn flatten_flex_container(
             letter_spacing: 0.0,
             word_spacing: 0.0,
             vertical_align: VerticalAlign::Baseline,
-            background_gradient: style.background_gradient.clone(),
-            background_radial_gradient: style.background_radial_gradient.clone(),
-            background_svg: style.background_svg.clone(),
-            background_size: style.background_size,
-            background_position: style.background_position,
-            background_repeat: style.background_repeat,
-            background_origin: style.background_origin,
+            background_gradient,
+            background_radial_gradient,
+            background_svg,
+            background_size,
+            background_position,
+            background_repeat,
+            background_origin,
             z_index: 0,
             repeat_on_each_page: false,
             heading_level: None,
         });
         // Pull y back so children flow inside the container background
+        let BackgroundFields {
+            gradient: background_gradient,
+            radial_gradient: background_radial_gradient,
+            svg: background_svg,
+            size: background_size,
+            position: background_position,
+            repeat: background_repeat,
+            origin: background_origin,
+        } = BackgroundFields::none();
         output.push(LayoutElement::TextBlock {
             lines: Vec::new(),
             margin_top: -bg_flow_height,
@@ -2259,13 +2372,13 @@ fn flatten_flex_container(
             letter_spacing: 0.0,
             word_spacing: 0.0,
             vertical_align: VerticalAlign::Baseline,
-            background_gradient: None,
-            background_radial_gradient: None,
-            background_svg: None,
-            background_size: BackgroundSize::Auto,
-            background_position: BackgroundPosition::default(),
-            background_repeat: BackgroundRepeat::Repeat,
-            background_origin: BackgroundOrigin::PaddingBox,
+            background_gradient,
+            background_radial_gradient,
+            background_svg,
+            background_size,
+            background_position,
+            background_repeat,
+            background_origin,
             z_index: 0,
             repeat_on_each_page: false,
             heading_level: None,
@@ -4200,7 +4313,7 @@ fn load_image_data(src: &str) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadat
         // Parse data URI: data:[<mediatype>][;base64],<data>
         let (_header, encoded) = rest.split_once(',')?;
         // Only support base64 for now
-        base64_decode(encoded)?
+        decode_base64(encoded)?
     } else if src.starts_with("http://") || src.starts_with("https://") {
         fetch_remote_url(src)?
     } else {
@@ -4223,50 +4336,6 @@ fn load_image_data(src: &str) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadat
     } else {
         None
     }
-}
-
-/// Simple base64 decoder (no external dependencies).
-fn base64_decode(input: &str) -> Option<Vec<u8>> {
-    let table = |c: u8| -> Option<u8> {
-        match c {
-            b'A'..=b'Z' => Some(c - b'A'),
-            b'a'..=b'z' => Some(c - b'a' + 26),
-            b'0'..=b'9' => Some(c - b'0' + 52),
-            b'+' => Some(62),
-            b'/' => Some(63),
-            _ => None,
-        }
-    };
-
-    // Strip whitespace
-    let bytes: Vec<u8> = input.bytes().filter(|b| !b.is_ascii_whitespace()).collect();
-    let mut result = Vec::with_capacity(bytes.len() * 3 / 4);
-    let mut i = 0;
-
-    while i < bytes.len() {
-        let remaining = bytes.len() - i;
-        if remaining < 2 {
-            break;
-        }
-
-        let a = table(bytes[i])?;
-        let b = table(bytes[i + 1])?;
-        result.push((a << 2) | (b >> 4));
-
-        if i + 2 < bytes.len() && bytes[i + 2] != b'=' {
-            let c = table(bytes[i + 2])?;
-            result.push((b << 4) | (c >> 2));
-
-            if i + 3 < bytes.len() && bytes[i + 3] != b'=' {
-                let d = table(bytes[i + 3])?;
-                result.push((c << 6) | d);
-            }
-        }
-
-        i += 4;
-    }
-
-    Some(result)
 }
 
 fn collapse_whitespace(text: &str) -> String {
@@ -4683,13 +4752,13 @@ mod tests {
     #[test]
     fn base64_decode_basic() {
         // "Hello" in base64 is "SGVsbG8="
-        let decoded = super::base64_decode("SGVsbG8=").unwrap();
+        let decoded = decode_base64("SGVsbG8=").unwrap();
         assert_eq!(decoded, b"Hello");
     }
 
     #[test]
     fn base64_decode_with_whitespace() {
-        let decoded = super::base64_decode("SGVs\nbG8=").unwrap();
+        let decoded = decode_base64("SGVs\nbG8=").unwrap();
         assert_eq!(decoded, b"Hello");
     }
 
@@ -4810,7 +4879,7 @@ mod tests {
     fn base64_decode_roundtrip() {
         let data = &[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
         let encoded = simple_base64_encode(data);
-        let decoded = base64_decode(&encoded).unwrap();
+        let decoded = decode_base64(&encoded).unwrap();
         assert_eq!(decoded, data);
     }
 
@@ -6667,15 +6736,16 @@ mod tests {
             heading_level: None,
         };
 
-        let pages = paginate(
-            vec![make_block(-1, true), make_block(-2, false)],
-            200.0,
-        );
+        let pages = paginate(vec![make_block(-1, true), make_block(-2, false)], 200.0);
 
         match &pages[0].elements[0].1 {
             LayoutElement::TextBlock {
-                repeat_on_each_page, ..
-            } => assert!(*repeat_on_each_page, "synthetic background should render first"),
+                repeat_on_each_page,
+                ..
+            } => assert!(
+                *repeat_on_each_page,
+                "synthetic background should render first"
+            ),
             other => panic!("expected text block, got {other:?}"),
         }
     }
@@ -7169,21 +7239,21 @@ mod tests {
     #[test]
     fn base64_decode_valid() {
         // Covers lines 2562,2574: base64 decode
-        let decoded = base64_decode("SGVsbG8=").unwrap();
+        let decoded = decode_base64("SGVsbG8=").unwrap();
         assert_eq!(&decoded, b"Hello");
     }
 
     #[test]
     fn base64_decode_invalid_char() {
         // Covers line 2562: base64 decode with invalid char
-        let result = base64_decode("!!!!");
+        let result = decode_base64("!!!!");
         assert!(result.is_none());
     }
 
     #[test]
     fn base64_decode_short_input() {
         // Covers line 2574: base64 decode with very short input (breaks early)
-        let result = base64_decode("A");
+        let result = decode_base64("A");
         assert!(result.is_some());
         assert!(result.unwrap().is_empty());
     }
@@ -7444,8 +7514,7 @@ mod tests {
 
     #[test]
     fn flex_row_child_preserves_svg_background() {
-        let child_style =
-            r#"background-image: url(data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='%23f00'/%3E%3C/svg%3E); width: 60pt;"#;
+        let child_style = r#"background-image: url(data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='%23f00'/%3E%3C/svg%3E); width: 60pt;"#;
         let parsed = crate::parser::css::parse_inline_style(child_style);
         assert!(
             parsed.get("background-svg").is_some(),
@@ -7460,9 +7529,8 @@ mod tests {
             computed.background_svg.is_some(),
             "expected computed style to retain SVG background"
         );
-        let html = format!(
-            r#"<div style="display: flex;"><div style="{child_style}">A</div></div>"#
-        );
+        let html =
+            format!(r#"<div style="display: flex;"><div style="{child_style}">A</div></div>"#);
         let pages = layout(&parse_html(&html).unwrap(), PageSize::A4, Margin::default());
         let has_cell_svg_background = pages.iter().any(|page| {
             page.elements.iter().any(|(_, el)| match el {

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -286,6 +286,11 @@ pub struct FlexCell {
     pub border_radius: f32,
     pub background_gradient: Option<LinearGradient>,
     pub background_radial_gradient: Option<RadialGradient>,
+    pub background_svg: Option<crate::parser::svg::SvgTree>,
+    pub background_size: BackgroundSize,
+    pub background_position: BackgroundPosition,
+    pub background_repeat: BackgroundRepeat,
+    pub background_origin: BackgroundOrigin,
 }
 
 /// A styled text run (a piece of text with uniform style).
@@ -2036,11 +2041,11 @@ fn flatten_flex_container(
             vertical_align: child_style.vertical_align,
             background_gradient: child_style.background_gradient.clone(),
             background_radial_gradient: child_style.background_radial_gradient.clone(),
-            background_svg: style.background_svg.clone(),
-            background_size: style.background_size,
-            background_position: style.background_position,
-            background_repeat: style.background_repeat,
-            background_origin: style.background_origin,
+            background_svg: child_style.background_svg.clone(),
+            background_size: child_style.background_size,
+            background_position: child_style.background_position,
+            background_repeat: child_style.background_repeat,
+            background_origin: child_style.background_origin,
             z_index: child_style.z_index,
             repeat_on_each_page: false,
             heading_level: None,
@@ -2358,6 +2363,11 @@ fn flatten_flex_container(
                         border_radius: tb_br,
                         background_gradient: tb_grad,
                         background_radial_gradient: tb_rgrad,
+                        background_svg: tb_bg_svg,
+                        background_size: tb_bg_size,
+                        background_position: tb_bg_pos,
+                        background_repeat: tb_bg_repeat,
+                        background_origin: tb_bg_origin,
                         ..
                     }) = item.elements.first()
                     {
@@ -2374,6 +2384,11 @@ fn flatten_flex_container(
                             border_radius: *tb_br,
                             background_gradient: tb_grad.clone(),
                             background_radial_gradient: tb_rgrad.clone(),
+                            background_svg: tb_bg_svg.clone(),
+                            background_size: *tb_bg_size,
+                            background_position: *tb_bg_pos,
+                            background_repeat: *tb_bg_repeat,
+                            background_origin: *tb_bg_origin,
                         });
                     }
 
@@ -7363,6 +7378,42 @@ mod tests {
         assert!(
             found_bg,
             "PAID badge text run should have background_color set"
+        );
+    }
+
+    #[test]
+    fn flex_row_child_preserves_svg_background() {
+        let child_style =
+            r#"background-image: url(data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='%23f00'/%3E%3C/svg%3E); width: 60pt;"#;
+        let parsed = crate::parser::css::parse_inline_style(child_style);
+        assert!(
+            parsed.get("background-svg").is_some(),
+            "expected inline style parser to capture SVG background"
+        );
+        let computed = crate::style::computed::compute_style(
+            HtmlTag::Div,
+            Some(child_style),
+            &ComputedStyle::default(),
+        );
+        assert!(
+            computed.background_svg.is_some(),
+            "expected computed style to retain SVG background"
+        );
+        let html = format!(
+            r#"<div style="display: flex;"><div style="{child_style}">A</div></div>"#
+        );
+        let pages = layout(&parse_html(&html).unwrap(), PageSize::A4, Margin::default());
+        let has_cell_svg_background = pages.iter().any(|page| {
+            page.elements.iter().any(|(_, el)| match el {
+                LayoutElement::FlexRow { cells, .. } => {
+                    cells.iter().any(|cell| cell.background_svg.is_some())
+                }
+                _ => false,
+            })
+        });
+        assert!(
+            has_cell_svg_background,
+            "expected flex row cell to retain SVG background data"
         );
     }
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -5,11 +5,12 @@ use crate::parser::dom::{DomNode, ElementNode, HtmlTag};
 use crate::parser::png;
 use crate::parser::ttf::TtfFont;
 use crate::style::computed::{
-    AlignItems, BackgroundPosition, BackgroundRepeat, BackgroundSize, BorderCollapse, BorderSides,
-    BoxShadow, BoxSizing, Clear, ComputedStyle, ContentItem, Display, FlexDirection, FlexWrap,
-    Float, FontFamily, FontStyle, FontWeight, GridTrack, JustifyContent, LinearGradient,
-    ListStylePosition, ListStyleType, Overflow, Position, RadialGradient, TextAlign, TextOverflow,
-    Transform, VerticalAlign, Visibility, WhiteSpace, compute_style_with_context,
+    AlignItems, BackgroundOrigin, BackgroundPosition, BackgroundRepeat, BackgroundSize,
+    BorderCollapse, BorderSides, BoxShadow, BoxSizing, Clear, ComputedStyle, ContentItem, Display,
+    FlexDirection, FlexWrap, Float, FontFamily, FontStyle, FontWeight, GridTrack, JustifyContent,
+    LinearGradient, ListStylePosition, ListStyleType, Overflow, Position, RadialGradient,
+    TextAlign, TextOverflow, Transform, VerticalAlign, Visibility, WhiteSpace,
+    compute_style_with_context,
 };
 use crate::types::{Margin, PageSize};
 use std::collections::HashMap;
@@ -369,6 +370,7 @@ pub enum LayoutElement {
         background_size: BackgroundSize,
         background_position: BackgroundPosition,
         background_repeat: BackgroundRepeat,
+        background_origin: BackgroundOrigin,
         z_index: i32,
         /// Heading level (1-6) if this block is an h1-h6, used for PDF bookmarks.
         heading_level: Option<u8>,
@@ -439,6 +441,7 @@ pub enum LayoutElement {
         background_size: BackgroundSize,
         background_position: BackgroundPosition,
         background_repeat: BackgroundRepeat,
+        background_origin: BackgroundOrigin,
     },
     /// A progress bar or meter element.
     ProgressBar {
@@ -552,6 +555,7 @@ pub fn layout_with_rules_and_fonts(
             background_size: parent_style.background_size,
             background_position: parent_style.background_position,
             background_repeat: parent_style.background_repeat,
+            background_origin: parent_style.background_origin,
             z_index: -1,
             heading_level: None,
         });
@@ -650,6 +654,7 @@ fn flatten_nodes(
                             background_size: BackgroundSize::Auto,
                             background_position: BackgroundPosition::default(),
                             background_repeat: BackgroundRepeat::Repeat,
+                            background_origin: BackgroundOrigin::PaddingBox,
                             z_index: 0,
                             heading_level: None,
                         });
@@ -787,6 +792,7 @@ fn flatten_element(
             background_size: BackgroundSize::Auto,
             background_position: BackgroundPosition::default(),
             background_repeat: BackgroundRepeat::Repeat,
+            background_origin: BackgroundOrigin::PaddingBox,
             z_index: 0,
             heading_level: None,
         });
@@ -936,6 +942,7 @@ fn flatten_element(
             background_size: style.background_size,
             background_position: style.background_position,
             background_repeat: style.background_repeat,
+            background_origin: style.background_origin,
             z_index: style.z_index,
             heading_level: None,
         });
@@ -1051,6 +1058,7 @@ fn flatten_element(
             background_size: style.background_size,
             background_position: style.background_position,
             background_repeat: style.background_repeat,
+            background_origin: style.background_origin,
             z_index: style.z_index,
             heading_level: None,
         });
@@ -1291,6 +1299,7 @@ fn flatten_element(
                 background_size: style.background_size,
                 background_position: style.background_position,
                 background_repeat: style.background_repeat,
+                background_origin: style.background_origin,
                 z_index: style.z_index,
                 heading_level: block_heading_level,
             });
@@ -1578,6 +1587,7 @@ fn flatten_element(
                 background_size: style.background_size,
                 background_position: style.background_position,
                 background_repeat: style.background_repeat,
+                background_origin: style.background_origin,
                 z_index: style.z_index,
                 heading_level: heading_level(el.tag),
             });
@@ -1679,6 +1689,7 @@ fn flatten_element(
                 background_size: style.background_size,
                 background_position: style.background_position,
                 background_repeat: style.background_repeat,
+                background_origin: style.background_origin,
                 z_index: style.z_index,
                 heading_level: None,
             });
@@ -1723,6 +1734,7 @@ fn flatten_element(
                 background_size: BackgroundSize::Auto,
                 background_position: BackgroundPosition::default(),
                 background_repeat: BackgroundRepeat::Repeat,
+                background_origin: BackgroundOrigin::PaddingBox,
                 z_index: 0,
                 heading_level: None,
             });
@@ -1782,6 +1794,7 @@ fn flatten_element(
                     background_size: BackgroundSize::Auto,
                     background_position: BackgroundPosition::default(),
                     background_repeat: BackgroundRepeat::Repeat,
+                    background_origin: BackgroundOrigin::PaddingBox,
                     z_index: 0,
                     heading_level: None,
                 });
@@ -2016,6 +2029,7 @@ fn flatten_flex_container(
             background_size: style.background_size,
             background_position: style.background_position,
             background_repeat: style.background_repeat,
+            background_origin: style.background_origin,
             z_index: child_style.z_index,
             heading_level: None,
         };
@@ -2192,6 +2206,7 @@ fn flatten_flex_container(
             background_size: style.background_size,
             background_position: style.background_position,
             background_repeat: style.background_repeat,
+            background_origin: style.background_origin,
             z_index: 0,
             heading_level: None,
         });
@@ -2232,6 +2247,7 @@ fn flatten_flex_container(
             background_size: BackgroundSize::Auto,
             background_position: BackgroundPosition::default(),
             background_repeat: BackgroundRepeat::Repeat,
+            background_origin: BackgroundOrigin::PaddingBox,
             z_index: 0,
             heading_level: None,
         });
@@ -2402,6 +2418,11 @@ fn flatten_flex_container(
                     } else {
                         BackgroundRepeat::Repeat
                     },
+                    background_origin: if cross_offset == 0.0 {
+                        style.background_origin
+                    } else {
+                        BackgroundOrigin::PaddingBox
+                    },
                 });
             }
             FlexDirection::Column => {
@@ -2465,6 +2486,7 @@ fn flatten_flex_container(
                             background_size: tb_bg_size,
                             background_position: tb_bg_pos,
                             background_repeat: tb_bg_repeat,
+                            background_origin: tb_bg_origin,
                             ..
                         } = elem
                         {
@@ -2516,6 +2538,7 @@ fn flatten_flex_container(
                                 background_size: *tb_bg_size,
                                 background_position: *tb_bg_pos,
                                 background_repeat: *tb_bg_repeat,
+                                background_origin: *tb_bg_origin,
                                 z_index: 0,
                                 heading_level: None,
                             });
@@ -2573,6 +2596,7 @@ fn flatten_flex_container(
             background_size: BackgroundSize::Auto,
             background_position: BackgroundPosition::default(),
             background_repeat: BackgroundRepeat::Repeat,
+            background_origin: BackgroundOrigin::PaddingBox,
             z_index: 0,
             heading_level: None,
         });

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -372,6 +372,7 @@ pub enum LayoutElement {
         background_repeat: BackgroundRepeat,
         background_origin: BackgroundOrigin,
         z_index: i32,
+        repeat_on_each_page: bool,
         /// Heading level (1-6) if this block is an h1-h6, used for PDF bookmarks.
         heading_level: Option<u8>,
     },
@@ -557,6 +558,7 @@ pub fn layout_with_rules_and_fonts(
             background_repeat: parent_style.background_repeat,
             background_origin: parent_style.background_origin,
             z_index: -1,
+            repeat_on_each_page: true,
             heading_level: None,
         });
     }
@@ -656,6 +658,7 @@ fn flatten_nodes(
                             background_repeat: BackgroundRepeat::Repeat,
                             background_origin: BackgroundOrigin::PaddingBox,
                             z_index: 0,
+                            repeat_on_each_page: false,
                             heading_level: None,
                         });
                     }
@@ -794,6 +797,7 @@ fn flatten_element(
             background_repeat: BackgroundRepeat::Repeat,
             background_origin: BackgroundOrigin::PaddingBox,
             z_index: 0,
+            repeat_on_each_page: false,
             heading_level: None,
         });
         return;
@@ -944,6 +948,7 @@ fn flatten_element(
             background_repeat: style.background_repeat,
             background_origin: style.background_origin,
             z_index: style.z_index,
+            repeat_on_each_page: false,
             heading_level: None,
         });
         return;
@@ -1060,6 +1065,7 @@ fn flatten_element(
             background_repeat: style.background_repeat,
             background_origin: style.background_origin,
             z_index: style.z_index,
+            repeat_on_each_page: false,
             heading_level: None,
         });
         return;
@@ -1301,6 +1307,7 @@ fn flatten_element(
                 background_repeat: style.background_repeat,
                 background_origin: style.background_origin,
                 z_index: style.z_index,
+                repeat_on_each_page: false,
                 heading_level: block_heading_level,
             });
         }
@@ -1589,6 +1596,7 @@ fn flatten_element(
                 background_repeat: style.background_repeat,
                 background_origin: style.background_origin,
                 z_index: style.z_index,
+                repeat_on_each_page: false,
                 heading_level: heading_level(el.tag),
             });
         }
@@ -1691,6 +1699,7 @@ fn flatten_element(
                 background_repeat: style.background_repeat,
                 background_origin: style.background_origin,
                 z_index: style.z_index,
+                repeat_on_each_page: false,
                 heading_level: None,
             });
             // Pull y back so children flow inside the wrapper, starting
@@ -1736,6 +1745,7 @@ fn flatten_element(
                 background_repeat: BackgroundRepeat::Repeat,
                 background_origin: BackgroundOrigin::PaddingBox,
                 z_index: 0,
+                repeat_on_each_page: false,
                 heading_level: None,
             });
             // Add the parent's left/right padding to children so they render
@@ -1796,6 +1806,7 @@ fn flatten_element(
                     background_repeat: BackgroundRepeat::Repeat,
                     background_origin: BackgroundOrigin::PaddingBox,
                     z_index: 0,
+                    repeat_on_each_page: false,
                     heading_level: None,
                 });
             }
@@ -2031,6 +2042,7 @@ fn flatten_flex_container(
             background_repeat: style.background_repeat,
             background_origin: style.background_origin,
             z_index: child_style.z_index,
+            repeat_on_each_page: false,
             heading_level: None,
         };
 
@@ -2208,6 +2220,7 @@ fn flatten_flex_container(
             background_repeat: style.background_repeat,
             background_origin: style.background_origin,
             z_index: 0,
+            repeat_on_each_page: false,
             heading_level: None,
         });
         // Pull y back so children flow inside the container background
@@ -2249,6 +2262,7 @@ fn flatten_flex_container(
             background_repeat: BackgroundRepeat::Repeat,
             background_origin: BackgroundOrigin::PaddingBox,
             z_index: 0,
+            repeat_on_each_page: false,
             heading_level: None,
         });
     }
@@ -2540,6 +2554,7 @@ fn flatten_flex_container(
                                 background_repeat: *tb_bg_repeat,
                                 background_origin: *tb_bg_origin,
                                 z_index: 0,
+                                repeat_on_each_page: false,
                                 heading_level: None,
                             });
                         }
@@ -2598,6 +2613,7 @@ fn flatten_flex_container(
             background_repeat: BackgroundRepeat::Repeat,
             background_origin: BackgroundOrigin::PaddingBox,
             z_index: 0,
+            repeat_on_each_page: false,
             heading_level: None,
         });
     }
@@ -3821,8 +3837,8 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
     let mut right_floats: Vec<FloatRegion> = Vec::new();
     let mut prev_margin_bottom: f32 = 0.0;
 
-    // Collect absolute background elements (z_index < 0) so they can be
-    // duplicated onto every page during pagination.
+    // Collect synthetic full-page background elements that should be repeated
+    // across every page during pagination.
     let mut absolute_backgrounds: Vec<(f32, LayoutElement)> = Vec::new();
 
     for element in elements {
@@ -3984,13 +4000,14 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
         // Handle position: absolute -- place at fixed position, don't affect flow
         if elem_position == Position::Absolute {
             let abs_y = elem_offset_top;
-            // Track absolute background elements (z_index < 0) for duplication
-            // across all pages.
-            let is_bg = match &element {
-                LayoutElement::TextBlock { z_index, .. } => *z_index < 0,
+            let repeats_on_each_page = match &element {
+                LayoutElement::TextBlock {
+                    repeat_on_each_page,
+                    ..
+                } => *repeat_on_each_page,
                 _ => false,
             };
-            if is_bg {
+            if repeats_on_each_page {
                 absolute_backgrounds.push((abs_y, element.clone()));
             }
             current_elements.push((abs_y, element));
@@ -6462,6 +6479,102 @@ mod tests {
             .iter()
             .any(|(_, el)| matches!(el, LayoutElement::TextBlock { z_index: 5, .. }));
         assert!(found, "Expected element with z_index=5");
+    }
+
+    #[test]
+    fn paginate_repeats_only_synthetic_page_background() {
+        let make_block =
+            |position, z_index, repeat_on_each_page, height| LayoutElement::TextBlock {
+                lines: Vec::new(),
+                margin_top: 0.0,
+                margin_bottom: 0.0,
+                text_align: TextAlign::Left,
+                background_color: None,
+                padding_top: 0.0,
+                padding_bottom: 0.0,
+                padding_left: 0.0,
+                padding_right: 0.0,
+                border: LayoutBorder::default(),
+                block_width: Some(100.0),
+                block_height: Some(height),
+                opacity: 1.0,
+                float: Float::None,
+                clear: Clear::None,
+                position,
+                offset_top: 0.0,
+                offset_left: 0.0,
+                box_shadow: None,
+                visible: true,
+                clip_rect: None,
+                transform: None,
+                border_radius: 0.0,
+                outline_width: 0.0,
+                outline_color: None,
+                text_indent: 0.0,
+                letter_spacing: 0.0,
+                word_spacing: 0.0,
+                vertical_align: VerticalAlign::Baseline,
+                background_gradient: None,
+                background_radial_gradient: None,
+                background_svg: None,
+                background_size: BackgroundSize::Auto,
+                background_position: BackgroundPosition::default(),
+                background_repeat: BackgroundRepeat::Repeat,
+                background_origin: BackgroundOrigin::PaddingBox,
+                z_index,
+                repeat_on_each_page,
+                heading_level: None,
+            };
+
+        let pages = paginate(
+            vec![
+                make_block(Position::Absolute, -1, true, 40.0),
+                make_block(Position::Absolute, -1, false, 40.0),
+                make_block(Position::Static, 0, false, 30.0),
+                make_block(Position::Static, 0, false, 30.0),
+            ],
+            40.0,
+        );
+
+        assert_eq!(pages.len(), 2);
+        let repeated_per_page: Vec<_> = pages
+            .iter()
+            .map(|page| {
+                page.elements
+                    .iter()
+                    .filter(|(_, element)| {
+                        matches!(
+                            element,
+                            LayoutElement::TextBlock {
+                                repeat_on_each_page: true,
+                                ..
+                            }
+                        )
+                    })
+                    .count()
+            })
+            .collect();
+        assert_eq!(repeated_per_page, vec![1, 1]);
+
+        let non_repeating_per_page: Vec<_> = pages
+            .iter()
+            .map(|page| {
+                page.elements
+                    .iter()
+                    .filter(|(_, element)| {
+                        matches!(
+                            element,
+                            LayoutElement::TextBlock {
+                                position: Position::Absolute,
+                                repeat_on_each_page: false,
+                                ..
+                            }
+                        )
+                    })
+                    .count()
+            })
+            .collect();
+        assert_eq!(non_repeating_per_page, vec![1, 0]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub(crate) mod security;
 pub(crate) mod style;
 /// Public types: page size, margins, and colors.
 pub mod types;
+pub(crate) mod util;
 
 /// Fetch bytes from a remote URL (requires the `remote` feature).
 /// Returns `None` when the feature is disabled or the request fails.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1838,6 +1838,29 @@ fn main() {
     }
 
     #[test]
+    fn svg_background_image_from_data_uri() {
+        let html = r#"<html><head><style>
+body { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100' height='100' fill='%23eee'/%3E%3Ccircle cx='50' cy='50' r='30' fill='%23ccc'/%3E%3C/svg%3E"); background-size: cover; }
+</style></head><body>
+<h1>Background Test</h1>
+<p>This page should have an SVG pattern background.</p>
+</body></html>"#;
+        let pdf = HtmlConverter::new().sanitize(false).convert(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("Background Test"));
+    }
+
+    #[test]
+    fn svg_background_image_base64() {
+        let html = r#"<html><head><style>
+body { background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc1MCcgaGVpZ2h0PSc1MCc+PHJlY3Qgd2lkdGg9JzUwJyBoZWlnaHQ9JzUwJyBmaWxsPSdibHVlJy8+PC9zdmc+"); }
+</style></head><body><p>Base64 SVG BG</p></body></html>"#;
+        let pdf = HtmlConverter::new().sanitize(false).convert(html).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
     fn html_to_pdf_border_radius() {
         let html = r#"<div style="border: 1px solid black; border-radius: 10pt; background-color: yellow; padding: 10pt">Rounded corners</div>"#;
         let pdf = html_to_pdf(html).unwrap();

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -111,23 +111,29 @@ impl StyleMap {
     }
 }
 
-/// Split a CSS declaration string on `;`, respecting quoted strings.
+/// Split a CSS declaration string on `;`, respecting quoted strings and
+/// parenthesized function arguments.
 ///
-/// Semicolons inside `"..."` or `'...'` are not treated as delimiters.
-/// This prevents data URIs like `data:image/svg+xml;base64,...` inside
-/// `url()` values from being split prematurely.
+/// Semicolons inside `"..."`, `'...'`, or `url(...)` are not treated as
+/// delimiters. This prevents data URIs like `data:image/svg+xml;base64,...`
+/// from being split prematurely.
 fn split_declarations(css: &str) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut start = 0;
     let bytes = css.as_bytes();
     let mut in_single_quote = false;
     let mut in_double_quote = false;
+    let mut paren_depth = 0usize;
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
-            b'\'' if !in_double_quote => in_single_quote = !in_single_quote,
-            b'"' if !in_single_quote => in_double_quote = !in_double_quote,
-            b';' if !in_single_quote && !in_double_quote => {
+            b'\'' if !in_double_quote && paren_depth > 0 => in_single_quote = !in_single_quote,
+            b'"' if !in_single_quote && paren_depth > 0 => in_double_quote = !in_double_quote,
+            b'(' if !in_single_quote && !in_double_quote => paren_depth += 1,
+            b')' if !in_single_quote && !in_double_quote && paren_depth > 0 => {
+                paren_depth -= 1;
+            }
+            b';' if !in_single_quote && !in_double_quote && paren_depth == 0 => {
                 parts.push(&css[start..i]);
                 start = i + 1;
             }
@@ -1279,14 +1285,15 @@ fn extract_svg_data_uri(val: &str) -> Option<String> {
     }
 
     let after_mime = &inner["data:image/svg+xml".len()..];
+    let comma = after_mime.find(',')?;
+    let params = &after_mime[..comma];
+    let data = &after_mime[comma + 1..];
 
-    if let Some(b64_data) = after_mime.strip_prefix(";base64,") {
-        let decoded = base64_decode_svg(b64_data)?;
+    if params.to_ascii_lowercase().contains(";base64") {
+        let decoded = base64_decode_svg(data)?;
         String::from_utf8(decoded).ok()
     } else {
-        after_mime
-            .strip_prefix(',')
-            .map(percent_decode)
+        Some(percent_decode(data))
     }
 }
 
@@ -1340,7 +1347,7 @@ fn base64_decode_svg(input: &str) -> Option<Vec<u8>> {
 
 /// Decode percent-encoded text (e.g. `%3Csvg` -> `<svg`).
 fn percent_decode(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
+    let mut out = Vec::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -1348,15 +1355,15 @@ fn percent_decode(input: &str) -> String {
             let hi = hex_val(bytes[i + 1]);
             let lo = hex_val(bytes[i + 2]);
             if let (Some(h), Some(l)) = (hi, lo) {
-                result.push((h << 4 | l) as char);
+                out.push((h << 4) | l);
                 i += 3;
                 continue;
             }
         }
-        result.push(bytes[i] as char);
+        out.push(bytes[i]);
         i += 1;
     }
-    result
+    String::from_utf8(out).unwrap_or_default()
 }
 
 fn hex_val(b: u8) -> Option<u8> {
@@ -3482,6 +3489,13 @@ mod tests {
     }
 
     #[test]
+    fn extract_svg_data_uri_charset_parameter() {
+        let val = r#"url("data:image/svg+xml;charset=utf-8,%3Csvg%3E%3C/svg%3E")"#;
+        let result = extract_svg_data_uri(val);
+        assert_eq!(result, Some("<svg></svg>".to_string()));
+    }
+
+    #[test]
     fn extract_svg_data_uri_not_svg() {
         let val = r#"url("data:image/png;base64,abc")"#;
         assert!(extract_svg_data_uri(val).is_none());
@@ -3492,6 +3506,19 @@ mod tests {
         assert_eq!(percent_decode("%3Csvg%3E"), "<svg>");
         assert_eq!(percent_decode("hello%20world"), "hello world");
         assert_eq!(percent_decode("no-encoding"), "no-encoding");
+    }
+
+    #[test]
+    fn percent_decode_utf8() {
+        assert_eq!(percent_decode("%E2%82%AC"), "€");
+    }
+
+    #[test]
+    fn split_declarations_preserves_unquoted_data_uri() {
+        let style = r#"background-image: url(data:image/svg+xml;base64,PHN2Zy8+); color: red;"#;
+        let map = parse_inline_style(style);
+        assert!(map.get("background-svg").is_some());
+        assert!(map.get("color").is_some());
     }
 
     #[test]

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::parser::dom::ElementNode;
 use crate::types::Color;
+use crate::util::decode_base64;
 
 /// Context for evaluating CSS media queries against the target page.
 #[derive(Debug, Clone, Copy)]
@@ -1347,59 +1348,11 @@ fn extract_svg_data_uri(val: &str) -> Option<String> {
     let data = &after_mime[comma + 1..];
 
     if params.to_ascii_lowercase().contains(";base64") {
-        let decoded = base64_decode_svg(data)?;
+        let decoded = decode_base64(data)?;
         String::from_utf8(decoded).ok()
     } else {
         Some(percent_decode(data))
     }
-}
-
-/// Decode a base64-encoded string into bytes.
-fn base64_decode_svg(input: &str) -> Option<Vec<u8>> {
-    const TABLE: [u8; 128] = {
-        let mut t = [255u8; 128];
-        let mut i = 0u8;
-        while i < 26 {
-            t[(b'A' + i) as usize] = i;
-            i += 1;
-        }
-        i = 0;
-        while i < 26 {
-            t[(b'a' + i) as usize] = 26 + i;
-            i += 1;
-        }
-        i = 0;
-        while i < 10 {
-            t[(b'0' + i) as usize] = 52 + i;
-            i += 1;
-        }
-        t[b'+' as usize] = 62;
-        t[b'/' as usize] = 63;
-        t
-    };
-
-    let bytes: Vec<u8> = input
-        .bytes()
-        .filter(|b| !b.is_ascii_whitespace() && *b != b'=')
-        .collect();
-    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
-    for chunk in bytes.chunks(4) {
-        let mut buf = [0u8; 4];
-        for (i, &b) in chunk.iter().enumerate() {
-            if b >= 128 || TABLE[b as usize] == 255 {
-                return None;
-            }
-            buf[i] = TABLE[b as usize];
-        }
-        out.push((buf[0] << 2) | (buf[1] >> 4));
-        if chunk.len() > 2 {
-            out.push((buf[1] << 4) | (buf[2] >> 2));
-        }
-        if chunk.len() > 3 {
-            out.push((buf[2] << 6) | buf[3]);
-        }
-    }
-    Some(out)
 }
 
 /// Decode percent-encoded text (e.g. `%3Csvg` -> `<svg`).
@@ -3629,8 +3582,9 @@ mod tests {
 
     #[test]
     fn later_background_none_clears_prior_color_and_repeat() {
-        let style =
-            parse_inline_style(r#"background-color: red; background-repeat: no-repeat; background: none"#);
+        let style = parse_inline_style(
+            r#"background-color: red; background-repeat: no-repeat; background: none"#,
+        );
         assert!(style.get("background-color").is_none());
         assert!(style.get("background-repeat").is_none());
         assert!(matches!(

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -206,29 +206,41 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
                 }
             } else if (prop == "margin-left" || prop == "margin-right") && val.trim() == "auto" {
                 map.set(&prop, CssValue::Keyword("auto".to_string()));
-            } else if (prop == "background" || prop == "background-image")
-                && val.trim_start().starts_with("linear-gradient(")
+            } else if prop == "background" {
+                let trimmed = val.trim();
+                parse_background_shorthand(trimmed, &mut map);
+                if trimmed.starts_with("linear-gradient(") {
+                    // Store the full gradient function string for later parsing.
+                    map.set(
+                        "background-gradient",
+                        CssValue::Keyword(trimmed.to_string()),
+                    );
+                } else if trimmed.starts_with("radial-gradient(") {
+                    map.set(
+                        "background-radial-gradient",
+                        CssValue::Keyword(trimmed.to_string()),
+                    );
+                } else if let Some(svg_text) = extract_svg_data_uri(trimmed) {
+                    map.set("background-svg", CssValue::Keyword(svg_text));
+                }
+            } else if prop == "background-image" && val.trim_start().starts_with("linear-gradient(")
             {
-                // Store the full gradient function string for later parsing
                 map.set(
                     "background-gradient",
                     CssValue::Keyword(val.trim().to_string()),
                 );
-            } else if (prop == "background" || prop == "background-image")
-                && val.trim_start().starts_with("radial-gradient(")
+            } else if prop == "background-image" && val.trim_start().starts_with("radial-gradient(")
             {
                 map.set(
                     "background-radial-gradient",
                     CssValue::Keyword(val.trim().to_string()),
                 );
-            } else if (prop == "background" || prop == "background-image")
-                && extract_svg_data_uri(val.trim()).is_some()
-            {
+            } else if prop == "background-image" {
                 if let Some(svg_text) = extract_svg_data_uri(val.trim()) {
                     map.set("background-svg", CssValue::Keyword(svg_text));
+                } else if let Some(css_val) = parse_value(&prop, val) {
+                    map.set(&prop, css_val);
                 }
-            } else if prop == "background" {
-                parse_background_shorthand(val.trim(), &mut map);
             } else if let Some(css_val) = parse_value(&prop, val) {
                 map.set(&prop, css_val);
             }
@@ -571,10 +583,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
                         i += 1;
                     }
                 }
-                map.set(
-                    "background-size",
-                    CssValue::Keyword(size_str),
-                );
+                map.set("background-size", CssValue::Keyword(size_str));
                 found_size = true;
             }
             i += 1;
@@ -3449,9 +3458,9 @@ mod tests {
     #[test]
     fn svg_data_uri_base64_in_background() {
         let b64 = "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxyZWN0IHdpZHRoPScxMCcgaGVpZ2h0PScxMCcgZmlsbD0ncmVkJy8+PC9zdmc+";
-        let style = parse_inline_style(
-            &format!(r#"background: url("data:image/svg+xml;base64,{b64}")"#),
-        );
+        let style = parse_inline_style(&format!(
+            r#"background: url("data:image/svg+xml;base64,{b64}")"#
+        ));
         assert!(style.get("background-svg").is_some());
         if let Some(CssValue::Keyword(svg)) = style.get("background-svg") {
             assert!(svg.contains("<svg"));
@@ -3467,10 +3476,28 @@ mod tests {
     }
 
     #[test]
-    fn non_svg_data_uri_not_matched() {
+    fn svg_background_shorthand_preserves_following_tokens() {
         let style = parse_inline_style(
-            r#"background-image: url("data:image/png;base64,iVBOR")"#,
+            r#"background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E") no-repeat center / 50% 25%"#,
         );
+        assert!(style.get("background-svg").is_some());
+        assert!(matches!(
+            style.get("background-repeat"),
+            Some(CssValue::Keyword(value)) if value == "no-repeat"
+        ));
+        assert!(matches!(
+            style.get("background-position"),
+            Some(CssValue::Keyword(value)) if value == "center"
+        ));
+        assert!(matches!(
+            style.get("background-size"),
+            Some(CssValue::Keyword(value)) if value == "50% 25%"
+        ));
+    }
+
+    #[test]
+    fn non_svg_data_uri_not_matched() {
+        let style = parse_inline_style(r#"background-image: url("data:image/png;base64,iVBOR")"#);
         assert!(style.get("background-svg").is_none());
     }
 

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -111,11 +111,41 @@ impl StyleMap {
     }
 }
 
+/// Split a CSS declaration string on `;`, respecting quoted strings.
+///
+/// Semicolons inside `"..."` or `'...'` are not treated as delimiters.
+/// This prevents data URIs like `data:image/svg+xml;base64,...` inside
+/// `url()` values from being split prematurely.
+fn split_declarations(css: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let bytes = css.as_bytes();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            b'"' if !in_single_quote => in_double_quote = !in_double_quote,
+            b';' if !in_single_quote && !in_double_quote => {
+                parts.push(&css[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if start < css.len() {
+        parts.push(&css[start..]);
+    }
+    parts
+}
+
 /// Parse an inline CSS style string (e.g. "color: red; font-size: 14px").
 pub fn parse_inline_style(style: &str) -> StyleMap {
     let mut map = StyleMap::new();
 
-    for declaration in style.split(';') {
+    for declaration in split_declarations(style) {
         let declaration = declaration.trim();
         if declaration.is_empty() {
             continue;
@@ -185,6 +215,12 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
                     "background-radial-gradient",
                     CssValue::Keyword(val.trim().to_string()),
                 );
+            } else if (prop == "background" || prop == "background-image")
+                && extract_svg_data_uri(val.trim()).is_some()
+            {
+                if let Some(svg_text) = extract_svg_data_uri(val.trim()) {
+                    map.set("background-svg", CssValue::Keyword(svg_text));
+                }
             } else if let Some(css_val) = parse_value(&prop, val) {
                 map.set(&prop, css_val);
             }
@@ -1034,6 +1070,114 @@ fn extract_url_path(val: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Extract and decode an SVG from a CSS `url(data:image/svg+xml,...)` value.
+///
+/// Supports both percent-encoded and base64-encoded SVG data URIs.
+/// Returns the decoded SVG markup string, or `None` if the value is not an
+/// SVG data URI.
+fn extract_svg_data_uri(val: &str) -> Option<String> {
+    let lower = val.to_ascii_lowercase();
+    let start = lower.find("url(")?;
+    let after_url = &val[start + 4..];
+    let end = after_url.rfind(')')?;
+    let inner = after_url[..end].trim();
+    let inner = inner.trim_matches('"').trim_matches('\'').trim();
+
+    let inner_lower = inner.to_ascii_lowercase();
+    if !inner_lower.starts_with("data:image/svg+xml") {
+        return None;
+    }
+
+    let after_mime = &inner["data:image/svg+xml".len()..];
+
+    if let Some(b64_data) = after_mime.strip_prefix(";base64,") {
+        let decoded = base64_decode_svg(b64_data)?;
+        String::from_utf8(decoded).ok()
+    } else {
+        after_mime
+            .strip_prefix(',')
+            .map(percent_decode)
+    }
+}
+
+/// Decode a base64-encoded string into bytes.
+fn base64_decode_svg(input: &str) -> Option<Vec<u8>> {
+    const TABLE: [u8; 128] = {
+        let mut t = [255u8; 128];
+        let mut i = 0u8;
+        while i < 26 {
+            t[(b'A' + i) as usize] = i;
+            i += 1;
+        }
+        i = 0;
+        while i < 26 {
+            t[(b'a' + i) as usize] = 26 + i;
+            i += 1;
+        }
+        i = 0;
+        while i < 10 {
+            t[(b'0' + i) as usize] = 52 + i;
+            i += 1;
+        }
+        t[b'+' as usize] = 62;
+        t[b'/' as usize] = 63;
+        t
+    };
+
+    let bytes: Vec<u8> = input
+        .bytes()
+        .filter(|b| !b.is_ascii_whitespace() && *b != b'=')
+        .collect();
+    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
+    for chunk in bytes.chunks(4) {
+        let mut buf = [0u8; 4];
+        for (i, &b) in chunk.iter().enumerate() {
+            if b >= 128 || TABLE[b as usize] == 255 {
+                return None;
+            }
+            buf[i] = TABLE[b as usize];
+        }
+        out.push((buf[0] << 2) | (buf[1] >> 4));
+        if chunk.len() > 2 {
+            out.push((buf[1] << 4) | (buf[2] >> 2));
+        }
+        if chunk.len() > 3 {
+            out.push((buf[2] << 6) | buf[3]);
+        }
+    }
+    Some(out)
+}
+
+/// Decode percent-encoded text (e.g. `%3Csvg` -> `<svg`).
+fn percent_decode(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = hex_val(bytes[i + 1]);
+            let lo = hex_val(bytes[i + 2]);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                result.push((h << 4 | l) as char);
+                i += 3;
+                continue;
+            }
+        }
+        result.push(bytes[i] as char);
+        i += 1;
+    }
+    result
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(10 + b - b'a'),
+        b'A'..=b'F' => Some(10 + b - b'A'),
+        _ => None,
+    }
 }
 
 /// Parse `@import` rules from a CSS string.
@@ -3093,6 +3237,73 @@ mod tests {
     fn radial_gradient_in_background() {
         let style = parse_inline_style("background: radial-gradient(red, blue)");
         assert!(style.get("background-radial-gradient").is_some());
+    }
+
+    #[test]
+    fn svg_data_uri_percent_encoded_in_background() {
+        let style = parse_inline_style(
+            r#"background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100' height='100' fill='%23eee'/%3E%3C/svg%3E")"#,
+        );
+        assert!(style.get("background-svg").is_some());
+        if let Some(CssValue::Keyword(svg)) = style.get("background-svg") {
+            assert!(svg.contains("<svg"));
+            assert!(svg.contains("<rect"));
+        }
+    }
+
+    #[test]
+    fn svg_data_uri_base64_in_background() {
+        let b64 = "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxyZWN0IHdpZHRoPScxMCcgaGVpZ2h0PScxMCcgZmlsbD0ncmVkJy8+PC9zdmc+";
+        let style = parse_inline_style(
+            &format!(r#"background: url("data:image/svg+xml;base64,{b64}")"#),
+        );
+        assert!(style.get("background-svg").is_some());
+        if let Some(CssValue::Keyword(svg)) = style.get("background-svg") {
+            assert!(svg.contains("<svg"));
+        }
+    }
+
+    #[test]
+    fn svg_data_uri_via_background_shorthand() {
+        let style = parse_inline_style(
+            r#"background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E")"#,
+        );
+        assert!(style.get("background-svg").is_some());
+    }
+
+    #[test]
+    fn non_svg_data_uri_not_matched() {
+        let style = parse_inline_style(
+            r#"background-image: url("data:image/png;base64,iVBOR")"#,
+        );
+        assert!(style.get("background-svg").is_none());
+    }
+
+    #[test]
+    fn extract_svg_data_uri_percent_decode() {
+        let val = r#"url("data:image/svg+xml,%3Csvg%3E%3C/svg%3E")"#;
+        let result = extract_svg_data_uri(val);
+        assert_eq!(result, Some("<svg></svg>".to_string()));
+    }
+
+    #[test]
+    fn extract_svg_data_uri_base64() {
+        let val = r#"url("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")"#;
+        let result = extract_svg_data_uri(val);
+        assert_eq!(result, Some("<svg></svg>".to_string()));
+    }
+
+    #[test]
+    fn extract_svg_data_uri_not_svg() {
+        let val = r#"url("data:image/png;base64,abc")"#;
+        assert!(extract_svg_data_uri(val).is_none());
+    }
+
+    #[test]
+    fn percent_decode_basic() {
+        assert_eq!(percent_decode("%3Csvg%3E"), "<svg>");
+        assert_eq!(percent_decode("hello%20world"), "hello world");
+        assert_eq!(percent_decode("no-encoding"), "no-encoding");
     }
 
     #[test]

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -103,6 +103,10 @@ impl StyleMap {
         self.properties.get(key)
     }
 
+    pub fn remove(&mut self, key: &str) {
+        self.properties.remove(key);
+    }
+
     #[allow(dead_code)]
     pub fn merge(&mut self, other: &StyleMap) {
         for (k, v) in &other.properties {
@@ -127,8 +131,8 @@ fn split_declarations(css: &str) -> Vec<&str> {
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
-            b'\'' if !in_double_quote && paren_depth > 0 => in_single_quote = !in_single_quote,
-            b'"' if !in_single_quote && paren_depth > 0 => in_double_quote = !in_double_quote,
+            b'\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            b'"' if !in_single_quote => in_double_quote = !in_double_quote,
             b'(' if !in_single_quote && !in_double_quote => paren_depth += 1,
             b')' if !in_single_quote && !in_double_quote && paren_depth > 0 => {
                 paren_depth -= 1;
@@ -208,6 +212,7 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
                 map.set(&prop, CssValue::Keyword("auto".to_string()));
             } else if prop == "background" {
                 let trimmed = val.trim();
+                clear_background_shorthand_keys(&mut map);
                 parse_background_shorthand(trimmed, &mut map);
                 if trimmed.starts_with("linear-gradient(") {
                     // Store the full gradient function string for later parsing.
@@ -225,17 +230,20 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
                 }
             } else if prop == "background-image" && val.trim_start().starts_with("linear-gradient(")
             {
+                clear_background_image_keys(&mut map);
                 map.set(
                     "background-gradient",
                     CssValue::Keyword(val.trim().to_string()),
                 );
             } else if prop == "background-image" && val.trim_start().starts_with("radial-gradient(")
             {
+                clear_background_image_keys(&mut map);
                 map.set(
                     "background-radial-gradient",
                     CssValue::Keyword(val.trim().to_string()),
                 );
             } else if prop == "background-image" {
+                clear_background_image_keys(&mut map);
                 if let Some(svg_text) = extract_svg_data_uri(val.trim()) {
                     map.set("background-svg", CssValue::Keyword(svg_text));
                 } else if let Some(css_val) = parse_value(&prop, val) {
@@ -248,6 +256,30 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
     }
 
     map
+}
+
+fn clear_background_image_keys(map: &mut StyleMap) {
+    for key in [
+        "background-image",
+        "background-svg",
+        "background-gradient",
+        "background-radial-gradient",
+    ] {
+        map.remove(key);
+    }
+}
+
+fn clear_background_shorthand_keys(map: &mut StyleMap) {
+    clear_background_image_keys(map);
+    for key in [
+        "background-color",
+        "background-size",
+        "background-repeat",
+        "background-position",
+        "background-origin",
+    ] {
+        map.remove(key);
+    }
 }
 
 fn parse_value(property: &str, val: &str) -> Option<CssValue> {
@@ -482,6 +514,10 @@ fn parse_value(property: &str, val: &str) -> Option<CssValue> {
         return Some(CssValue::Keyword(val.to_string()));
     }
 
+    if property == "background-image" {
+        return Some(CssValue::Keyword(val.to_string()));
+    }
+
     // White-space — keyword
     if property == "white-space" {
         return Some(CssValue::Keyword(val.to_string()));
@@ -537,8 +573,20 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
             // Check if it's an SVG data URI
             if let Some(svg_text) = extract_svg_data_uri(tok) {
                 map.set("background-svg", CssValue::Keyword(svg_text));
+            } else {
+                map.set(
+                    "background-image",
+                    CssValue::Keyword(tok.trim().to_string()),
+                );
             }
             // Note: non-SVG URLs are stored but won't render (no raster bg support)
+            found_image = true;
+            i += 1;
+            continue;
+        }
+
+        if !found_image && lower == "none" {
+            map.set("background-image", CssValue::Keyword("none".to_string()));
             found_image = true;
             i += 1;
             continue;
@@ -3546,6 +3594,49 @@ mod tests {
         let map = parse_inline_style(style);
         assert!(map.get("background-svg").is_some());
         assert!(map.get("color").is_some());
+    }
+
+    #[test]
+    fn split_declarations_preserves_top_level_quoted_semicolon() {
+        let style = r#"content: "a;b"; color: red;"#;
+        let decls = split_declarations(style);
+        assert_eq!(decls, vec![r#"content: "a;b""#, " color: red"]);
+    }
+
+    #[test]
+    fn later_background_image_none_clears_prior_svg() {
+        let style = parse_inline_style(
+            r#"background-image: url("data:image/svg+xml,%3Csvg%3E%3C/svg%3E"); background-image: none"#,
+        );
+        assert!(style.get("background-svg").is_none());
+        assert!(matches!(
+            style.get("background-image"),
+            Some(CssValue::Keyword(value)) if value == "none"
+        ));
+    }
+
+    #[test]
+    fn later_background_none_clears_prior_svg() {
+        let style = parse_inline_style(
+            r#"background-image: url("data:image/svg+xml,%3Csvg%3E%3C/svg%3E"); background: none"#,
+        );
+        assert!(style.get("background-svg").is_none());
+        assert!(matches!(
+            style.get("background-image"),
+            Some(CssValue::Keyword(value)) if value == "none"
+        ));
+    }
+
+    #[test]
+    fn later_background_none_clears_prior_color_and_repeat() {
+        let style =
+            parse_inline_style(r#"background-color: red; background-repeat: no-repeat; background: none"#);
+        assert!(style.get("background-color").is_none());
+        assert!(style.get("background-repeat").is_none());
+        assert!(matches!(
+            style.get("background-image"),
+            Some(CssValue::Keyword(value)) if value == "none"
+        ));
     }
 
     #[test]

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -214,6 +214,11 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
             } else if prop == "background" {
                 let trimmed = val.trim();
                 clear_background_shorthand_keys(&mut map);
+                if trimmed.starts_with("linear-gradient(")
+                    || trimmed.starts_with("radial-gradient(")
+                {
+                    apply_background_shorthand_defaults(&mut map);
+                }
                 parse_background_shorthand(trimmed, &mut map);
                 if trimmed.starts_with("linear-gradient(") {
                     // Store the full gradient function string for later parsing.
@@ -280,6 +285,29 @@ fn clear_background_shorthand_keys(map: &mut StyleMap) {
         "background-origin",
     ] {
         map.remove(key);
+    }
+}
+
+fn apply_background_shorthand_defaults(map: &mut StyleMap) {
+    // CSS shorthand semantics reset omitted subproperties to their initial values.
+    map.set("background-color", CssValue::Keyword("initial".to_string()));
+    map.set("background-image", CssValue::Keyword("none".to_string()));
+    map.set("background-size", CssValue::Keyword("auto".to_string()));
+    map.set("background-repeat", CssValue::Keyword("repeat".to_string()));
+    map.set(
+        "background-position",
+        CssValue::Keyword("0% 0%".to_string()),
+    );
+    map.set(
+        "background-origin",
+        CssValue::Keyword("padding-box".to_string()),
+    );
+}
+
+fn ensure_background_shorthand_defaults(map: &mut StyleMap, defaults_applied: &mut bool) {
+    if !*defaults_applied {
+        apply_background_shorthand_defaults(map);
+        *defaults_applied = true;
     }
 }
 
@@ -542,9 +570,12 @@ fn parse_value(property: &str, val: &str) -> Option<CssValue> {
 /// values, ignoring unknown tokens.  Gradient and SVG data-URI images are
 /// handled by earlier branches in `parse_inline_style` and never reach here.
 fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
+    let mut defaults_applied = false;
+
     // First, try to parse as a simple color.
     // If the *entire* value parses as a color, treat it as background-color only.
     if let Some(color_val) = parse_color(val) {
+        ensure_background_shorthand_defaults(map, &mut defaults_applied);
         map.set("background-color", color_val);
         return;
     }
@@ -573,8 +604,10 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
         if !found_image && lower.starts_with("url(") {
             // Check if it's an SVG data URI
             if let Some(svg_text) = extract_svg_data_uri(tok) {
+                ensure_background_shorthand_defaults(map, &mut defaults_applied);
                 map.set("background-svg", CssValue::Keyword(svg_text));
             } else {
+                ensure_background_shorthand_defaults(map, &mut defaults_applied);
                 map.set(
                     "background-image",
                     CssValue::Keyword(tok.trim().to_string()),
@@ -587,6 +620,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
         }
 
         if !found_image && lower == "none" {
+            ensure_background_shorthand_defaults(map, &mut defaults_applied);
             map.set("background-image", CssValue::Keyword("none".to_string()));
             found_image = true;
             i += 1;
@@ -595,6 +629,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
 
         // background-origin / background-clip
         if !found_origin && origin_keywords.contains(&lower.as_str()) {
+            ensure_background_shorthand_defaults(map, &mut defaults_applied);
             map.set("background-origin", CssValue::Keyword(lower.clone()));
             found_origin = true;
             i += 1;
@@ -603,6 +638,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
 
         // background-repeat
         if !found_repeat && repeat_keywords.contains(&lower.as_str()) {
+            ensure_background_shorthand_defaults(map, &mut defaults_applied);
             map.set("background-repeat", CssValue::Keyword(lower.clone()));
             found_repeat = true;
             i += 1;
@@ -613,6 +649,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
         if lower == "/" {
             i += 1;
             if i < tokens.len() && !found_size {
+                ensure_background_shorthand_defaults(map, &mut defaults_applied);
                 let size_tok = tokens[i].trim();
                 // Collect potential second size token (e.g. "100px 200px")
                 let mut size_str = size_tok.to_string();
@@ -649,6 +686,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
         // Color — try parsing as color
         if !found_color {
             if let Some(color_val) = parse_color(tok) {
+                ensure_background_shorthand_defaults(map, &mut defaults_applied);
                 map.set("background-color", color_val);
                 found_color = true;
                 i += 1;
@@ -658,6 +696,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
 
         // Length value that could be a position (e.g. "10px", "50%")
         if parse_length(tok).is_some() {
+            ensure_background_shorthand_defaults(map, &mut defaults_applied);
             pos_parts.push(lower.clone());
             i += 1;
             continue;
@@ -3585,8 +3624,14 @@ mod tests {
         let style = parse_inline_style(
             r#"background-color: red; background-repeat: no-repeat; background: none"#,
         );
-        assert!(style.get("background-color").is_none());
-        assert!(style.get("background-repeat").is_none());
+        assert!(matches!(
+            style.get("background-color"),
+            Some(CssValue::Keyword(value)) if value == "initial"
+        ));
+        assert!(matches!(
+            style.get("background-repeat"),
+            Some(CssValue::Keyword(value)) if value == "repeat"
+        ));
         assert!(matches!(
             style.get("background-image"),
             Some(CssValue::Keyword(value)) if value == "none"

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -221,6 +221,8 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
                 if let Some(svg_text) = extract_svg_data_uri(val.trim()) {
                     map.set("background-svg", CssValue::Keyword(svg_text));
                 }
+            } else if prop == "background" {
+                parse_background_shorthand(val.trim(), &mut map);
             } else if let Some(css_val) = parse_value(&prop, val) {
                 map.set(&prop, css_val);
             }
@@ -457,6 +459,11 @@ fn parse_value(property: &str, val: &str) -> Option<CssValue> {
         return Some(CssValue::Keyword(val.to_string()));
     }
 
+    // Background-origin — keyword
+    if property == "background-origin" {
+        return Some(CssValue::Keyword(val.to_string()));
+    }
+
     // White-space — keyword
     if property == "white-space" {
         return Some(CssValue::Keyword(val.to_string()));
@@ -469,6 +476,187 @@ fn parse_value(property: &str, val: &str) -> Option<CssValue> {
 
     // Length values (font-size, margin, padding, width, height, top, left, etc.)
     parse_length(val)
+}
+
+/// Parse the CSS `background` shorthand and emit individual longhand properties.
+///
+/// Per CSS spec, the background shorthand accepts (in any order):
+///   `[color] [image] [position] [/ size] [repeat] [origin] [clip]`
+///
+/// This implementation is lenient: it scans tokens and extracts recognized
+/// values, ignoring unknown tokens.  Gradient and SVG data-URI images are
+/// handled by earlier branches in `parse_inline_style` and never reach here.
+fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
+    // First, try to parse as a simple color.
+    // If the *entire* value parses as a color, treat it as background-color only.
+    if let Some(color_val) = parse_color(val) {
+        map.set("background-color", color_val);
+        return;
+    }
+
+    // Tokenize, keeping `url(...)` as a single token.
+    let tokens = tokenize_background_value(val);
+
+    let origin_keywords = ["padding-box", "border-box", "content-box"];
+    let repeat_keywords = ["no-repeat", "repeat", "repeat-x", "repeat-y"];
+    let position_keywords = ["center", "top", "bottom", "left", "right"];
+
+    let mut found_color = false;
+    let mut found_image = false;
+    let mut found_repeat = false;
+    let mut found_origin = false;
+    let mut found_size = false;
+    // Track position tokens for combining "top left" etc.
+    let mut pos_parts: Vec<String> = Vec::new();
+
+    let mut i = 0;
+    while i < tokens.len() {
+        let tok = tokens[i].trim();
+        let lower = tok.to_ascii_lowercase();
+
+        // url(...) — image
+        if !found_image && lower.starts_with("url(") {
+            // Check if it's an SVG data URI
+            if let Some(svg_text) = extract_svg_data_uri(tok) {
+                map.set("background-svg", CssValue::Keyword(svg_text));
+            }
+            // Note: non-SVG URLs are stored but won't render (no raster bg support)
+            found_image = true;
+            i += 1;
+            continue;
+        }
+
+        // background-origin / background-clip
+        if !found_origin && origin_keywords.contains(&lower.as_str()) {
+            map.set("background-origin", CssValue::Keyword(lower.clone()));
+            found_origin = true;
+            i += 1;
+            continue;
+        }
+
+        // background-repeat
+        if !found_repeat && repeat_keywords.contains(&lower.as_str()) {
+            map.set("background-repeat", CssValue::Keyword(lower.clone()));
+            found_repeat = true;
+            i += 1;
+            continue;
+        }
+
+        // "/" followed by size — parse background-size
+        if lower == "/" {
+            i += 1;
+            if i < tokens.len() && !found_size {
+                let size_tok = tokens[i].trim();
+                // Collect potential second size token (e.g. "100px 200px")
+                let mut size_str = size_tok.to_string();
+                if i + 1 < tokens.len() {
+                    let next = tokens[i + 1].trim().to_ascii_lowercase();
+                    // If next token is also a size value (not a keyword), combine
+                    if !origin_keywords.contains(&next.as_str())
+                        && !repeat_keywords.contains(&next.as_str())
+                        && !position_keywords.contains(&next.as_str())
+                        && next != "/"
+                        && !next.starts_with("url(")
+                        && !next.starts_with('#')
+                        && parse_color(&next).is_none()
+                    {
+                        size_str.push(' ');
+                        size_str.push_str(tokens[i + 1].trim());
+                        i += 1;
+                    }
+                }
+                map.set(
+                    "background-size",
+                    CssValue::Keyword(size_str),
+                );
+                found_size = true;
+            }
+            i += 1;
+            continue;
+        }
+
+        // Position keywords
+        if position_keywords.contains(&lower.as_str()) {
+            pos_parts.push(lower.clone());
+            i += 1;
+            continue;
+        }
+
+        // Color — try parsing as color
+        if !found_color {
+            if let Some(color_val) = parse_color(tok) {
+                map.set("background-color", color_val);
+                found_color = true;
+                i += 1;
+                continue;
+            }
+        }
+
+        // Length value that could be a position (e.g. "10px", "50%")
+        if parse_length(tok).is_some() {
+            pos_parts.push(lower.clone());
+            i += 1;
+            continue;
+        }
+
+        // Skip unrecognized tokens
+        i += 1;
+    }
+
+    // Combine position parts
+    if !pos_parts.is_empty() {
+        let pos_str = pos_parts.join(" ");
+        map.set("background-position", CssValue::Keyword(pos_str));
+    }
+}
+
+/// Tokenize a background shorthand value, keeping `url(...)` as single tokens.
+fn tokenize_background_value(val: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut paren_depth = 0u32;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+
+    for ch in val.chars() {
+        match ch {
+            '\'' if !in_double_quote && paren_depth > 0 => {
+                in_single_quote = !in_single_quote;
+                current.push(ch);
+            }
+            '"' if !in_single_quote && paren_depth > 0 => {
+                in_double_quote = !in_double_quote;
+                current.push(ch);
+            }
+            '(' if !in_single_quote && !in_double_quote => {
+                paren_depth += 1;
+                current.push(ch);
+            }
+            ')' if !in_single_quote && !in_double_quote && paren_depth > 0 => {
+                paren_depth -= 1;
+                current.push(ch);
+            }
+            ' ' | '\t' if paren_depth == 0 && !in_single_quote && !in_double_quote => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            '/' if paren_depth == 0 && !in_single_quote && !in_double_quote => {
+                // Emit '/' as its own token so we can detect position/size separator
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+                tokens.push("/".to_string());
+            }
+            _ => {
+                current.push(ch);
+            }
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
 }
 
 /// Evaluate whether a media query matches the PDF output context.

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -213,31 +213,16 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
                 map.set(&prop, CssValue::Keyword("auto".to_string()));
             } else if prop == "background" {
                 let trimmed = val.trim();
-                clear_background_shorthand_keys(&mut map);
                 let lower = trimmed.to_ascii_lowercase();
                 if matches!(lower.as_str(), "inherit" | "initial" | "unset") {
+                    clear_background_shorthand_keys(&mut map);
                     map.set("background", CssValue::Keyword(lower));
                     continue;
                 }
-                if trimmed.starts_with("linear-gradient(")
-                    || trimmed.starts_with("radial-gradient(")
-                {
-                    apply_background_shorthand_defaults(&mut map);
-                }
-                parse_background_shorthand(trimmed, &mut map);
-                if trimmed.starts_with("linear-gradient(") {
-                    // Store the full gradient function string for later parsing.
-                    map.set(
-                        "background-gradient",
-                        CssValue::Keyword(trimmed.to_string()),
-                    );
-                } else if trimmed.starts_with("radial-gradient(") {
-                    map.set(
-                        "background-radial-gradient",
-                        CssValue::Keyword(trimmed.to_string()),
-                    );
-                } else if let Some(svg_text) = extract_svg_data_uri(trimmed) {
-                    map.set("background-svg", CssValue::Keyword(svg_text));
+                let mut parsed = StyleMap::new();
+                if parse_background_shorthand(trimmed, &mut parsed) {
+                    clear_background_shorthand_keys(&mut map);
+                    map.merge(&parsed);
                 }
             } else if prop == "background-image" && val.trim_start().starts_with("linear-gradient(")
             {
@@ -573,9 +558,9 @@ fn parse_value(property: &str, val: &str) -> Option<CssValue> {
 ///   `[color] [image] [position] [/ size] [repeat] [origin] [clip]`
 ///
 /// This implementation is lenient: it scans tokens and extracts recognized
-/// values, ignoring unknown tokens.  Gradient and SVG data-URI images are
-/// handled by earlier branches in `parse_inline_style` and never reach here.
-fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
+/// values, ignoring unknown tokens.  Unrecognized shorthand values are left
+/// untouched so earlier declarations in the same block are preserved.
+fn parse_background_shorthand(val: &str, map: &mut StyleMap) -> bool {
     let mut defaults_applied = false;
 
     // First, try to parse as a simple color.
@@ -583,7 +568,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
     if let Some(color_val) = parse_color(val) {
         ensure_background_shorthand_defaults(map, &mut defaults_applied);
         map.set("background-color", color_val);
-        return;
+        return true;
     }
 
     // Tokenize, keeping `url(...)` as a single token.
@@ -605,6 +590,25 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
     while i < tokens.len() {
         let tok = tokens[i].trim();
         let lower = tok.to_ascii_lowercase();
+
+        if !found_image && lower.starts_with("linear-gradient(") {
+            ensure_background_shorthand_defaults(map, &mut defaults_applied);
+            map.set("background-gradient", CssValue::Keyword(tok.to_string()));
+            found_image = true;
+            i += 1;
+            continue;
+        }
+
+        if !found_image && lower.starts_with("radial-gradient(") {
+            ensure_background_shorthand_defaults(map, &mut defaults_applied);
+            map.set(
+                "background-radial-gradient",
+                CssValue::Keyword(tok.to_string()),
+            );
+            found_image = true;
+            i += 1;
+            continue;
+        }
 
         // url(...) — image
         if !found_image && lower.starts_with("url(") {
@@ -659,8 +663,8 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
                 let size_tok = tokens[i].trim();
                 // Collect potential second size token (e.g. "100px 200px")
                 let mut size_str = size_tok.to_string();
-                if i + 1 < tokens.len() {
-                    let next = tokens[i + 1].trim().to_ascii_lowercase();
+                if let Some(next_tok) = tokens.get(i + 1) {
+                    let next = next_tok.trim().to_ascii_lowercase();
                     // If next token is also a size value (not a keyword), combine
                     if !origin_keywords.contains(&next.as_str())
                         && !repeat_keywords.contains(&next.as_str())
@@ -671,7 +675,7 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
                         && parse_color(&next).is_none()
                     {
                         size_str.push(' ');
-                        size_str.push_str(tokens[i + 1].trim());
+                        size_str.push_str(next_tok.trim());
                         i += 1;
                     }
                 }
@@ -701,7 +705,10 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
         }
 
         // Length value that could be a position (e.g. "10px", "50%")
-        if parse_length(tok).is_some() {
+        if matches!(
+            parse_length(tok),
+            Some(CssValue::Length(_) | CssValue::Percentage(_) | CssValue::Calc(_))
+        ) {
             ensure_background_shorthand_defaults(map, &mut defaults_applied);
             pos_parts.push(lower.clone());
             i += 1;
@@ -717,6 +724,8 @@ fn parse_background_shorthand(val: &str, map: &mut StyleMap) {
         let pos_str = pos_parts.join(" ");
         map.set("background-position", CssValue::Keyword(pos_str));
     }
+
+    defaults_applied
 }
 
 /// Tokenize a background shorthand value, keeping `url(...)` as single tokens.
@@ -3634,6 +3643,22 @@ mod tests {
         ));
         assert!(style.get("background-color").is_none());
         assert!(style.get("background-image").is_none());
+    }
+
+    #[test]
+    fn background_invalid_shorthand_preserves_previous_background_values() {
+        let style = parse_inline_style(
+            "background-color: red; background-repeat: no-repeat; background: var(--bg)",
+        );
+        assert!(matches!(
+            style.get("background-color"),
+            Some(CssValue::Color(value)) if (value.r, value.g, value.b, value.a) == (255, 0, 0, 255)
+        ));
+        assert!(matches!(
+            style.get("background-repeat"),
+            Some(CssValue::Keyword(value)) if value == "no-repeat"
+        ));
+        assert!(style.get("background").is_none());
     }
 
     #[test]

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -214,6 +214,11 @@ pub fn parse_inline_style(style: &str) -> StyleMap {
             } else if prop == "background" {
                 let trimmed = val.trim();
                 clear_background_shorthand_keys(&mut map);
+                let lower = trimmed.to_ascii_lowercase();
+                if matches!(lower.as_str(), "inherit" | "initial" | "unset") {
+                    map.set("background", CssValue::Keyword(lower));
+                    continue;
+                }
                 if trimmed.starts_with("linear-gradient(")
                     || trimmed.starts_with("radial-gradient(")
                 {
@@ -278,6 +283,7 @@ fn clear_background_image_keys(map: &mut StyleMap) {
 fn clear_background_shorthand_keys(map: &mut StyleMap) {
     clear_background_image_keys(map);
     for key in [
+        "background",
         "background-color",
         "background-size",
         "background-repeat",
@@ -3617,6 +3623,17 @@ mod tests {
             style.get("background-image"),
             Some(CssValue::Keyword(value)) if value == "none"
         ));
+    }
+
+    #[test]
+    fn background_special_keyword_is_preserved_in_style_map() {
+        let style = parse_inline_style("background: inherit");
+        assert!(matches!(
+            style.get("background"),
+            Some(CssValue::Keyword(value)) if value == "inherit"
+        ));
+        assert!(style.get("background-color").is_none());
+        assert!(style.get("background-image").is_none());
     }
 
     #[test]

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -91,6 +91,23 @@ pub enum PathCommand {
     ClosePath,
 }
 
+/// Parse an SVG tree from a raw SVG string (e.g. from a data URI).
+///
+/// The input should be the SVG markup (e.g. `<svg ...>...</svg>`).
+/// It is parsed through the HTML parser to obtain a DOM tree, then
+/// the root `<svg>` element is extracted and processed normally.
+pub fn parse_svg_from_string(svg_text: &str) -> Option<SvgTree> {
+    let nodes = crate::parser::html::parse_html(svg_text).ok()?;
+    for node in &nodes {
+        if let crate::parser::dom::DomNode::Element(el) = node {
+            if el.tag == crate::parser::dom::HtmlTag::Svg {
+                return parse_svg_from_element(el);
+            }
+        }
+    }
+    None
+}
+
 /// Entry point: parse an `<svg>` ElementNode into an SvgTree.
 pub fn parse_svg_from_element(el: &ElementNode) -> Option<SvgTree> {
     let width = el

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -404,9 +404,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                 (render_width - padding_left - padding_right).max(0.0),
                                 (total_h - padding_top - padding_bottom).max(0.0),
                             ),
-                            BackgroundOrigin::PaddingBox => {
-                                (block_x, bg_y, render_width, total_h)
-                            }
+                            BackgroundOrigin::PaddingBox => (block_x, bg_y, render_width, total_h),
                         };
                         render_svg_background(
                             &mut content,
@@ -415,6 +413,11 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             ref_y,
                             ref_w,
                             ref_h,
+                            block_x - border.left.width,
+                            bg_y - border.bottom.width,
+                            render_width + border.left.width + border.right.width,
+                            total_h + border.top.width + border.bottom.width,
+                            *border_radius,
                             background_size,
                             background_position,
                             background_repeat,
@@ -1043,6 +1046,11 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             ref_y,
                             ref_w,
                             ref_h,
+                            bg_x - border.left.width,
+                            bg_y - border.bottom.width,
+                            *container_width + border.left.width + border.right.width,
+                            full_height + border.top.width + border.bottom.width,
+                            *border_radius,
                             flex_bg_size,
                             flex_bg_pos,
                             flex_bg_repeat,
@@ -1826,6 +1834,11 @@ fn render_svg_background(
     y: f32,
     width: f32,
     height: f32,
+    clip_x: f32,
+    clip_y: f32,
+    clip_width: f32,
+    clip_height: f32,
+    border_radius: f32,
     bg_size: &BackgroundSize,
     bg_pos: &BackgroundPosition,
     bg_repeat: &BackgroundRepeat,
@@ -1843,6 +1856,14 @@ fn render_svg_background(
         return;
     }
 
+    let resolve_axis = |value: f32, is_percent: bool, extent: f32| {
+        if is_percent {
+            extent * (value / 100.0)
+        } else {
+            value
+        }
+    };
+
     // Compute the rendered size of one SVG tile based on background-size.
     let (scaled_w, scaled_h) = match bg_size {
         BackgroundSize::Cover => {
@@ -1854,7 +1875,18 @@ fn render_svg_background(
             (vb_w * s, vb_h * s)
         }
         BackgroundSize::Auto => (vb_w, vb_h),
-        BackgroundSize::Explicit(w, h) => (*w, *h),
+        BackgroundSize::Explicit {
+            width: explicit_width,
+            height: explicit_height,
+            width_is_percent,
+            height_is_percent,
+        } => {
+            let scaled_w = resolve_axis(*explicit_width, *width_is_percent, width);
+            let scaled_h = explicit_height
+                .map(|value| resolve_axis(value, *height_is_percent, height))
+                .unwrap_or_else(|| scaled_w * vb_h / vb_w);
+            (scaled_w, scaled_h)
+        }
     };
 
     if scaled_w <= 0.0 || scaled_h <= 0.0 {
@@ -1900,7 +1932,20 @@ fn render_svg_background(
 
     // Clip to the element box.
     content.push_str("q\n");
-    content.push_str(&format!("{x} {y} {width} {height} re W n\n"));
+    if border_radius > 0.0 {
+        content.push_str(&rounded_rect_path(
+            clip_x,
+            clip_y,
+            clip_width,
+            clip_height,
+            border_radius,
+        ));
+        content.push_str("W n\n");
+    } else {
+        content.push_str(&format!(
+            "{clip_x} {clip_y} {clip_width} {clip_height} re W n\n"
+        ));
+    }
 
     let sx = scaled_w / vb_w;
     let sy = scaled_h / vb_h;
@@ -3938,6 +3983,7 @@ mod tests {
                     word_spacing: 0.0,
                     vertical_align: crate::style::computed::VerticalAlign::Baseline,
                     z_index: 0,
+                    repeat_on_each_page: false,
                     heading_level: None,
                 },
             )],
@@ -4008,6 +4054,7 @@ mod tests {
                         word_spacing: 0.0,
                         vertical_align: crate::style::computed::VerticalAlign::Baseline,
                         z_index: 0,
+                        repeat_on_each_page: false,
                         heading_level: None,
                     },
                 ),
@@ -4405,6 +4452,156 @@ mod tests {
         assert!(
             pdf_str.contains("W n"),
             "Should have clip operator for border-radius"
+        );
+    }
+
+    #[test]
+    fn svg_background_clipped_to_border_radius() {
+        let html = r#"<div style="width: 200pt; height: 80pt; border-radius: 12pt; background: url('data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%221%22 height=%221%22%3E%3Crect width=%221%22 height=%221%22 fill=%22red%22/%3E%3C/svg%3E') no-repeat"></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let pdf_str = String::from_utf8_lossy(&pdf);
+        assert!(
+            pdf_str.contains(" c\n"),
+            "Rounded clip should use Bezier curves"
+        );
+        assert!(pdf_str.contains("W n"), "SVG background should be clipped");
+    }
+
+    #[test]
+    fn svg_background_percent_size_uses_positioning_area() {
+        let tree = crate::parser::svg::SvgTree {
+            width: 1.0,
+            height: 1.0,
+            view_box: None,
+            children: vec![crate::parser::svg::SvgNode::Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 1.0,
+                height: 1.0,
+                rx: 0.0,
+                ry: 0.0,
+                style: crate::parser::svg::SvgStyle {
+                    fill: Some((1.0, 0.0, 0.0)),
+                    ..Default::default()
+                },
+            }],
+        };
+        let mut content = String::new();
+        render_svg_background(
+            &mut content,
+            &tree,
+            0.0,
+            0.0,
+            200.0,
+            100.0,
+            0.0,
+            0.0,
+            200.0,
+            100.0,
+            0.0,
+            &BackgroundSize::Explicit {
+                width: 50.0,
+                height: Some(25.0),
+                width_is_percent: true,
+                height_is_percent: true,
+            },
+            &BackgroundPosition::default(),
+            &BackgroundRepeat::NoRepeat,
+        );
+        assert!(
+            content.contains("100 0 0 25 0 0 cm"),
+            "Expected SVG tile scale to resolve against the 200pt by 100pt positioning area"
+        );
+    }
+
+    #[test]
+    fn svg_background_single_percent_size_preserves_aspect_ratio() {
+        let tree = crate::parser::svg::SvgTree {
+            width: 2.0,
+            height: 1.0,
+            view_box: None,
+            children: vec![crate::parser::svg::SvgNode::Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 2.0,
+                height: 1.0,
+                rx: 0.0,
+                ry: 0.0,
+                style: crate::parser::svg::SvgStyle {
+                    fill: Some((1.0, 0.0, 0.0)),
+                    ..Default::default()
+                },
+            }],
+        };
+        let mut content = String::new();
+        render_svg_background(
+            &mut content,
+            &tree,
+            0.0,
+            0.0,
+            200.0,
+            100.0,
+            0.0,
+            0.0,
+            200.0,
+            100.0,
+            0.0,
+            &BackgroundSize::Explicit {
+                width: 50.0,
+                height: None,
+                width_is_percent: true,
+                height_is_percent: false,
+            },
+            &BackgroundPosition::default(),
+            &BackgroundRepeat::NoRepeat,
+        );
+        assert!(
+            content.contains("50 0 0 50 0 0 cm"),
+            "Single-value background-size should preserve intrinsic aspect ratio"
+        );
+    }
+
+    #[test]
+    fn svg_background_uses_outer_clip_box() {
+        let tree = crate::parser::svg::SvgTree {
+            width: 1.0,
+            height: 1.0,
+            view_box: None,
+            children: vec![crate::parser::svg::SvgNode::Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 1.0,
+                height: 1.0,
+                rx: 0.0,
+                ry: 0.0,
+                style: crate::parser::svg::SvgStyle {
+                    fill: Some((1.0, 0.0, 0.0)),
+                    ..Default::default()
+                },
+            }],
+        };
+        let mut content = String::new();
+        render_svg_background(
+            &mut content,
+            &tree,
+            20.0,
+            10.0,
+            160.0,
+            80.0,
+            0.0,
+            0.0,
+            200.0,
+            100.0,
+            0.0,
+            &BackgroundSize::Auto,
+            &BackgroundPosition::default(),
+            &BackgroundRepeat::NoRepeat,
+        );
+        assert!(
+            content.contains("0 0 200 100 re W n"),
+            "Clip box should stay on the outer element box, not shrink to the origin box"
         );
     }
 
@@ -5116,6 +5313,7 @@ mod tests {
                     word_spacing: 0.0,
                     vertical_align: crate::style::computed::VerticalAlign::Baseline,
                     z_index: 0,
+                    repeat_on_each_page: false,
                     heading_level: None,
                 },
             )],

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -4,8 +4,8 @@ use crate::layout::engine::{
 };
 use crate::parser::ttf::TtfFont;
 use crate::style::computed::{
-    BackgroundPosition, BackgroundRepeat, BackgroundSize, BorderCollapse, Float, FontFamily,
-    LinearGradient, Position, RadialGradient, TextAlign,
+    BackgroundOrigin, BackgroundPosition, BackgroundRepeat, BackgroundSize, BorderCollapse, Float,
+    FontFamily, LinearGradient, Position, RadialGradient, TextAlign,
 };
 use crate::types::{Margin, PageSize};
 use std::collections::HashMap;
@@ -148,6 +148,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     background_size,
                     background_position,
                     background_repeat,
+                    background_origin,
                     border_radius,
                     outline_width,
                     outline_color,
@@ -389,13 +390,31 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             None => content_h,
                         };
                         let bg_y = block_y - total_h;
+                        // Adjust reference box based on background-origin
+                        let (ref_x, ref_y, ref_w, ref_h) = match background_origin {
+                            BackgroundOrigin::BorderBox => (
+                                block_x - border.left.width,
+                                bg_y - border.bottom.width,
+                                render_width + border.left.width + border.right.width,
+                                total_h + border.top.width + border.bottom.width,
+                            ),
+                            BackgroundOrigin::ContentBox => (
+                                block_x + padding_left,
+                                bg_y + padding_bottom,
+                                (render_width - padding_left - padding_right).max(0.0),
+                                (total_h - padding_top - padding_bottom).max(0.0),
+                            ),
+                            BackgroundOrigin::PaddingBox => {
+                                (block_x, bg_y, render_width, total_h)
+                            }
+                        };
                         render_svg_background(
                             &mut content,
                             svg_tree,
-                            block_x,
-                            bg_y,
-                            render_width,
-                            total_h,
+                            ref_x,
+                            ref_y,
+                            ref_w,
+                            ref_h,
                             background_size,
                             background_position,
                             background_repeat,
@@ -881,7 +900,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     padding_top,
                     padding_bottom,
                     padding_left,
-                    padding_right: _,
+                    padding_right,
                     border,
                     border_radius,
                     box_shadow,
@@ -891,6 +910,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     background_size: flex_bg_size,
                     background_position: flex_bg_pos,
                     background_repeat: flex_bg_repeat,
+                    background_origin: flex_bg_origin,
                     ..
                 } => {
                     let row_y = page_size.height - margin.top - y_pos;
@@ -998,13 +1018,31 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     if let Some(svg_tree) = background_svg {
                         let bg_x = margin.left;
                         let bg_y = row_y - full_height;
+                        // Adjust reference box based on background-origin
+                        let (ref_x, ref_y, ref_w, ref_h) = match flex_bg_origin {
+                            BackgroundOrigin::BorderBox => (
+                                bg_x - border.left.width,
+                                bg_y - border.bottom.width,
+                                *container_width + border.left.width + border.right.width,
+                                full_height + border.top.width + border.bottom.width,
+                            ),
+                            BackgroundOrigin::ContentBox => (
+                                bg_x + padding_left,
+                                bg_y + padding_bottom,
+                                (*container_width - padding_left - padding_right).max(0.0),
+                                (full_height - padding_top - padding_bottom).max(0.0),
+                            ),
+                            BackgroundOrigin::PaddingBox => {
+                                (bg_x, bg_y, *container_width, full_height)
+                            }
+                        };
                         render_svg_background(
                             &mut content,
                             svg_tree,
-                            bg_x,
-                            bg_y,
-                            *container_width,
-                            full_height,
+                            ref_x,
+                            ref_y,
+                            ref_w,
+                            ref_h,
                             flex_bg_size,
                             flex_bg_pos,
                             flex_bg_repeat,
@@ -3891,6 +3929,7 @@ mod tests {
                     background_size: BackgroundSize::Auto,
                     background_position: BackgroundPosition::default(),
                     background_repeat: BackgroundRepeat::Repeat,
+                    background_origin: BackgroundOrigin::PaddingBox,
                     border_radius: 0.0,
                     outline_width: 0.0,
                     outline_color: None,
@@ -3960,6 +3999,7 @@ mod tests {
                         background_size: BackgroundSize::Auto,
                         background_position: BackgroundPosition::default(),
                         background_repeat: BackgroundRepeat::Repeat,
+                        background_origin: BackgroundOrigin::PaddingBox,
                         border_radius: 0.0,
                         outline_width: 0.0,
                         outline_color: None,
@@ -5067,6 +5107,7 @@ mod tests {
                     background_size: BackgroundSize::Auto,
                     background_position: BackgroundPosition::default(),
                     background_repeat: BackgroundRepeat::Repeat,
+                    background_origin: BackgroundOrigin::PaddingBox,
                     border_radius: 0.0,
                     outline_width: 0.0,
                     outline_color: None,

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1214,6 +1214,38 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             }
                         }
 
+                        if let Some(svg_tree) = &cell.background_svg {
+                            let bg_x = margin.left + padding_left + cell.x_offset;
+                            let bg_y = text_area_top - row_height;
+                            let (ref_x, ref_y, ref_w, ref_h) = match cell.background_origin {
+                                BackgroundOrigin::ContentBox => (
+                                    bg_x + cell.padding_left,
+                                    bg_y + cell.padding_bottom,
+                                    (cell.width - cell.padding_left - cell.padding_right).max(0.0),
+                                    (row_height - cell.padding_top - cell.padding_bottom).max(0.0),
+                                ),
+                                BackgroundOrigin::BorderBox | BackgroundOrigin::PaddingBox => {
+                                    (bg_x, bg_y, cell.width, *row_height)
+                                }
+                            };
+                            render_svg_background(
+                                &mut content,
+                                svg_tree,
+                                ref_x,
+                                ref_y,
+                                ref_w,
+                                ref_h,
+                                bg_x,
+                                bg_y,
+                                cell.width,
+                                *row_height,
+                                cell.border_radius,
+                                &cell.background_size,
+                                &cell.background_position,
+                                &cell.background_repeat,
+                            );
+                        }
+
                         // Render cell text
                         let mut text_y = text_area_top - cell.padding_top;
                         for line in &cell.lines {

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1745,7 +1745,9 @@ fn merge_runs(runs: &[TextRun]) -> Vec<TextRun> {
             false
         };
         if can_merge {
-            merged.last_mut().unwrap().text.push_str(&run.text);
+            if let Some(previous) = merged.last_mut() {
+                previous.text.push_str(&run.text);
+            }
         } else {
             merged.push(run.clone());
         }
@@ -1856,9 +1858,6 @@ fn render_radial_gradient(
     content.push_str("Q\n");
 }
 
-/// Render an SVG tree as a background behind content.
-///
-/// Supports CSS `background-size`, `background-position`, and `background-repeat`.
 fn render_svg_background(
     content: &mut String,
     tree: &crate::parser::svg::SvgTree,

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -143,6 +143,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     transform,
                     background_gradient,
                     background_radial_gradient,
+                    background_svg,
                     border_radius,
                     outline_width,
                     outline_color,
@@ -373,6 +374,25 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                         if *border_radius > 0.0 {
                             content.push_str("Q\n");
                         }
+                    }
+
+                    // Draw SVG background image if specified
+                    if let Some(svg_tree) = background_svg {
+                        let text_height: f32 = lines.iter().map(|l| l.height).sum();
+                        let content_h = padding_top + text_height + padding_bottom;
+                        let total_h = match block_height {
+                            Some(h) => content_h.max(*h),
+                            None => content_h,
+                        };
+                        let bg_y = block_y - total_h;
+                        render_svg_background(
+                            &mut content,
+                            svg_tree,
+                            block_x,
+                            bg_y,
+                            render_width,
+                            total_h,
+                        );
                     }
 
                     // Draw border if specified
@@ -860,6 +880,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     box_shadow,
                     background_gradient,
                     background_radial_gradient,
+                    background_svg,
                     ..
                 } => {
                     let row_y = page_size.height - margin.top - y_pos;
@@ -961,6 +982,20 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                         if *border_radius > 0.0 {
                             content.push_str("Q\n");
                         }
+                    }
+
+                    // Draw SVG background image for flex container
+                    if let Some(svg_tree) = background_svg {
+                        let bg_x = margin.left;
+                        let bg_y = row_y - full_height;
+                        render_svg_background(
+                            &mut content,
+                            svg_tree,
+                            bg_x,
+                            bg_y,
+                            *container_width,
+                            full_height,
+                        );
                     }
 
                     // Draw border
@@ -1727,6 +1762,56 @@ fn render_radial_gradient(
     content.push_str("q\n");
     content.push_str(&format!("{x} {y} {width} {height} re W n\n"));
     content.push_str(&format!("/{name} sh\n"));
+    content.push_str("Q\n");
+}
+
+/// Render an SVG tree as a background behind content.
+///
+/// The SVG is scaled to cover the given rectangle (respecting aspect ratio
+/// for `background-size: cover` semantics) and clipped to the box.
+fn render_svg_background(
+    content: &mut String,
+    tree: &crate::parser::svg::SvgTree,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+) {
+    if tree.width <= 0.0 || tree.height <= 0.0 {
+        return;
+    }
+
+    let (vb_w, vb_h) = if let Some(ref vb) = tree.view_box {
+        (vb.width, vb.height)
+    } else {
+        (tree.width, tree.height)
+    };
+    if vb_w <= 0.0 || vb_h <= 0.0 {
+        return;
+    }
+
+    // Render SVG background at natural size, positioned at top-left per CSS defaults
+    // (background-size: auto, background-position: 0% 0%, background-repeat: repeat).
+    // Currently stretches to fill the element box (no repeat).
+    // TODO: wire background_size, background_position, background_repeat from
+    // ComputedStyle through LayoutElement to support the full CSS spec.
+    let sx = width / vb_w;
+    let sy = height / vb_h;
+
+    content.push_str("q\n");
+    // Clip to the target rectangle
+    content.push_str(&format!("{x} {y} {width} {height} re W n\n"));
+    // Position at top-left, flip y-axis (SVG is top-down, PDF is bottom-up)
+    content.push_str(&format!("1 0 0 -1 {} {} cm\n", x, y + height));
+    // Scale to fill element box
+    content.push_str(&format!("{sx} 0 0 {sy} 0 0 cm\n"));
+    // Offset for viewBox origin
+    if let Some(ref vb) = tree.view_box {
+        if vb.min_x != 0.0 || vb.min_y != 0.0 {
+            content.push_str(&format!("1 0 0 1 {} {} cm\n", -vb.min_x, -vb.min_y));
+        }
+    }
+    crate::render::svg_to_pdf::render_svg_tree(tree, content);
     content.push_str("Q\n");
 }
 
@@ -3701,6 +3786,7 @@ mod tests {
                     transform: None,
                     background_gradient: None,
                     background_radial_gradient: None,
+                    background_svg: None,
                     border_radius: 0.0,
                     outline_width: 0.0,
                     outline_color: None,
@@ -3766,6 +3852,7 @@ mod tests {
                         transform: None,
                         background_gradient: None,
                         background_radial_gradient: None,
+                        background_svg: None,
                         border_radius: 0.0,
                         outline_width: 0.0,
                         outline_color: None,
@@ -4869,6 +4956,7 @@ mod tests {
                     transform: None,
                     background_gradient: None,
                     background_radial_gradient: None,
+                    background_svg: None,
                     border_radius: 0.0,
                     outline_width: 0.0,
                     outline_color: None,

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -4,7 +4,8 @@ use crate::layout::engine::{
 };
 use crate::parser::ttf::TtfFont;
 use crate::style::computed::{
-    BorderCollapse, Float, FontFamily, LinearGradient, Position, RadialGradient, TextAlign,
+    BackgroundPosition, BackgroundRepeat, BackgroundSize, BorderCollapse, Float, FontFamily,
+    LinearGradient, Position, RadialGradient, TextAlign,
 };
 use crate::types::{Margin, PageSize};
 use std::collections::HashMap;
@@ -144,6 +145,9 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     background_gradient,
                     background_radial_gradient,
                     background_svg,
+                    background_size,
+                    background_position,
+                    background_repeat,
                     border_radius,
                     outline_width,
                     outline_color,
@@ -392,6 +396,9 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             bg_y,
                             render_width,
                             total_h,
+                            background_size,
+                            background_position,
+                            background_repeat,
                         );
                     }
 
@@ -881,6 +888,9 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     background_gradient,
                     background_radial_gradient,
                     background_svg,
+                    background_size: flex_bg_size,
+                    background_position: flex_bg_pos,
+                    background_repeat: flex_bg_repeat,
                     ..
                 } => {
                     let row_y = page_size.height - margin.top - y_pos;
@@ -995,6 +1005,9 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             bg_y,
                             *container_width,
                             full_height,
+                            flex_bg_size,
+                            flex_bg_pos,
+                            flex_bg_repeat,
                         );
                     }
 
@@ -1767,8 +1780,7 @@ fn render_radial_gradient(
 
 /// Render an SVG tree as a background behind content.
 ///
-/// The SVG is scaled to cover the given rectangle (respecting aspect ratio
-/// for `background-size: cover` semantics) and clipped to the box.
+/// Supports CSS `background-size`, `background-position`, and `background-repeat`.
 fn render_svg_background(
     content: &mut String,
     tree: &crate::parser::svg::SvgTree,
@@ -1776,6 +1788,9 @@ fn render_svg_background(
     y: f32,
     width: f32,
     height: f32,
+    bg_size: &BackgroundSize,
+    bg_pos: &BackgroundPosition,
+    bg_repeat: &BackgroundRepeat,
 ) {
     if tree.width <= 0.0 || tree.height <= 0.0 {
         return;
@@ -1790,29 +1805,115 @@ fn render_svg_background(
         return;
     }
 
-    // Render SVG background at natural size, positioned at top-left per CSS defaults
-    // (background-size: auto, background-position: 0% 0%, background-repeat: repeat).
-    // Currently stretches to fill the element box (no repeat).
-    // TODO: wire background_size, background_position, background_repeat from
-    // ComputedStyle through LayoutElement to support the full CSS spec.
-    let sx = width / vb_w;
-    let sy = height / vb_h;
+    // Compute the rendered size of one SVG tile based on background-size.
+    let (scaled_w, scaled_h) = match bg_size {
+        BackgroundSize::Cover => {
+            let s = (width / vb_w).max(height / vb_h);
+            (vb_w * s, vb_h * s)
+        }
+        BackgroundSize::Contain => {
+            let s = (width / vb_w).min(height / vb_h);
+            (vb_w * s, vb_h * s)
+        }
+        BackgroundSize::Auto => (vb_w, vb_h),
+        BackgroundSize::Explicit(w, h) => (*w, *h),
+    };
 
-    content.push_str("q\n");
-    // Clip to the target rectangle
-    content.push_str(&format!("{x} {y} {width} {height} re W n\n"));
-    // Position at top-left, flip y-axis (SVG is top-down, PDF is bottom-up)
-    content.push_str(&format!("1 0 0 -1 {} {} cm\n", x, y + height));
-    // Scale to fill element box
-    content.push_str(&format!("{sx} 0 0 {sy} 0 0 cm\n"));
-    // Offset for viewBox origin
-    if let Some(ref vb) = tree.view_box {
-        if vb.min_x != 0.0 || vb.min_y != 0.0 {
-            content.push_str(&format!("1 0 0 1 {} {} cm\n", -vb.min_x, -vb.min_y));
+    if scaled_w <= 0.0 || scaled_h <= 0.0 {
+        return;
+    }
+
+    // Compute background-position offset (in the CSS coordinate system,
+    // origin at top-left of the element box).
+    let offset_x = if bg_pos.x_is_percent {
+        (width - scaled_w) * bg_pos.x
+    } else {
+        bg_pos.x
+    };
+    let offset_y = if bg_pos.y_is_percent {
+        (height - scaled_h) * bg_pos.y
+    } else {
+        bg_pos.y
+    };
+
+    // Determine tiling grid based on background-repeat.
+    // We compute the set of tile origin offsets (in CSS coords, top-left = 0,0).
+    let tiles_x: Vec<f32>;
+    let tiles_y: Vec<f32>;
+
+    match bg_repeat {
+        BackgroundRepeat::NoRepeat => {
+            tiles_x = vec![offset_x];
+            tiles_y = vec![offset_y];
+        }
+        BackgroundRepeat::Repeat => {
+            tiles_x = tile_offsets(offset_x, scaled_w, width);
+            tiles_y = tile_offsets(offset_y, scaled_h, height);
+        }
+        BackgroundRepeat::RepeatX => {
+            tiles_x = tile_offsets(offset_x, scaled_w, width);
+            tiles_y = vec![offset_y];
+        }
+        BackgroundRepeat::RepeatY => {
+            tiles_x = vec![offset_x];
+            tiles_y = tile_offsets(offset_y, scaled_h, height);
         }
     }
-    crate::render::svg_to_pdf::render_svg_tree(tree, content);
+
+    // Clip to the element box.
+    content.push_str("q\n");
+    content.push_str(&format!("{x} {y} {width} {height} re W n\n"));
+
+    let sx = scaled_w / vb_w;
+    let sy = scaled_h / vb_h;
+
+    for &ty in &tiles_y {
+        for &tx in &tiles_x {
+            content.push_str("q\n");
+            // Position: PDF y-axis is bottom-up, SVG is top-down.
+            // `y` is the PDF bottom of the box, `y + height` is the PDF top.
+            // A CSS offset (tx, ty) from the top-left maps to PDF:
+            //   pdf_x = x + tx
+            //   pdf_y = (y + height) - ty   (top of box minus CSS-y offset)
+            // Then we flip y for SVG rendering.
+            let pdf_x = x + tx;
+            let pdf_top = y + height - ty;
+            content.push_str(&format!("1 0 0 -1 {pdf_x} {pdf_top} cm\n"));
+            content.push_str(&format!("{sx} 0 0 {sy} 0 0 cm\n"));
+            if let Some(ref vb) = tree.view_box {
+                if vb.min_x != 0.0 || vb.min_y != 0.0 {
+                    content.push_str(&format!("1 0 0 1 {} {} cm\n", -vb.min_x, -vb.min_y));
+                }
+            }
+            crate::render::svg_to_pdf::render_svg_tree(tree, content);
+            content.push_str("Q\n");
+        }
+    }
     content.push_str("Q\n");
+}
+
+/// Compute tile origin offsets that cover `[0, extent)` when starting from
+/// `origin` and repeating every `step`.  Returns offsets that overlap the
+/// visible range.
+fn tile_offsets(origin: f32, step: f32, extent: f32) -> Vec<f32> {
+    if step <= 0.0 {
+        return vec![origin];
+    }
+    let mut offsets = Vec::new();
+    // Walk backwards from origin to find the first tile that overlaps [0, extent).
+    let mut start = origin;
+    while start > 0.0 {
+        start -= step;
+    }
+    let mut pos = start;
+    while pos < extent {
+        offsets.push(pos);
+        pos += step;
+    }
+    if offsets.is_empty() {
+        offsets.push(origin);
+    }
+    offsets
 }
 
 /// Build an inline PDF Function dictionary string for a gradient's color stops.
@@ -3787,6 +3888,9 @@ mod tests {
                     background_gradient: None,
                     background_radial_gradient: None,
                     background_svg: None,
+                    background_size: BackgroundSize::Auto,
+                    background_position: BackgroundPosition::default(),
+                    background_repeat: BackgroundRepeat::Repeat,
                     border_radius: 0.0,
                     outline_width: 0.0,
                     outline_color: None,
@@ -3853,6 +3957,9 @@ mod tests {
                         background_gradient: None,
                         background_radial_gradient: None,
                         background_svg: None,
+                        background_size: BackgroundSize::Auto,
+                        background_position: BackgroundPosition::default(),
+                        background_repeat: BackgroundRepeat::Repeat,
                         border_radius: 0.0,
                         outline_width: 0.0,
                         outline_color: None,
@@ -4957,6 +5064,9 @@ mod tests {
                     background_gradient: None,
                     background_radial_gradient: None,
                     background_svg: None,
+                    background_size: BackgroundSize::Auto,
+                    background_position: BackgroundPosition::default(),
+                    background_repeat: BackgroundRepeat::Repeat,
                     border_radius: 0.0,
                     outline_width: 0.0,
                     outline_color: None,

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -1000,10 +1000,18 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
         style.background_color = Some(*c);
     }
 
+    if get_non_special(map, "background-image").is_some() {
+        style.background_gradient = None;
+        style.background_radial_gradient = None;
+        style.background_svg = None;
+    }
+
     // Linear gradient (from background or background-image)
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-gradient") {
         if let Some(lg) = parse_linear_gradient(k) {
             style.background_gradient = Some(lg);
+            style.background_radial_gradient = None;
+            style.background_svg = None;
         }
     }
 
@@ -1011,6 +1019,8 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-radial-gradient") {
         if let Some(rg) = parse_radial_gradient(k) {
             style.background_radial_gradient = Some(rg);
+            style.background_gradient = None;
+            style.background_svg = None;
         }
     }
 
@@ -1018,6 +1028,8 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-svg") {
         if let Some(tree) = crate::parser::svg::parse_svg_from_string(k) {
             style.background_svg = Some(tree);
+            style.background_gradient = None;
+            style.background_radial_gradient = None;
         }
     }
 
@@ -5747,6 +5759,51 @@ mod tests {
         assert!(parent.background_svg.is_some());
         let s = compute_style(HtmlTag::Div, Some("background-image: inherit"), &parent);
         assert!(s.background_svg.is_some());
+    }
+
+    #[test]
+    fn background_image_none_clears_existing_svg_background() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(
+            HtmlTag::Div,
+            Some(
+                r#"background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"); background-image: none"#,
+            ),
+            &parent,
+        );
+        assert!(style.background_svg.is_none());
+        assert!(style.background_gradient.is_none());
+        assert!(style.background_radial_gradient.is_none());
+    }
+
+    #[test]
+    fn background_none_clears_existing_svg_background() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(
+            HtmlTag::Div,
+            Some(
+                r#"background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"); background: none"#,
+            ),
+            &parent,
+        );
+        assert!(style.background_svg.is_none());
+        assert!(style.background_gradient.is_none());
+        assert!(style.background_radial_gradient.is_none());
+    }
+
+    #[test]
+    fn background_image_url_clears_existing_svg_background() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(
+            HtmlTag::Div,
+            Some(
+                r#"background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"); background-image: url("data:image/png;base64,AAAA")"#,
+            ),
+            &parent,
+        );
+        assert!(style.background_svg.is_none());
+        assert!(style.background_gradient.is_none());
+        assert!(style.background_radial_gradient.is_none());
     }
 
     #[test]

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -782,6 +782,9 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
         "background-repeat" => style.background_repeat = default.background_repeat,
         "background-position" => style.background_position = default.background_position,
         "background-origin" => style.background_origin = default.background_origin,
+        "background-image" | "background" | "background-svg" => {
+            style.background_svg = default.background_svg.clone()
+        }
         "list-style-type" => style.list_style_type = default.list_style_type,
         "list-style-position" => style.list_style_position = default.list_style_position,
         "content" => style.content = default.content,
@@ -862,6 +865,9 @@ fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &Compu
         "background-repeat" => style.background_repeat = parent.background_repeat,
         "background-position" => style.background_position = parent.background_position,
         "background-origin" => style.background_origin = parent.background_origin,
+        "background-image" | "background" | "background-svg" => {
+            style.background_svg = parent.background_svg.clone()
+        }
         "list-style-type" => style.list_style_type = parent.list_style_type,
         "list-style-position" => style.list_style_position = parent.list_style_position,
         "content" => style.content = parent.content.clone(),
@@ -5707,6 +5713,17 @@ mod tests {
         };
         let s = compute_style(HtmlTag::Div, Some("background-position: inherit"), &parent);
         assert_eq!(s.background_position, parent.background_position);
+    }
+
+    #[test]
+    fn inherit_keyword_restores_background_svg() {
+        let mut parent = ComputedStyle::default();
+        parent.background_svg = crate::parser::svg::parse_svg_from_string(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>"#,
+        );
+        assert!(parent.background_svg.is_some());
+        let s = compute_style(HtmlTag::Div, Some("background-image: inherit"), &parent);
+        assert!(s.background_svg.is_some());
     }
 
     #[test]

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -5895,40 +5895,6 @@ mod tests {
     }
 
     #[test]
-    fn background_image_initial_preserves_existing_background_color() {
-        let style = compute_style(
-            HtmlTag::Div,
-            Some("background-color: red; background-image: initial"),
-            &ComputedStyle::default(),
-        );
-        assert_eq!(
-            style.background_color.map(|c| (c.r, c.g, c.b, c.a)),
-            Some((255, 0, 0, 255))
-        );
-        assert!(style.background_svg.is_none());
-        assert!(style.background_gradient.is_none());
-        assert!(style.background_radial_gradient.is_none());
-    }
-
-    #[test]
-    fn background_image_inherit_preserves_child_background_color() {
-        let mut parent = ComputedStyle::default();
-        parent.background_svg = crate::parser::svg::parse_svg_from_string(
-            r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>"#,
-        );
-        let style = compute_style(
-            HtmlTag::Div,
-            Some("background-color: blue; background-image: inherit"),
-            &parent,
-        );
-        assert_eq!(
-            style.background_color.map(|c| (c.r, c.g, c.b, c.a)),
-            Some((0, 0, 255, 255))
-        );
-        assert!(style.background_svg.is_some());
-    }
-
-    #[test]
     fn background_initial_resets_all_background_state() {
         let style = compute_style(
             HtmlTag::Div,

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -556,11 +556,15 @@ impl ComputedStyle {
         self.background_origin = BackgroundOrigin::PaddingBox;
     }
 
-    fn inherit_background(&mut self, source: &ComputedStyle) {
-        self.background_color = source.background_color;
+    fn inherit_background_image(&mut self, source: &ComputedStyle) {
         self.background_gradient = source.background_gradient.clone();
         self.background_radial_gradient = source.background_radial_gradient.clone();
         self.background_svg = source.background_svg.clone();
+    }
+
+    fn inherit_background(&mut self, source: &ComputedStyle) {
+        self.background_color = source.background_color;
+        self.inherit_background_image(source);
         self.background_size = source.background_size;
         self.background_repeat = source.background_repeat;
         self.background_position = source.background_position;
@@ -811,7 +815,8 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
         "background-repeat" => style.background_repeat = default.background_repeat,
         "background-position" => style.background_position = default.background_position,
         "background-origin" => style.background_origin = default.background_origin,
-        "background-image" | "background" | "background-svg" => style.reset_background(),
+        "background-image" | "background-svg" => style.clear_background_images(),
+        "background" => style.reset_background(),
         "list-style-type" => style.list_style_type = default.list_style_type,
         "list-style-position" => style.list_style_position = default.list_style_position,
         "content" => style.content = default.content,
@@ -892,7 +897,8 @@ fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &Compu
         "background-repeat" => style.background_repeat = parent.background_repeat,
         "background-position" => style.background_position = parent.background_position,
         "background-origin" => style.background_origin = parent.background_origin,
-        "background-image" | "background" | "background-svg" => style.inherit_background(parent),
+        "background-image" | "background-svg" => style.inherit_background_image(parent),
+        "background" => style.inherit_background(parent),
         "list-style-type" => style.list_style_type = parent.list_style_type,
         "list-style-position" => style.list_style_position = parent.list_style_position,
         "content" => style.content = parent.content.clone(),
@@ -5777,6 +5783,73 @@ mod tests {
     }
 
     #[test]
+    fn background_image_initial_clears_only_image_layers() {
+        let style = compute_style(
+            HtmlTag::Div,
+            Some(
+                r#"background-color: red; background-repeat: no-repeat; background-size: cover; background-position: center; background-origin: content-box; background-image: initial"#,
+            ),
+            &ComputedStyle::default(),
+        );
+
+        assert_eq!(
+            style.background_color.map(|c| (c.r, c.g, c.b, c.a)),
+            Some((255, 0, 0, 255))
+        );
+        assert_eq!(style.background_repeat, BackgroundRepeat::NoRepeat);
+        assert_eq!(style.background_size, BackgroundSize::Cover);
+        assert_eq!(
+            style.background_position,
+            BackgroundPosition {
+                x: 0.5,
+                y: 0.5,
+                x_is_percent: true,
+                y_is_percent: true,
+            }
+        );
+        assert_eq!(style.background_origin, BackgroundOrigin::ContentBox);
+        assert!(style.background_svg.is_none());
+        assert!(style.background_gradient.is_none());
+        assert!(style.background_radial_gradient.is_none());
+    }
+
+    #[test]
+    fn background_image_inherit_restores_only_image_layers() {
+        let mut parent = ComputedStyle::default();
+        parent.background_color = Some(Color::rgb(10, 20, 30));
+        parent.background_repeat = BackgroundRepeat::NoRepeat;
+        parent.background_size = BackgroundSize::Cover;
+        parent.background_position = BackgroundPosition {
+            x: 0.25,
+            y: 0.75,
+            x_is_percent: true,
+            y_is_percent: true,
+        };
+        parent.background_origin = BackgroundOrigin::ContentBox;
+        parent.background_svg = crate::parser::svg::parse_svg_from_string(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>"#,
+        );
+
+        let style = compute_style(
+            HtmlTag::Div,
+            Some("background-color: red; background-repeat: repeat-x; background-image: inherit"),
+            &parent,
+        );
+
+        assert_eq!(
+            style.background_color.map(|c| (c.r, c.g, c.b, c.a)),
+            Some((255, 0, 0, 255))
+        );
+        assert_eq!(style.background_repeat, BackgroundRepeat::RepeatX);
+        assert_eq!(style.background_size, BackgroundSize::Auto);
+        assert_eq!(style.background_position, BackgroundPosition::default());
+        assert_eq!(style.background_origin, BackgroundOrigin::PaddingBox);
+        assert!(style.background_svg.is_some());
+        assert!(style.background_gradient.is_none());
+        assert!(style.background_radial_gradient.is_none());
+    }
+
+    #[test]
     fn background_image_none_clears_existing_svg_background() {
         let parent = ComputedStyle::default();
         let style = compute_style(
@@ -5819,6 +5892,40 @@ mod tests {
         assert!(style.background_svg.is_none());
         assert!(style.background_gradient.is_none());
         assert!(style.background_radial_gradient.is_none());
+    }
+
+    #[test]
+    fn background_image_initial_preserves_existing_background_color() {
+        let style = compute_style(
+            HtmlTag::Div,
+            Some("background-color: red; background-image: initial"),
+            &ComputedStyle::default(),
+        );
+        assert_eq!(
+            style.background_color.map(|c| (c.r, c.g, c.b, c.a)),
+            Some((255, 0, 0, 255))
+        );
+        assert!(style.background_svg.is_none());
+        assert!(style.background_gradient.is_none());
+        assert!(style.background_radial_gradient.is_none());
+    }
+
+    #[test]
+    fn background_image_inherit_preserves_child_background_color() {
+        let mut parent = ComputedStyle::default();
+        parent.background_svg = crate::parser::svg::parse_svg_from_string(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>"#,
+        );
+        let style = compute_style(
+            HtmlTag::Div,
+            Some("background-color: blue; background-image: inherit"),
+            &parent,
+        );
+        assert_eq!(
+            style.background_color.map(|c| (c.r, c.g, c.b, c.a)),
+            Some((0, 0, 255, 255))
+        );
+        assert!(style.background_svg.is_some());
     }
 
     #[test]

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -242,6 +242,14 @@ pub enum BorderCollapse {
     Separate,
     Collapse,
 }
+/// CSS background-origin property.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum BackgroundOrigin {
+    #[default]
+    PaddingBox,
+    BorderBox,
+    ContentBox,
+}
 /// CSS background-size property.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum BackgroundSize {
@@ -433,6 +441,7 @@ pub struct ComputedStyle {
     pub background_size: BackgroundSize,
     pub background_repeat: BackgroundRepeat,
     pub background_position: BackgroundPosition,
+    pub background_origin: BackgroundOrigin,
     /// CSS z-index (0 = auto).
     pub z_index: i32,
     /// CSS custom properties inherited from ancestors.
@@ -512,6 +521,7 @@ impl Default for ComputedStyle {
             background_size: BackgroundSize::Auto,
             background_repeat: BackgroundRepeat::Repeat,
             background_position: BackgroundPosition::default(),
+            background_origin: BackgroundOrigin::PaddingBox,
             z_index: 0,
             custom_properties: HashMap::new(),
             list_style_type: ListStyleType::Disc,
@@ -643,6 +653,7 @@ pub fn compute_style_with_context(
     style.background_size = BackgroundSize::Auto;
     style.background_repeat = BackgroundRepeat::Repeat;
     style.background_position = BackgroundPosition::default();
+    style.background_origin = BackgroundOrigin::PaddingBox;
     style.content = Vec::new();
     style.counter_reset = Vec::new();
     style.counter_increment = Vec::new();
@@ -770,6 +781,7 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
         "background-size" => style.background_size = default.background_size,
         "background-repeat" => style.background_repeat = default.background_repeat,
         "background-position" => style.background_position = default.background_position,
+        "background-origin" => style.background_origin = default.background_origin,
         "list-style-type" => style.list_style_type = default.list_style_type,
         "list-style-position" => style.list_style_position = default.list_style_position,
         "content" => style.content = default.content,
@@ -849,6 +861,7 @@ fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &Compu
         "background-size" => style.background_size = parent.background_size,
         "background-repeat" => style.background_repeat = parent.background_repeat,
         "background-position" => style.background_position = parent.background_position,
+        "background-origin" => style.background_origin = parent.background_origin,
         "list-style-type" => style.list_style_type = parent.list_style_type,
         "list-style-position" => style.list_style_position = parent.list_style_position,
         "content" => style.content = parent.content.clone(),
@@ -1490,6 +1503,13 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
         if let Some(pos) = parse_background_position(k) {
             style.background_position = pos;
         }
+    }
+    if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-origin") {
+        style.background_origin = match k.as_str() {
+            "border-box" => BackgroundOrigin::BorderBox,
+            "content-box" => BackgroundOrigin::ContentBox,
+            _ => BackgroundOrigin::PaddingBox,
+        };
     }
 
     // z-index

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -5841,6 +5841,40 @@ mod tests {
     }
 
     #[test]
+    fn background_shorthand_resets_omitted_longhands_from_previous_rule() {
+        let parent = ComputedStyle::default();
+        let prior_rule = CssRule {
+            selector: "div".to_string(),
+            declarations: crate::parser::css::parse_inline_style(
+                "background-repeat: no-repeat; background-position: center; background-origin: content-box; background-size: cover; background-color: red",
+            ),
+            pseudo_element: None,
+        };
+        let later_rule = CssRule {
+            selector: "div".to_string(),
+            declarations: crate::parser::css::parse_inline_style(
+                r#"background: url("data:image/png;base64,AAAA")"#,
+            ),
+            pseudo_element: None,
+        };
+        let style = compute_style_with_rules(
+            HtmlTag::Div,
+            None,
+            &parent,
+            &[prior_rule, later_rule],
+            "div",
+            &[],
+            None,
+        );
+
+        assert_eq!(style.background_repeat, BackgroundRepeat::Repeat);
+        assert_eq!(style.background_size, BackgroundSize::Auto);
+        assert_eq!(style.background_position, BackgroundPosition::default());
+        assert_eq!(style.background_origin, BackgroundOrigin::PaddingBox);
+        assert!(style.background_color.is_none());
+    }
+
+    #[test]
     fn inherit_keyword_restores_list_style_type() {
         let mut parent = ComputedStyle::default();
         parent.list_style_type = ListStyleType::Square;

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -5875,6 +5875,91 @@ mod tests {
     }
 
     #[test]
+    fn later_background_initial_rule_resets_previous_background_state() {
+        let parent = ComputedStyle::default();
+        let prior_rule = CssRule {
+            selector: "div".to_string(),
+            declarations: crate::parser::css::parse_inline_style(
+                r#"background: url("data:image/png;base64,AAAA") no-repeat center / cover content-box"#,
+            ),
+            pseudo_element: None,
+        };
+        let later_rule = CssRule {
+            selector: "div".to_string(),
+            declarations: crate::parser::css::parse_inline_style("background: initial"),
+            pseudo_element: None,
+        };
+        let style = compute_style_with_rules(
+            HtmlTag::Div,
+            None,
+            &parent,
+            &[prior_rule, later_rule],
+            "div",
+            &[],
+            None,
+        );
+
+        assert!(style.background_color.is_none());
+        assert!(style.background_svg.is_none());
+        assert!(style.background_gradient.is_none());
+        assert!(style.background_radial_gradient.is_none());
+        assert_eq!(style.background_size, BackgroundSize::Auto);
+        assert_eq!(style.background_repeat, BackgroundRepeat::Repeat);
+        assert_eq!(style.background_position, BackgroundPosition::default());
+        assert_eq!(style.background_origin, BackgroundOrigin::PaddingBox);
+    }
+
+    #[test]
+    fn later_background_inherit_rule_restores_parent_background_state() {
+        let mut parent = ComputedStyle::default();
+        parent.background_color = Some(Color::rgb(10, 20, 30));
+        parent.background_repeat = BackgroundRepeat::NoRepeat;
+        parent.background_size = BackgroundSize::Cover;
+        parent.background_position = BackgroundPosition {
+            x: 0.25,
+            y: 0.75,
+            x_is_percent: true,
+            y_is_percent: true,
+        };
+        parent.background_origin = BackgroundOrigin::ContentBox;
+        parent.background_svg = crate::parser::svg::parse_svg_from_string(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>"#,
+        );
+
+        let prior_rule = CssRule {
+            selector: "div".to_string(),
+            declarations: crate::parser::css::parse_inline_style(
+                r#"background: url("data:image/png;base64,AAAA") no-repeat center / cover content-box"#,
+            ),
+            pseudo_element: None,
+        };
+        let later_rule = CssRule {
+            selector: "div".to_string(),
+            declarations: crate::parser::css::parse_inline_style("background: inherit"),
+            pseudo_element: None,
+        };
+        let style = compute_style_with_rules(
+            HtmlTag::Div,
+            None,
+            &parent,
+            &[prior_rule, later_rule],
+            "div",
+            &[],
+            None,
+        );
+
+        assert_eq!(
+            style.background_color.map(|c| (c.r, c.g, c.b, c.a)),
+            parent.background_color.map(|c| (c.r, c.g, c.b, c.a))
+        );
+        assert_eq!(style.background_repeat, parent.background_repeat);
+        assert_eq!(style.background_size, parent.background_size);
+        assert_eq!(style.background_position, parent.background_position);
+        assert_eq!(style.background_origin, parent.background_origin);
+        assert!(style.background_svg.is_some());
+    }
+
+    #[test]
     fn inherit_keyword_restores_list_style_type() {
         let mut parent = ComputedStyle::default();
         parent.list_style_type = ListStyleType::Square;

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -257,7 +257,12 @@ pub enum BackgroundSize {
     Auto,
     Cover,
     Contain,
-    Explicit(f32, f32),
+    Explicit {
+        width: f32,
+        height: Option<f32>,
+        width_is_percent: bool,
+        height_is_percent: bool,
+    },
 }
 /// CSS background-repeat property.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -1813,26 +1818,36 @@ fn parse_counter_directive(raw: &str) -> Vec<(String, i32)> {
 
 fn parse_background_size_explicit(val: &str) -> Option<BackgroundSize> {
     let parts: Vec<&str> = val.split_whitespace().collect();
-    let pd = |s: &str| -> Option<f32> {
+    let parse_dimension = |s: &str| -> Option<(f32, bool)> {
         if let Some(n) = s.strip_suffix("px") {
-            n.parse::<f32>().ok().map(|v| v * 0.75)
+            n.parse::<f32>().ok().map(|v| (v * 0.75, false))
         } else if let Some(n) = s.strip_suffix("pt") {
-            n.parse::<f32>().ok()
+            n.parse::<f32>().ok().map(|v| (v, false))
         } else if let Some(n) = s.strip_suffix('%') {
-            n.parse::<f32>().ok()
+            n.parse::<f32>().ok().map(|v| (v, true))
         } else {
-            s.parse::<f32>().ok()
+            s.parse::<f32>().ok().map(|v| (v, false))
         }
     };
     match parts.len() {
         1 => {
-            let w = pd(parts[0])?;
-            Some(BackgroundSize::Explicit(w, w))
+            let (width, width_is_percent) = parse_dimension(parts[0])?;
+            Some(BackgroundSize::Explicit {
+                width,
+                height: None,
+                width_is_percent,
+                height_is_percent: false,
+            })
         }
         2 => {
-            let w = pd(parts[0])?;
-            let h = pd(parts[1])?;
-            Some(BackgroundSize::Explicit(w, h))
+            let (width, width_is_percent) = parse_dimension(parts[0])?;
+            let (height, height_is_percent) = parse_dimension(parts[1])?;
+            Some(BackgroundSize::Explicit {
+                width,
+                height: Some(height),
+                width_is_percent,
+                height_is_percent,
+            })
         }
         _ => None,
     }
@@ -5252,9 +5267,17 @@ mod tests {
     fn background_size_explicit_parsed() {
         let parent = ComputedStyle::default();
         let s = compute_style(HtmlTag::Div, Some("background-size: 100px 200px"), &parent);
-        if let BackgroundSize::Explicit(w, h) = s.background_size {
-            assert!((w - 75.0).abs() < 0.001); // 100px = 75pt
-            assert!((h - 150.0).abs() < 0.001); // 200px = 150pt
+        if let BackgroundSize::Explicit {
+            width,
+            height,
+            width_is_percent,
+            height_is_percent,
+        } = s.background_size
+        {
+            assert!(!width_is_percent);
+            assert!(!height_is_percent);
+            assert!((width - 75.0).abs() < 0.001); // 100px = 75pt
+            assert!((height.unwrap_or_default() - 150.0).abs() < 0.001); // 200px = 150pt
         } else {
             panic!(
                 "Expected BackgroundSize::Explicit, got {:?}",
@@ -6118,35 +6141,75 @@ mod tests {
     fn background_size_explicit_px() {
         let parent = ComputedStyle::default();
         let s = compute_style(HtmlTag::Div, Some("background-size: 100px"), &parent);
-        assert_eq!(s.background_size, BackgroundSize::Explicit(75.0, 75.0));
+        assert_eq!(
+            s.background_size,
+            BackgroundSize::Explicit {
+                width: 75.0,
+                height: None,
+                width_is_percent: false,
+                height_is_percent: false,
+            }
+        );
     }
 
     #[test]
     fn background_size_explicit_pt() {
         let parent = ComputedStyle::default();
         let s = compute_style(HtmlTag::Div, Some("background-size: 50pt"), &parent);
-        assert_eq!(s.background_size, BackgroundSize::Explicit(50.0, 50.0));
+        assert_eq!(
+            s.background_size,
+            BackgroundSize::Explicit {
+                width: 50.0,
+                height: None,
+                width_is_percent: false,
+                height_is_percent: false,
+            }
+        );
     }
 
     #[test]
     fn background_size_explicit_percent() {
         let parent = ComputedStyle::default();
         let s = compute_style(HtmlTag::Div, Some("background-size: 50%"), &parent);
-        assert_eq!(s.background_size, BackgroundSize::Explicit(50.0, 50.0));
+        assert_eq!(
+            s.background_size,
+            BackgroundSize::Explicit {
+                width: 50.0,
+                height: None,
+                width_is_percent: true,
+                height_is_percent: false,
+            }
+        );
     }
 
     #[test]
     fn background_size_explicit_bare_number() {
         let parent = ComputedStyle::default();
         let s = compute_style(HtmlTag::Div, Some("background-size: 42"), &parent);
-        assert_eq!(s.background_size, BackgroundSize::Explicit(42.0, 42.0));
+        assert_eq!(
+            s.background_size,
+            BackgroundSize::Explicit {
+                width: 42.0,
+                height: None,
+                width_is_percent: false,
+                height_is_percent: false,
+            }
+        );
     }
 
     #[test]
     fn background_size_explicit_two_values() {
         let parent = ComputedStyle::default();
         let s = compute_style(HtmlTag::Div, Some("background-size: 100px 200px"), &parent);
-        assert_eq!(s.background_size, BackgroundSize::Explicit(75.0, 150.0));
+        assert_eq!(
+            s.background_size,
+            BackgroundSize::Explicit {
+                width: 75.0,
+                height: Some(150.0),
+                width_is_percent: false,
+                height_is_percent: false,
+            }
+        );
     }
 
     #[test]

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -426,6 +426,7 @@ pub struct ComputedStyle {
     pub vertical_align: VerticalAlign,
     pub background_gradient: Option<LinearGradient>,
     pub background_radial_gradient: Option<RadialGradient>,
+    pub background_svg: Option<crate::parser::svg::SvgTree>,
     pub text_overflow: TextOverflow,
     pub border_collapse: BorderCollapse,
     pub border_spacing: f32,
@@ -504,6 +505,7 @@ impl Default for ComputedStyle {
             vertical_align: VerticalAlign::Baseline,
             background_gradient: None,
             background_radial_gradient: None,
+            background_svg: None,
             text_overflow: TextOverflow::Clip,
             border_collapse: BorderCollapse::Separate,
             border_spacing: 0.0,
@@ -586,6 +588,7 @@ pub fn compute_style_with_context(
         style.background_color = None;
         style.background_gradient = None;
         style.background_radial_gradient = None;
+        style.background_svg = None;
     }
 
     // Reset non-inherited properties for inline elements too
@@ -594,6 +597,7 @@ pub fn compute_style_with_context(
         style.background_color = None;
         style.background_gradient = None;
         style.background_radial_gradient = None;
+        style.background_svg = None;
     }
 
     // Border does not inherit in CSS — reset for all elements
@@ -983,6 +987,13 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-radial-gradient") {
         if let Some(rg) = parse_radial_gradient(k) {
             style.background_radial_gradient = Some(rg);
+        }
+    }
+
+    // SVG background image (from data:image/svg+xml URI)
+    if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-svg") {
+        if let Some(tree) = crate::parser::svg::parse_svg_from_string(k) {
+            style.background_svg = Some(tree);
         }
     }
 

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -540,6 +540,34 @@ impl Default for ComputedStyle {
     }
 }
 
+impl ComputedStyle {
+    fn clear_background_images(&mut self) {
+        self.background_gradient = None;
+        self.background_radial_gradient = None;
+        self.background_svg = None;
+    }
+
+    fn reset_background(&mut self) {
+        self.background_color = None;
+        self.clear_background_images();
+        self.background_size = BackgroundSize::Auto;
+        self.background_repeat = BackgroundRepeat::Repeat;
+        self.background_position = BackgroundPosition::default();
+        self.background_origin = BackgroundOrigin::PaddingBox;
+    }
+
+    fn inherit_background(&mut self, source: &ComputedStyle) {
+        self.background_color = source.background_color;
+        self.background_gradient = source.background_gradient.clone();
+        self.background_radial_gradient = source.background_radial_gradient.clone();
+        self.background_svg = source.background_svg.clone();
+        self.background_size = source.background_size;
+        self.background_repeat = source.background_repeat;
+        self.background_position = source.background_position;
+        self.background_origin = source.background_origin;
+    }
+}
+
 /// Compute the style for a node given its tag, inline styles, and parent style.
 #[cfg(test)]
 pub fn compute_style(
@@ -601,18 +629,14 @@ pub fn compute_style_with_context(
         style.margin = EdgeSizes::default();
         style.padding = EdgeSizes::default();
         style.background_color = None;
-        style.background_gradient = None;
-        style.background_radial_gradient = None;
-        style.background_svg = None;
+        style.clear_background_images();
     }
 
     // Reset non-inherited properties for inline elements too
     // (background-color does not inherit in CSS)
     if !tag.is_block() {
         style.background_color = None;
-        style.background_gradient = None;
-        style.background_radial_gradient = None;
-        style.background_svg = None;
+        style.clear_background_images();
     }
 
     // Border does not inherit in CSS — reset for all elements
@@ -720,16 +744,6 @@ fn is_inherited_property(property: &str) -> bool {
 /// Reset a property to its initial (default) value on the given style.
 fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
     let default = ComputedStyle::default();
-    let reset_background = |style: &mut ComputedStyle, source: &ComputedStyle| {
-        style.background_color = source.background_color;
-        style.background_gradient = source.background_gradient.clone();
-        style.background_radial_gradient = source.background_radial_gradient.clone();
-        style.background_svg = source.background_svg.clone();
-        style.background_size = source.background_size;
-        style.background_repeat = source.background_repeat;
-        style.background_position = source.background_position;
-        style.background_origin = source.background_origin;
-    };
     match property {
         "color" => style.color = default.color,
         "font-size" => style.font_size = default.font_size,
@@ -797,7 +811,7 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
         "background-repeat" => style.background_repeat = default.background_repeat,
         "background-position" => style.background_position = default.background_position,
         "background-origin" => style.background_origin = default.background_origin,
-        "background-image" | "background" | "background-svg" => reset_background(style, &default),
+        "background-image" | "background" | "background-svg" => style.reset_background(),
         "list-style-type" => style.list_style_type = default.list_style_type,
         "list-style-position" => style.list_style_position = default.list_style_position,
         "content" => style.content = default.content,
@@ -811,16 +825,6 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
 
 /// Restore a property to the parent's value (inherit behavior).
 fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &ComputedStyle) {
-    let restore_background = |style: &mut ComputedStyle, source: &ComputedStyle| {
-        style.background_color = source.background_color;
-        style.background_gradient = source.background_gradient.clone();
-        style.background_radial_gradient = source.background_radial_gradient.clone();
-        style.background_svg = source.background_svg.clone();
-        style.background_size = source.background_size;
-        style.background_repeat = source.background_repeat;
-        style.background_position = source.background_position;
-        style.background_origin = source.background_origin;
-    };
     match property {
         "color" => style.color = parent.color,
         "font-size" => style.font_size = parent.font_size,
@@ -888,9 +892,7 @@ fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &Compu
         "background-repeat" => style.background_repeat = parent.background_repeat,
         "background-position" => style.background_position = parent.background_position,
         "background-origin" => style.background_origin = parent.background_origin,
-        "background-image" | "background" | "background-svg" => {
-            restore_background(style, parent)
-        }
+        "background-image" | "background" | "background-svg" => style.inherit_background(parent),
         "list-style-type" => style.list_style_type = parent.list_style_type,
         "list-style-position" => style.list_style_position = parent.list_style_position,
         "content" => style.content = parent.content.clone(),
@@ -1019,35 +1021,30 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
     }
 
     if get_non_special(map, "background-image").is_some() {
-        style.background_gradient = None;
-        style.background_radial_gradient = None;
-        style.background_svg = None;
+        style.clear_background_images();
     }
 
     // Linear gradient (from background or background-image)
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-gradient") {
         if let Some(lg) = parse_linear_gradient(k) {
+            style.clear_background_images();
             style.background_gradient = Some(lg);
-            style.background_radial_gradient = None;
-            style.background_svg = None;
         }
     }
 
     // Radial gradient (from background or background-image)
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-radial-gradient") {
         if let Some(rg) = parse_radial_gradient(k) {
+            style.clear_background_images();
             style.background_radial_gradient = Some(rg);
-            style.background_gradient = None;
-            style.background_svg = None;
         }
     }
 
     // SVG background image (from data:image/svg+xml URI)
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "background-svg") {
         if let Some(tree) = crate::parser::svg::parse_svg_from_string(k) {
+            style.clear_background_images();
             style.background_svg = Some(tree);
-            style.background_gradient = None;
-            style.background_radial_gradient = None;
         }
     }
 

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -720,6 +720,16 @@ fn is_inherited_property(property: &str) -> bool {
 /// Reset a property to its initial (default) value on the given style.
 fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
     let default = ComputedStyle::default();
+    let reset_background = |style: &mut ComputedStyle, source: &ComputedStyle| {
+        style.background_color = source.background_color;
+        style.background_gradient = source.background_gradient.clone();
+        style.background_radial_gradient = source.background_radial_gradient.clone();
+        style.background_svg = source.background_svg.clone();
+        style.background_size = source.background_size;
+        style.background_repeat = source.background_repeat;
+        style.background_position = source.background_position;
+        style.background_origin = source.background_origin;
+    };
     match property {
         "color" => style.color = default.color,
         "font-size" => style.font_size = default.font_size,
@@ -787,9 +797,7 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
         "background-repeat" => style.background_repeat = default.background_repeat,
         "background-position" => style.background_position = default.background_position,
         "background-origin" => style.background_origin = default.background_origin,
-        "background-image" | "background" | "background-svg" => {
-            style.background_svg = default.background_svg.clone()
-        }
+        "background-image" | "background" | "background-svg" => reset_background(style, &default),
         "list-style-type" => style.list_style_type = default.list_style_type,
         "list-style-position" => style.list_style_position = default.list_style_position,
         "content" => style.content = default.content,
@@ -803,6 +811,16 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
 
 /// Restore a property to the parent's value (inherit behavior).
 fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &ComputedStyle) {
+    let restore_background = |style: &mut ComputedStyle, source: &ComputedStyle| {
+        style.background_color = source.background_color;
+        style.background_gradient = source.background_gradient.clone();
+        style.background_radial_gradient = source.background_radial_gradient.clone();
+        style.background_svg = source.background_svg.clone();
+        style.background_size = source.background_size;
+        style.background_repeat = source.background_repeat;
+        style.background_position = source.background_position;
+        style.background_origin = source.background_origin;
+    };
     match property {
         "color" => style.color = parent.color,
         "font-size" => style.font_size = parent.font_size,
@@ -871,7 +889,7 @@ fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &Compu
         "background-position" => style.background_position = parent.background_position,
         "background-origin" => style.background_origin = parent.background_origin,
         "background-image" | "background" | "background-svg" => {
-            style.background_svg = parent.background_svg.clone()
+            restore_background(style, parent)
         }
         "list-style-type" => style.list_style_type = parent.list_style_type,
         "list-style-position" => style.list_style_position = parent.list_style_position,
@@ -5804,6 +5822,25 @@ mod tests {
         assert!(style.background_svg.is_none());
         assert!(style.background_gradient.is_none());
         assert!(style.background_radial_gradient.is_none());
+    }
+
+    #[test]
+    fn background_initial_resets_all_background_state() {
+        let style = compute_style(
+            HtmlTag::Div,
+            Some(
+                r#"background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E") no-repeat center / cover; background: initial"#,
+            ),
+            &ComputedStyle::default(),
+        );
+        assert!(style.background_color.is_none());
+        assert!(style.background_svg.is_none());
+        assert!(style.background_gradient.is_none());
+        assert!(style.background_radial_gradient.is_none());
+        assert_eq!(style.background_size, BackgroundSize::Auto);
+        assert_eq!(style.background_repeat, BackgroundRepeat::Repeat);
+        assert_eq!(style.background_position, BackgroundPosition::default());
+        assert_eq!(style.background_origin, BackgroundOrigin::PaddingBox);
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,65 @@
+/// Shared helpers used across the parser, layout, and renderer.
+
+/// Decode a standard Base64 string without pulling in an extra dependency.
+pub(crate) fn decode_base64(input: &str) -> Option<Vec<u8>> {
+    let table = |c: u8| -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    };
+
+    let bytes: Vec<u8> = input.bytes().filter(|b| !b.is_ascii_whitespace()).collect();
+    let mut result = Vec::with_capacity(bytes.len() * 3 / 4);
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let remaining = bytes.len() - i;
+        if remaining < 2 {
+            break;
+        }
+
+        let a = table(bytes[i])?;
+        let b = table(bytes[i + 1])?;
+        result.push((a << 2) | (b >> 4));
+
+        if i + 2 < bytes.len() && bytes[i + 2] != b'=' {
+            let c = table(bytes[i + 2])?;
+            result.push((b << 4) | (c >> 2));
+
+            if i + 3 < bytes.len() && bytes[i + 3] != b'=' {
+                let d = table(bytes[i + 3])?;
+                result.push((c << 6) | d);
+            }
+        }
+
+        i += 4;
+    }
+
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_base64;
+
+    #[test]
+    fn decode_base64_basic() {
+        assert_eq!(
+            decode_base64("SGVsbG8=").as_deref(),
+            Some(b"Hello".as_ref())
+        );
+    }
+
+    #[test]
+    fn decode_base64_with_whitespace() {
+        assert_eq!(
+            decode_base64("SGVs\nbG8=").as_deref(),
+            Some(b"Hello".as_ref())
+        );
+    }
+}

--- a/tests/pdf_smoke_tests.rs
+++ b/tests/pdf_smoke_tests.rs
@@ -302,3 +302,55 @@ fn smoke_full_document() {
     assert!(pdf_has_text(&pdf, "Confidential"));
     assert!(pdf_page_count(&pdf) >= 1);
 }
+
+// === SVG background image ===
+
+#[test]
+fn smoke_svg_background_image_percent_encoded() {
+    let html = r#"<html><head><style>
+body { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100' height='100' fill='%23eee'/%3E%3Ccircle cx='50' cy='50' r='30' fill='%23ccc'/%3E%3C/svg%3E"); background-size: cover; }
+</style></head><body>
+<h1>Background Test</h1>
+<p>This page should have an SVG pattern background.</p>
+</body></html>"#;
+    let pdf = ironpress::HtmlConverter::new()
+        .sanitize(false)
+        .convert(html)
+        .unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Background Test"));
+    // The SVG should generate PDF drawing operators (rect and circle beziers)
+    let content = String::from_utf8_lossy(&pdf);
+    // "re" (rectangle) from the SVG rect element
+    assert!(content.contains(" re\n"));
+}
+
+#[test]
+fn smoke_svg_background_image_base64() {
+    // SVG: <svg xmlns='http://www.w3.org/2000/svg' width='50' height='50'><rect width='50' height='50' fill='blue'/></svg>
+    let html = r#"<html><head><style>
+body { background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc1MCcgaGVpZ2h0PSc1MCc+PHJlY3Qgd2lkdGg9JzUwJyBoZWlnaHQ9JzUwJyBmaWxsPSdibHVlJy8+PC9zdmc+"); background-size: cover; }
+</style></head><body>
+<p>Base64 SVG background</p>
+</body></html>"#;
+    let pdf = ironpress::HtmlConverter::new()
+        .sanitize(false)
+        .convert(html)
+        .unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Base64 SVG background"));
+}
+
+#[test]
+fn smoke_svg_background_with_sanitizer() {
+    // Verify that the sanitizer preserves data: URIs in CSS
+    let html = r#"<html><head><style>
+body { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='%23ddd'/%3E%3C/svg%3E"); }
+</style></head><body>
+<p>Sanitized SVG background</p>
+</body></html>"#;
+    // With sanitizer enabled (default)
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Sanitized SVG background"));
+}


### PR DESCRIPTION
## Summary

CSS `background-image: url("data:image/svg+xml,...")` was ignored entirely. Full background property support added.

## Before / After

```html
<html><head><style>
body {
  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100' height='100' fill='%23f0f0f0'/%3E%3Ccircle cx='50' cy='50' r='30' fill='%23ddd'/%3E%3C/svg%3E");
  background-size: cover;
}
</style></head><body>
<h1>Background Test</h1>
<p>This page has an SVG background pattern.</p>
</body></html>
```

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/Wicpar/ironpress/pr-assets/assets/pr/cssbg_before.png) | ![after](https://raw.githubusercontent.com/Wicpar/ironpress/pr-assets/assets/pr/cssbg_after.png) |

## Features

- `background-size`: cover, contain, auto, explicit lengths
- `background-position`: percentages, fixed offsets, keywords
- `background-repeat`: repeat, no-repeat, repeat-x, repeat-y
- `background-origin`: padding-box, border-box, content-box
- `background` shorthand parsing
- Root background replicated across paginated pages

## Test plan

- [x] All 1740 tests pass
- [x] Flex child backgrounds use child_style
- [x] Root background appears on all pages