### PR TITLE
feat: add CSS filter: blur() support for raster images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ wasm = ["wasm-bindgen", "js-sys"]
 
 [dependencies]
 html5ever = "0.27"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
+png_decoder = { package = "png", version = "0.18" }
 pulldown-cmark = "0.12"
 markup5ever_rcdom = "0.3"
 thiserror = "2"

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -395,8 +395,6 @@ pub enum LayoutElement {
         png_metadata: Option<PngMetadata>,
         margin_top: f32,
         margin_bottom: f32,
-        /// CSS `filter: blur()` radius in points (0.0 = no blur).
-        blur_radius: f32,
     },
     /// A horizontal rule.
     HorizontalRule { margin_top: f32, margin_bottom: f32 },
@@ -3950,7 +3948,6 @@ fn load_image_from_element(
         png_metadata: png_meta,
         margin_top: style.margin.top,
         margin_bottom: style.margin.bottom,
-        blur_radius: style.blur_radius,
     })
 }
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -3964,14 +3964,7 @@ fn load_image_data_blurred(
     blur_sigma: f32,
 ) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadata>)> {
     // Get the raw file bytes (before any PNG IDAT extraction).
-    let raw = if let Some(rest) = src.strip_prefix("data:") {
-        let (_header, encoded) = rest.split_once(',')?;
-        base64_decode(encoded)?
-    } else if src.starts_with("http://") || src.starts_with("https://") {
-        fetch_remote_url(src)?
-    } else {
-        std::fs::read(src).ok()?
-    };
+    let raw = load_image_source_bytes(src)?;
 
     // Decode the image into a DynamicImage.
     // For PNG: use the `png` crate directly with CRC checking disabled (some
@@ -4079,20 +4072,23 @@ fn fetch_remote_url(url: &str) -> Option<Vec<u8>> {
     }
 }
 
+fn load_image_source_bytes(src: &str) -> Option<Vec<u8>> {
+    if let Some(rest) = src.strip_prefix("data:") {
+        let (_header, encoded) = rest.split_once(',')?;
+        return base64_decode(encoded);
+    }
+
+    if src.starts_with("http://") || src.starts_with("https://") {
+        return fetch_remote_url(src);
+    }
+
+    std::fs::read(src).ok()
+}
+
 /// Load image data from a src attribute (supports data: URIs, local files, and remote URLs).
 /// Returns (raw_bytes, format, optional_png_metadata).
 fn load_image_data(src: &str) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadata>)> {
-    let raw = if let Some(rest) = src.strip_prefix("data:") {
-        // Parse data URI: data:[<mediatype>][;base64],<data>
-        let (_header, encoded) = rest.split_once(',')?;
-        // Only support base64 for now
-        base64_decode(encoded)?
-    } else if src.starts_with("http://") || src.starts_with("https://") {
-        fetch_remote_url(src)?
-    } else {
-        // Treat as local file path
-        std::fs::read(src).ok()?
-    };
+    let raw = load_image_source_bytes(src)?;
 
     // Detect format from content
     if png::is_png(&raw) {
@@ -8108,12 +8104,15 @@ mod tests {
         let nodes = parse_html(html).unwrap();
         let pages = layout(&nodes, PageSize::A4, Margin::default());
         assert!(!pages.is_empty());
-        let has_jpeg_image = pages[0]
-            .elements
-            .iter()
-            .any(|(_, el)| {
-                matches!(el, LayoutElement::Image { format: ImageFormat::Jpeg, .. })
-            });
+        let has_jpeg_image = pages[0].elements.iter().any(|(_, el)| {
+            matches!(
+                el,
+                LayoutElement::Image {
+                    format: ImageFormat::Jpeg,
+                    ..
+                }
+            )
+        });
         assert!(
             has_jpeg_image,
             "Blurred PNG image should be re-encoded as JPEG in layout"

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -395,6 +395,8 @@ pub enum LayoutElement {
         png_metadata: Option<PngMetadata>,
         margin_top: f32,
         margin_bottom: f32,
+        /// CSS `filter: blur()` radius in points (0.0 = no blur).
+        blur_radius: f32,
     },
     /// A horizontal rule.
     HorizontalRule { margin_top: f32, margin_bottom: f32 },
@@ -3897,13 +3899,22 @@ fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
 }
 
 /// Load image data from an <img> element and return a LayoutElement::Image.
+///
+/// When the element has a `filter: blur()` style, the image is decoded with the
+/// `image` crate, Gaussian-blurred, and re-encoded as JPEG before embedding.
 fn load_image_from_element(
     el: &ElementNode,
     available_width: f32,
     style: &ComputedStyle,
 ) -> Option<LayoutElement> {
     let src = el.attributes.get("src")?;
-    let (data, format, png_meta) = load_image_data(src)?;
+
+    // When blur is requested, decode the raw image, apply blur, and re-encode as JPEG.
+    let (data, format, png_meta) = if style.blur_radius > 0.0 {
+        load_image_data_blurred(src, style.blur_radius)?
+    } else {
+        load_image_data(src)?
+    };
 
     // Determine dimensions from attributes
     let attr_width = el
@@ -3939,7 +3950,102 @@ fn load_image_from_element(
         png_metadata: png_meta,
         margin_top: style.margin.top,
         margin_bottom: style.margin.bottom,
+        blur_radius: style.blur_radius,
     })
+}
+
+/// Load image data from a src attribute, apply Gaussian blur, and return the
+/// blurred image re-encoded as JPEG for PDF embedding.
+///
+/// Both JPEG and PNG sources are supported. The blurred result is always
+/// re-encoded as JPEG (the `image` crate decodes the full file, so PNG IDAT
+/// extraction is bypassed).
+///
+/// Returns `None` if the source cannot be loaded or decoded.
+fn load_image_data_blurred(
+    src: &str,
+    blur_sigma: f32,
+) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadata>)> {
+    // Get the raw file bytes (before any PNG IDAT extraction).
+    let raw = if let Some(rest) = src.strip_prefix("data:") {
+        let (_header, encoded) = rest.split_once(',')?;
+        base64_decode(encoded)?
+    } else if src.starts_with("http://") || src.starts_with("https://") {
+        fetch_remote_url(src)?
+    } else {
+        std::fs::read(src).ok()?
+    };
+
+    // Decode the image into a DynamicImage.
+    // For PNG: use the `png` crate directly with CRC checking disabled (some
+    // data-URI PNGs omit valid CRC checksums, and ironpress's own PNG parser
+    // already tolerates this).
+    // For JPEG: use the `image` crate's normal decoder.
+    let img = if png::is_png(&raw) {
+        decode_png_for_blur(&raw)?
+    } else {
+        image::load_from_memory(&raw).ok()?
+    };
+
+    // Apply Gaussian blur (sigma = blur_radius in points).
+    let blurred = image::DynamicImage::from(image::imageops::blur(&img, blur_sigma));
+
+    // Convert to RGB (JPEG does not support alpha channels) and re-encode.
+    let rgb = blurred.to_rgb8();
+    let mut buf = Vec::new();
+    image::DynamicImage::ImageRgb8(rgb)
+        .write_to(
+            &mut std::io::Cursor::new(&mut buf),
+            image::ImageFormat::Jpeg,
+        )
+        .ok()?;
+
+    Some((buf, ImageFormat::Jpeg, None))
+}
+
+/// Decode a PNG file into a `DynamicImage` with CRC checking disabled.
+///
+/// This is necessary because some PNGs (especially those in data URIs) may
+/// have incorrect CRC checksums that the `image` crate's default PNG decoder
+/// would reject.
+fn decode_png_for_blur(data: &[u8]) -> Option<image::DynamicImage> {
+    use image::{DynamicImage, ImageBuffer, RgbImage, RgbaImage};
+    use std::io::Cursor;
+
+    let cursor = Cursor::new(data);
+    let mut decoder = png_decoder::Decoder::new(cursor);
+    decoder.ignore_checksums(true);
+    let mut reader = decoder.read_info().ok()?;
+    let mut buf = vec![0u8; reader.output_buffer_size()?];
+    let info = reader.next_frame(&mut buf).ok()?;
+    buf.truncate(info.buffer_size());
+
+    let width = info.width;
+    let height = info.height;
+
+    match info.color_type {
+        png_decoder::ColorType::Rgba => {
+            let img_buf: RgbaImage = ImageBuffer::from_raw(width, height, buf)?;
+            Some(DynamicImage::ImageRgba8(img_buf))
+        }
+        png_decoder::ColorType::Rgb => {
+            let img_buf: RgbImage = ImageBuffer::from_raw(width, height, buf)?;
+            Some(DynamicImage::ImageRgb8(img_buf))
+        }
+        png_decoder::ColorType::Grayscale => {
+            let img_buf: image::GrayImage = ImageBuffer::from_raw(width, height, buf)?;
+            Some(DynamicImage::ImageLuma8(img_buf))
+        }
+        png_decoder::ColorType::GrayscaleAlpha => {
+            let img_buf: image::GrayAlphaImage = ImageBuffer::from_raw(width, height, buf)?;
+            Some(DynamicImage::ImageLumaA8(img_buf))
+        }
+        _ => {
+            // For indexed/other color types, fall back to the image crate
+            // (which may fail on CRC, but these are rare)
+            image::load_from_memory(data).ok()
+        }
+    }
 }
 
 /// Maximum size for remote resources (10 MB).
@@ -7960,6 +8066,61 @@ mod tests {
             .collect();
         let pages = layout_with_rules(&result.nodes, PageSize::A4, Margin::default(), &rules);
         assert!(!pages.is_empty());
+    }
+
+    #[test]
+    fn load_image_data_blurred_decodes_png() {
+        // 10x10 RGBA PNG (note: this PNG has invalid CRC checksums, which is
+        // common for hand-crafted test PNGs; our decoder tolerates this)
+        let b64 = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2P8z8BQz0BFwMgwasCoAgBGWAkF3c01mQAAAABJRU5ErkJggg==";
+
+        // Step 1: Verify base64 decode works
+        let raw = super::base64_decode(b64).expect("base64 decode should succeed");
+        assert_eq!(raw.len(), 79, "decoded PNG should be 79 bytes");
+        assert_eq!(
+            &raw[..4],
+            &[0x89, 0x50, 0x4E, 0x47],
+            "should start with PNG magic"
+        );
+
+        // Step 2: Verify the CRC-tolerant PNG decoder works
+        let img =
+            super::decode_png_for_blur(&raw).expect("CRC-tolerant decoder should decode the PNG");
+        assert_eq!(img.width(), 10);
+        assert_eq!(img.height(), 10);
+
+        // Step 3: Verify the full load_image_data_blurred pipeline
+        let src = format!("data:image/png;base64,{}", b64);
+        let result = super::load_image_data_blurred(&src, 3.75);
+        assert!(
+            result.is_some(),
+            "load_image_data_blurred should decode the PNG data URI and apply blur"
+        );
+        let (data, format, meta) = result.unwrap();
+        assert_eq!(format, ImageFormat::Jpeg, "should be re-encoded as JPEG");
+        assert!(meta.is_none(), "JPEG has no PNG metadata");
+        assert!(!data.is_empty(), "blurred JPEG should have data");
+        // JPEG files start with FF D8
+        assert_eq!(data[0], 0xFF, "JPEG should start with FF");
+        assert_eq!(data[1], 0xD8, "JPEG should start with FF D8");
+    }
+
+    #[test]
+    fn blur_image_produces_jpeg_layout_element() {
+        let html = r#"<img style="filter: blur(5px)" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2P8z8BQz0BFwMgwasCoAgBGWAkF3c01mQAAAABJRU5ErkJggg==" width="100" height="100" />"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert!(!pages.is_empty());
+        let has_jpeg_image = pages[0]
+            .elements
+            .iter()
+            .any(|(_, el)| {
+                matches!(el, LayoutElement::Image { format: ImageFormat::Jpeg, .. })
+            });
+        assert!(
+            has_jpeg_image,
+            "Blurred PNG image should be re-encoded as JPEG in layout"
+        );
     }
 }
 

--- a/src/parser/css.rs
+++ b/src/parser/css.rs
@@ -342,6 +342,11 @@ fn parse_value(property: &str, val: &str) -> Option<CssValue> {
         return Some(CssValue::Keyword(val.to_string()));
     }
 
+    // Filter — store as keyword (e.g. "blur(20px)")
+    if property == "filter" {
+        return Some(CssValue::Keyword(val.to_string()));
+    }
+
     // Grid template columns — store as keyword for later parsing
     if property == "grid-template-columns" {
         return Some(CssValue::Keyword(val.to_string()));

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -1940,15 +1940,11 @@ fn parse_shadow_length(val: &str) -> Option<f32> {
     }
 }
 
-/// Parse a CSS `filter: blur(Npx)` value and return the blur radius in points.
+/// Parse a CSS `filter: blur(<length>)` value and return the blur radius in points.
 ///
-/// Supported forms:
-/// - `blur(20px)` — converts px to pt (1px = 0.75pt)
-/// - `blur(15pt)` — used as-is
-/// - `blur(10)` — bare number treated as px
-/// - `none` — returns 0.0 (no blur)
-///
-/// Returns `None` if the value is not a recognized blur filter.
+/// The CSS `blur()` function takes a length. We reuse the shared length parser
+/// so any supported absolute CSS length works here. Unitless zero is accepted
+/// because CSS length syntax allows `0` without a unit.
 fn parse_filter_blur(val: &str) -> Option<f32> {
     let val = val.trim();
     if val == "none" {
@@ -1956,16 +1952,10 @@ fn parse_filter_blur(val: &str) -> Option<f32> {
     }
     let inner = val.strip_prefix("blur(")?.strip_suffix(')')?;
     let inner = inner.trim();
-    if let Some(px_str) = inner.strip_suffix("px") {
-        let px: f32 = px_str.trim().parse().ok()?;
-        // Convert CSS pixels to PDF points (1px = 0.75pt)
-        Some(px * 0.75)
-    } else if let Some(pt_str) = inner.strip_suffix("pt") {
-        pt_str.trim().parse().ok()
-    } else {
-        // Bare number: treat as px
-        let px: f32 = inner.parse().ok()?;
-        Some(px * 0.75)
+    let is_unitless = inner.parse::<f32>().is_ok();
+    match crate::parser::css::parse_length(inner) {
+        Some(CssValue::Length(v)) if v >= 0.0 && (!is_unitless || v == 0.0) => Some(v),
+        _ => None,
     }
 }
 
@@ -6571,11 +6561,10 @@ mod tests {
     }
 
     #[test]
-    fn filter_blur_bare_number() {
+    fn filter_blur_bare_number_is_rejected() {
         let parent = ComputedStyle::default();
         let style = compute_style(HtmlTag::Div, Some("filter: blur(8)"), &parent);
-        // 8px * 0.75 = 6pt
-        assert!((style.blur_radius - 6.0).abs() < 0.01);
+        assert!((style.blur_radius - 0.0).abs() < f32::EPSILON);
     }
 
     #[test]
@@ -6620,7 +6609,7 @@ mod tests {
 
     #[test]
     fn parse_filter_blur_bare_number() {
-        assert!((parse_filter_blur("blur(12)").unwrap() - 9.0).abs() < 0.01);
+        assert_eq!(parse_filter_blur("blur(12)"), None);
     }
 
     #[test]
@@ -6633,6 +6622,12 @@ mod tests {
         assert!(parse_filter_blur("brightness(50%)").is_none());
         assert!(parse_filter_blur("blur()").is_none());
         assert!(parse_filter_blur("blur(abc)").is_none());
+        assert!(parse_filter_blur("blur(-1px)").is_none());
+    }
+
+    #[test]
+    fn parse_filter_blur_unitless_zero() {
+        assert!((parse_filter_blur("blur(0)").unwrap() - 0.0).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -1952,9 +1952,12 @@ fn parse_filter_blur(val: &str) -> Option<f32> {
     }
     let inner = val.strip_prefix("blur(")?.strip_suffix(')')?;
     let inner = inner.trim();
-    let is_unitless = inner.parse::<f32>().is_ok();
+    if let Ok(value) = inner.parse::<f32>() {
+        return (value == 0.0).then_some(0.0);
+    }
+
     match crate::parser::css::parse_length(inner) {
-        Some(CssValue::Length(v)) if v >= 0.0 && (!is_unitless || v == 0.0) => Some(v),
+        Some(CssValue::Length(value)) if value >= 0.0 => Some(value),
         _ => None,
     }
 }

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -443,6 +443,8 @@ pub struct ComputedStyle {
     pub counter_increment: Vec<(String, i32)>,
     pub column_count: Option<u32>,
     pub column_gap: f32,
+    /// CSS `filter: blur(Npx)` radius in points (0.0 = no blur).
+    pub blur_radius: f32,
 }
 
 impl Default for ComputedStyle {
@@ -519,6 +521,7 @@ impl Default for ComputedStyle {
             counter_increment: Vec::new(),
             column_count: None,
             column_gap: 0.0,
+            blur_radius: 0.0,
         }
     }
 }
@@ -643,6 +646,7 @@ pub fn compute_style_with_context(
     style.counter_reset = Vec::new();
     style.counter_increment = Vec::new();
     style.z_index = 0;
+    style.blur_radius = 0.0;
     // custom_properties inherit from parent (already cloned)
 
     // Apply tag defaults
@@ -773,6 +777,7 @@ fn reset_to_initial(style: &mut ComputedStyle, property: &str) {
         "counter-increment" => style.counter_increment = default.counter_increment,
         "column-count" | "columns" => style.column_count = default.column_count,
         "column-gap" => style.column_gap = default.column_gap,
+        "filter" => style.blur_radius = default.blur_radius,
         _ => {}
     }
 }
@@ -852,6 +857,7 @@ fn restore_from_parent(style: &mut ComputedStyle, property: &str, parent: &Compu
         "counter-increment" => style.counter_increment = parent.counter_increment.clone(),
         "column-count" | "columns" => style.column_count = parent.column_count,
         "column-gap" => style.column_gap = parent.column_gap,
+        "filter" => style.blur_radius = parent.blur_radius,
         _ => {}
     }
 }
@@ -1352,6 +1358,13 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "transform") {
         if let Some(t) = parse_transform(k) {
             style.transform = Some(t);
+        }
+    }
+
+    // Filter: blur(Npx)
+    if let Some(CssValue::Keyword(k)) = get_non_special(map, "filter") {
+        if let Some(radius) = parse_filter_blur(k) {
+            style.blur_radius = radius;
         }
     }
 
@@ -1924,6 +1937,35 @@ fn parse_shadow_length(val: &str) -> Option<f32> {
         n.parse::<f32>().ok()
     } else {
         val.parse::<f32>().ok()
+    }
+}
+
+/// Parse a CSS `filter: blur(Npx)` value and return the blur radius in points.
+///
+/// Supported forms:
+/// - `blur(20px)` — converts px to pt (1px = 0.75pt)
+/// - `blur(15pt)` — used as-is
+/// - `blur(10)` — bare number treated as px
+/// - `none` — returns 0.0 (no blur)
+///
+/// Returns `None` if the value is not a recognized blur filter.
+fn parse_filter_blur(val: &str) -> Option<f32> {
+    let val = val.trim();
+    if val == "none" {
+        return Some(0.0);
+    }
+    let inner = val.strip_prefix("blur(")?.strip_suffix(')')?;
+    let inner = inner.trim();
+    if let Some(px_str) = inner.strip_suffix("px") {
+        let px: f32 = px_str.trim().parse().ok()?;
+        // Convert CSS pixels to PDF points (1px = 0.75pt)
+        Some(px * 0.75)
+    } else if let Some(pt_str) = inner.strip_suffix("pt") {
+        pt_str.trim().parse().ok()
+    } else {
+        // Bare number: treat as px
+        let px: f32 = inner.parse().ok()?;
+        Some(px * 0.75)
     }
 }
 
@@ -6503,5 +6545,98 @@ mod tests {
         parent.flex_grow = 3.0;
         let style = compute_style(HtmlTag::Div, Some("flex-grow: inherit"), &parent);
         assert!((style.flex_grow - 3.0).abs() < f32::EPSILON);
+    }
+
+    // --- filter: blur() ---
+
+    #[test]
+    fn filter_blur_default_is_zero() {
+        let style = ComputedStyle::default();
+        assert!((style.blur_radius - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn filter_blur_from_inline_style_px() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("filter: blur(20px)"), &parent);
+        // 20px * 0.75 = 15pt
+        assert!((style.blur_radius - 15.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn filter_blur_from_inline_style_pt() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("filter: blur(10pt)"), &parent);
+        assert!((style.blur_radius - 10.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn filter_blur_bare_number() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("filter: blur(8)"), &parent);
+        // 8px * 0.75 = 6pt
+        assert!((style.blur_radius - 6.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn filter_blur_none_resets() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("filter: none"), &parent);
+        assert!((style.blur_radius - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn filter_blur_not_inherited() {
+        let mut parent = ComputedStyle::default();
+        parent.blur_radius = 10.0;
+        let style = compute_style(HtmlTag::Div, None, &parent);
+        assert!((style.blur_radius - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn filter_blur_inherit_from_parent() {
+        let mut parent = ComputedStyle::default();
+        parent.blur_radius = 12.0;
+        let style = compute_style(HtmlTag::Div, Some("filter: inherit"), &parent);
+        assert!((style.blur_radius - 12.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn filter_blur_initial_resets() {
+        let parent = ComputedStyle::default();
+        let style = compute_style(HtmlTag::Div, Some("filter: initial"), &parent);
+        assert!((style.blur_radius - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn parse_filter_blur_valid_px() {
+        assert!((parse_filter_blur("blur(5px)").unwrap() - 3.75).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_filter_blur_valid_pt() {
+        assert!((parse_filter_blur("blur(10pt)").unwrap() - 10.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_filter_blur_bare_number() {
+        assert!((parse_filter_blur("blur(12)").unwrap() - 9.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_filter_blur_none() {
+        assert!((parse_filter_blur("none").unwrap() - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn parse_filter_blur_invalid() {
+        assert!(parse_filter_blur("brightness(50%)").is_none());
+        assert!(parse_filter_blur("blur()").is_none());
+        assert!(parse_filter_blur("blur(abc)").is_none());
+    }
+
+    #[test]
+    fn parse_filter_blur_whitespace() {
+        assert!((parse_filter_blur("  blur( 5px )  ").unwrap() - 3.75).abs() < 0.01);
     }
 }

--- a/tests/pdf_smoke_tests.rs
+++ b/tests/pdf_smoke_tests.rs
@@ -302,3 +302,80 @@ fn smoke_full_document() {
     assert!(pdf_has_text(&pdf, "Confidential"));
     assert!(pdf_page_count(&pdf) >= 1);
 }
+
+// === CSS filter: blur() ===
+
+#[test]
+fn smoke_filter_blur_png_image() {
+    // 10x10 orange PNG encoded as a base64 data URI
+    let html = r#"
+        <style>
+        .blurred { filter: blur(5px); }
+        </style>
+        <img class="blurred" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2P8z8BQz0BFwMgwasCoAgBGWAkF3c01mQAAAABJRU5ErkJggg==" width="200" height="200" />
+        <p>Text below blurred image</p>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    // The blurred PNG is re-encoded as JPEG, so the PDF should contain a DCTDecode image
+    assert!(pdf_has_text(&pdf, "/Filter /DCTDecode"));
+    // Text after the image should still be present
+    assert!(pdf_has_text(&pdf, "Text below blurred image"));
+}
+
+#[test]
+fn smoke_filter_blur_zero_radius_no_blur() {
+    // blur(0px) should not alter the image pipeline (PNG stays as PNG)
+    let html = r#"
+        <style>
+        .no-blur { filter: blur(0px); }
+        </style>
+        <img class="no-blur" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2P8z8BQz0BFwMgwasCoAgBGWAkF3c01mQAAAABJRU5ErkJggg==" width="100" height="100" />
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    // With blur(0px), the PNG should remain as FlateDecode (not re-encoded to JPEG)
+    assert!(pdf_has_text(&pdf, "/Filter /FlateDecode"));
+}
+
+#[test]
+fn smoke_filter_blur_none_keyword() {
+    // filter: none should not apply any blur
+    let html = r#"
+        <style>
+        .clear { filter: none; }
+        </style>
+        <img class="clear" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2P8z8BQz0BFwMgwasCoAgBGWAkF3c01mQAAAABJRU5ErkJggg==" width="100" height="100" />
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "/Filter /FlateDecode"));
+}
+
+#[test]
+fn smoke_filter_blur_inline_style() {
+    // Inline style should also work
+    let html = r#"
+        <img style="filter: blur(10px)" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2P8z8BQz0BFwMgwasCoAgBGWAkF3c01mQAAAABJRU5ErkJggg==" width="150" height="150" />
+        <p>After inline blur</p>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "/Filter /DCTDecode"));
+    assert!(pdf_has_text(&pdf, "After inline blur"));
+}
+
+#[test]
+fn smoke_filter_blur_text_element_no_crash() {
+    // Blur on a non-image element should not crash (blur is silently ignored for text)
+    let html = r#"
+        <style>
+        .blurred-text { filter: blur(3px); }
+        </style>
+        <p class="blurred-text">This text has a blur filter applied</p>
+        <p>Normal text</p>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Normal text"));
+}

--- a/tests/pdf_smoke_tests.rs
+++ b/tests/pdf_smoke_tests.rs
@@ -367,7 +367,8 @@ fn smoke_filter_blur_inline_style() {
 
 #[test]
 fn smoke_filter_blur_text_element_no_crash() {
-    // Blur on a non-image element should not crash (blur is silently ignored for text)
+    // Non-image elements still need to parse cleanly even though this branch
+    // only rewrites raster image sources today.
     let html = r#"
         <style>
         .blurred-text { filter: blur(3px); }


### PR DESCRIPTION
## Summary

Adds `filter: blur(Npx)` support for raster images using Gaussian blur.

## Before / After

```html
<html><head><style>
.blurred { filter: blur(5px); }
</style></head><body>
<img class="blurred" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2P8z8BQz0BFwMgwasCoAgBGWAkF3c01mQAAAABJRU5ErkJggg==" width="200" height="200" />
<p>Text below</p>
</body></html>
```

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/Wicpar/ironpress/pr-assets/assets/pr/blur_before.png) | ![after](https://raw.githubusercontent.com/Wicpar/ironpress/pr-assets/assets/pr/blur_after.png) |

## Known Limitations

- Blur on non-image elements (text, vectors) silently ignored
- Only `blur()` supported; other filter functions not parsed
- Blurred output always JPEG

## Test plan

- [x] All existing tests pass + 7 new tests
- [x] blur(0px) and filter: none keep original format
- [x] Blur on text elements doesn't crash