### PR TITLE
feat: add SVG text element support with style inheritance

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -59,6 +59,7 @@
       <option value="report">Report</option>
       <option value="markdown">Markdown doc</option>
       <option value="math">Math paper</option>
+      <option value="svg">SVG graphics</option>
     </select>
     <div class="spacer"></div>
     <span class="status" id="status">Loading WASM...</span>
@@ -250,7 +251,35 @@ $$\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix} \\begin{pmatrix} x \\\\ y \\e
 
 ---
 
-*Generated with ironpress*`
+*Generated with ironpress*`,
+
+svg: `<h1>SVG Graphics</h1>
+<p>Vector graphics rendered directly to PDF drawing operators.</p>
+
+<h2>Shapes and Text</h2>
+<svg width="400" height="200" viewBox="0 0 400 200">
+  <rect x="10" y="10" width="180" height="80" rx="10" fill="#4A90D9" />
+  <text x="100" y="58" text-anchor="middle" font-size="18" fill="white" font-weight="bold">ironpress</text>
+  <circle cx="300" cy="50" r="40" fill="#E74C3C" />
+  <text x="300" y="55" text-anchor="middle" font-size="14" fill="white">SVG</text>
+  <line x1="10" y1="120" x2="390" y2="120" stroke="#ccc" stroke-width="1" />
+  <polygon points="200,130 230,190 170,190" fill="#2ECC71" />
+  <text x="200" y="175" text-anchor="middle" font-size="10" fill="white">OK</text>
+</svg>
+
+<h2>Chart</h2>
+<svg width="300" height="150" viewBox="0 0 300 150">
+  <rect x="20" y="90" width="40" height="50" fill="#3498DB" />
+  <text x="40" y="85" text-anchor="middle" font-size="10">Q1</text>
+  <rect x="80" y="50" width="40" height="90" fill="#2ECC71" />
+  <text x="100" y="45" text-anchor="middle" font-size="10">Q2</text>
+  <rect x="140" y="70" width="40" height="70" fill="#E67E22" />
+  <text x="160" y="65" text-anchor="middle" font-size="10">Q3</text>
+  <rect x="200" y="20" width="40" height="120" fill="#9B59B6" />
+  <text x="220" y="15" text-anchor="middle" font-size="10">Q4</text>
+</svg>
+
+<p style="font-size: 9pt; color: #999;">Generated with ironpress</p>`
     };
 
     // Init WASM
@@ -265,6 +294,7 @@ $$\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix} \\begin{pmatrix} x \\\\ y \\e
       if (key && EXAMPLES[key]) {
         input.value = EXAMPLES[key];
         modeSelect.value = (key === 'markdown' || key === 'math') ? 'markdown' : 'html';
+        if (key === 'svg') modeSelect.value = 'html';
         examplesSelect.value = '';
       }
     });

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -5,11 +5,11 @@ use crate::parser::dom::{DomNode, ElementNode, HtmlTag};
 use crate::parser::png;
 use crate::parser::ttf::TtfFont;
 use crate::style::computed::{
-    AlignItems, BorderCollapse, BorderSides, BorderSpacing, BoxShadow, BoxSizing, Clear,
-    ComputedStyle, ContentItem, Display, FlexDirection, FlexWrap, Float, FontFamily, FontStyle,
-    FontWeight, GridTrack, JustifyContent, LinearGradient, ListStylePosition, ListStyleType,
-    Overflow, Position, RadialGradient, TextAlign, TextOverflow, Transform, VerticalAlign,
-    Visibility, WhiteSpace, compute_style_with_context,
+    AlignItems, BorderCollapse, BorderSide, BorderSides, BorderSpacing, BoxShadow, BoxSizing,
+    Clear, ComputedStyle, ContentItem, Display, FlexDirection, FlexWrap, Float, FontFamily,
+    FontStyle, FontWeight, GridTrack, JustifyContent, LinearGradient, ListStylePosition,
+    ListStyleType, Overflow, Position, RadialGradient, TextAlign, TextOverflow, Transform,
+    VerticalAlign, Visibility, WhiteSpace, compute_style_with_context,
 };
 use crate::types::{Margin, PageSize};
 use std::collections::HashMap;
@@ -35,23 +35,15 @@ pub struct LayoutBorder {
 #[allow(dead_code)]
 impl LayoutBorder {
     pub fn from_computed(b: &BorderSides) -> Self {
+        let side = |side: &BorderSide| LayoutBorderSide {
+            width: side.width,
+            color: side.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
+        };
         Self {
-            top: LayoutBorderSide {
-                width: b.top.width,
-                color: b.top.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
-            },
-            right: LayoutBorderSide {
-                width: b.right.width,
-                color: b.right.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
-            },
-            bottom: LayoutBorderSide {
-                width: b.bottom.width,
-                color: b.bottom.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
-            },
-            left: LayoutBorderSide {
-                width: b.left.width,
-                color: b.left.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
-            },
+            top: side(&b.top),
+            right: side(&b.right),
+            bottom: side(&b.bottom),
+            left: side(&b.left),
         }
     }
     pub fn has_any(&self) -> bool {
@@ -91,11 +83,10 @@ impl CounterState {
     fn apply_increments(&mut self, increments: &[(String, i32)]) {
         for (name, val) in increments {
             let stack = self.stacks.entry(name.clone()).or_default();
-            if stack.is_empty() {
-                stack.push(0);
-            }
             if let Some(top) = stack.last_mut() {
                 *top += val;
+            } else {
+                stack.push(*val);
             }
         }
     }
@@ -113,15 +104,16 @@ impl CounterState {
             .unwrap_or(0)
     }
     fn get_all(&self, name: &str, sep: &str) -> String {
-        self.stacks
-            .get(name)
-            .map(|s| {
-                s.iter()
-                    .map(|v| v.to_string())
+        self.stacks.get(name).map_or_else(
+            || "0".to_string(),
+            |stack| {
+                stack
+                    .iter()
+                    .map(i32::to_string)
                     .collect::<Vec<_>>()
                     .join(sep)
-            })
-            .unwrap_or_else(|| "0".to_string())
+            },
+        )
     }
 }
 
@@ -224,18 +216,24 @@ fn resolve_pseudo_content(
     counter_state: &CounterState,
 ) -> Option<String> {
     for rule in rules {
-        if rule.pseudo_element == Some(pseudo)
-            && selector_matches(&rule.selector, tag_name, classes, id)
+        if rule.pseudo_element != Some(pseudo)
+            || !selector_matches(&rule.selector, tag_name, classes, id)
         {
-            if let Some(CssValue::Keyword(k)) = rule.declarations.get("content") {
-                let items = crate::style::computed::parse_content_value_pub(k);
-                if !items.is_empty() {
-                    let text = resolve_content(&items, attributes, counter_state);
-                    if !text.is_empty() {
-                        return Some(text);
-                    }
-                }
-            }
+            continue;
+        }
+
+        let Some(CssValue::Keyword(k)) = rule.declarations.get("content") else {
+            continue;
+        };
+
+        let items = crate::style::computed::parse_content_value_pub(k);
+        if items.is_empty() {
+            continue;
+        }
+
+        let text = resolve_content(&items, attributes, counter_state);
+        if !text.is_empty() {
+            return Some(text);
         }
     }
     None
@@ -559,6 +557,8 @@ pub fn layout_with_rules_and_fonts(
         nodes,
         &parent_style,
         available_width,
+        content_height,
+        false,
         &mut elements,
         None,
         rules,
@@ -575,6 +575,8 @@ fn flatten_nodes(
     nodes: &[DomNode],
     parent_style: &ComputedStyle,
     available_width: f32,
+    available_height: f32,
+    available_height_is_definite: bool,
     output: &mut Vec<LayoutElement>,
     list_ctx: Option<&ListContext>,
     rules: &[CssRule],
@@ -655,6 +657,8 @@ fn flatten_nodes(
                     el,
                     parent_style,
                     available_width,
+                    available_height,
+                    available_height_is_definite,
                     output,
                     list_ctx,
                     rules,
@@ -694,6 +698,8 @@ fn flatten_element(
     el: &ElementNode,
     parent_style: &ComputedStyle,
     available_width: f32,
+    available_height: f32,
+    available_height_is_definite: bool,
     output: &mut Vec<LayoutElement>,
     list_ctx: Option<&ListContext>,
     rules: &[CssRule],
@@ -721,6 +727,8 @@ fn flatten_element(
         &el.attributes,
         &selector_ctx,
     );
+    let available_height = style.height.unwrap_or(available_height);
+    let available_height_is_definite = style.height.is_some() || available_height_is_definite;
 
     // display: none — skip this element entirely
     if style.display == Display::None {
@@ -819,9 +827,54 @@ fn flatten_element(
     }
 
     if el.tag == HtmlTag::Svg {
-        if let Some(tree) = crate::parser::svg::parse_svg_from_element(el) {
-            let svg_width = tree.width.min(available_width);
-            let svg_height = tree.height;
+        let text_ctx = crate::parser::svg::SvgTextContext {
+            font_family: match (
+                &style.font_family,
+                style.font_weight == FontWeight::Bold,
+                style.font_style == FontStyle::Italic,
+            ) {
+                (FontFamily::Helvetica, true, true) => "Helvetica-BoldOblique",
+                (FontFamily::Helvetica, true, false) => "Helvetica-Bold",
+                (FontFamily::Helvetica, false, true) => "Helvetica-Oblique",
+                (FontFamily::Helvetica, false, false) => "Helvetica",
+                (FontFamily::TimesRoman, true, true) => "Times-BoldItalic",
+                (FontFamily::TimesRoman, true, false) => "Times-Bold",
+                (FontFamily::TimesRoman, false, true) => "Times-Italic",
+                (FontFamily::TimesRoman, false, false) => "Times-Roman",
+                (FontFamily::Courier, true, true) => "Courier-BoldOblique",
+                (FontFamily::Courier, true, false) => "Courier-Bold",
+                (FontFamily::Courier, false, true) => "Courier-Oblique",
+                (FontFamily::Courier, false, false) => "Courier",
+                (FontFamily::Custom(_), true, true) => "Helvetica-BoldOblique",
+                (FontFamily::Custom(_), true, false) => "Helvetica-Bold",
+                (FontFamily::Custom(_), false, true) => "Helvetica-Oblique",
+                (FontFamily::Custom(_), false, false) => "Helvetica",
+            }
+            .to_string(),
+            font_size: style.font_size,
+            font_bold: style.font_weight == FontWeight::Bold,
+            font_italic: style.font_style == FontStyle::Italic,
+            color: Some((
+                style.color.r as f32 / 255.0,
+                style.color.g as f32 / 255.0,
+                style.color.b as f32 / 255.0,
+            )),
+        };
+        if let Some(initial_tree) =
+            crate::parser::svg::parse_svg_from_element_with_ctx(el, text_ctx.clone())
+        {
+            let (svg_width, svg_height) = resolve_svg_size(
+                &initial_tree,
+                available_width,
+                available_height,
+                available_height_is_definite,
+            );
+            let tree = crate::parser::svg::parse_svg_from_element_with_ctx_and_viewport(
+                el,
+                text_ctx,
+                Some((svg_width, svg_height)),
+            )
+            .unwrap_or(initial_tree);
             output.push(LayoutElement::Svg {
                 tree,
                 width: svg_width,
@@ -1178,6 +1231,8 @@ fn flatten_element(
                         child_el,
                         &style,
                         inner_width,
+                        available_height,
+                        available_height_is_definite,
                         output,
                         Some(&ctx),
                         rules,
@@ -1195,6 +1250,8 @@ fn flatten_element(
                         child_el,
                         &style,
                         inner_width,
+                        available_height,
+                        available_height_is_definite,
                         output,
                         None,
                         rules,
@@ -1313,6 +1370,8 @@ fn flatten_element(
                         child_el,
                         &style,
                         inner_width,
+                        available_height,
+                        available_height_is_definite,
                         output,
                         list_ctx,
                         rules,
@@ -1327,6 +1386,8 @@ fn flatten_element(
                         child_el,
                         &style,
                         available_width,
+                        available_height,
+                        available_height_is_definite,
                         output,
                         None,
                         rules,
@@ -1757,6 +1818,8 @@ fn flatten_element(
                             child_el,
                             &style,
                             inner_width,
+                            available_height,
+                            available_height_is_definite,
                             &mut child_elements,
                             None,
                             rules,
@@ -1925,6 +1988,8 @@ fn flatten_element(
                             child_el,
                             &style,
                             inner_width,
+                            available_height,
+                            available_height_is_definite,
                             output,
                             None,
                             rules,
@@ -1945,6 +2010,8 @@ fn flatten_element(
             &el.children,
             &style,
             available_width,
+            available_height,
+            available_height_is_definite,
             output,
             None,
             rules,
@@ -1956,6 +2023,100 @@ fn flatten_element(
     if style.page_break_after {
         output.push(LayoutElement::PageBreak);
     }
+}
+
+fn resolve_svg_size(
+    tree: &crate::parser::svg::SvgTree,
+    available_width: f32,
+    available_height: f32,
+    available_height_is_definite: bool,
+) -> (f32, f32) {
+    let intrinsic_width = if tree.width > 0.0 { tree.width } else { 300.0 };
+    let intrinsic_height = if tree.height > 0.0 {
+        tree.height
+    } else {
+        150.0
+    };
+    let intrinsic_ratio = if let Some(vb) = &tree.view_box {
+        if vb.width > 0.0 {
+            vb.height / vb.width
+        } else {
+            intrinsic_height / intrinsic_width.max(1.0)
+        }
+    } else {
+        intrinsic_height / intrinsic_width.max(1.0)
+    };
+
+    let mut width = resolve_svg_dimension(
+        tree.width_attr.as_deref(),
+        intrinsic_width,
+        available_width,
+        true,
+    );
+    let mut height = resolve_svg_dimension(
+        tree.height_attr.as_deref(),
+        intrinsic_height,
+        available_height,
+        available_height_is_definite,
+    );
+    let height_is_auto = match tree.height_attr.as_deref() {
+        None => true,
+        Some(raw) if raw.trim_end().ends_with('%') && !available_height_is_definite => true,
+        _ => false,
+    };
+
+    if matches!(
+        (tree.width_attr.as_deref(), tree.height_attr.as_deref()),
+        (Some(w_attr), None) if w_attr.trim_end().ends_with('%')
+    ) {
+        height = width * intrinsic_ratio;
+    }
+
+    if matches!(
+        (tree.width_attr.as_deref(), tree.height_attr.as_deref()),
+        (None, Some(h_attr)) if h_attr.trim_end().ends_with('%')
+    ) {
+        width = height / intrinsic_ratio.max(f32::EPSILON);
+    }
+
+    if width > available_width {
+        let scale = if width > 0.0 {
+            available_width / width
+        } else {
+            1.0
+        };
+        width = available_width;
+        if height_is_auto {
+            height *= scale;
+        }
+    }
+
+    (width, height)
+}
+
+fn resolve_svg_dimension(
+    raw: Option<&str>,
+    fallback: f32,
+    available_width: f32,
+    allow_percent: bool,
+) -> f32 {
+    let Some(raw) = raw else {
+        return fallback;
+    };
+    let raw = raw.trim();
+    if let Some(pct) = raw.strip_suffix('%') {
+        if allow_percent {
+            if let Ok(value) = pct.trim().parse::<f32>() {
+                if value >= 0.0 {
+                    return available_width * (value / 100.0);
+                }
+            }
+        }
+        return fallback;
+    }
+
+    let value = crate::parser::svg::parse_length(raw).unwrap_or(fallback);
+    if value >= 0.0 { value } else { fallback }
 }
 
 /// Lay out children of a `display: flex` container.
@@ -4798,7 +4959,7 @@ fn load_image_data(src: &str) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadat
         };
         // For PNG, we pass the IDAT data (already zlib-compressed) to PDF
         Some((png_info.idat_data, ImageFormat::Png, Some(metadata)))
-    } else if raw.len() >= 2 && raw[0] == 0xFF && raw[1] == 0xD8 {
+    } else if raw.starts_with(&[0xFF, 0xD8]) {
         // JPEG: pass entire file as-is
         Some((raw, ImageFormat::Jpeg, None))
     } else {
@@ -4872,6 +5033,7 @@ mod tests {
     use super::*;
     use crate::parser::css::parse_stylesheet;
     use crate::parser::html::{parse_html, parse_html_with_styles};
+    use crate::parser::svg::SvgTree;
 
     fn table_rows<'a>(pages: &'a [Page]) -> Vec<&'a [TableCell]> {
         pages
@@ -4973,6 +5135,68 @@ mod tests {
         let nodes = parse_html(html).unwrap();
         let pages = layout(&nodes, PageSize::A4, Margin::default());
         assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn svg_size_percent_height_resolves_against_available_height() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 60.0,
+            width_attr: Some("100".to_string()),
+            height_attr: Some("50%".to_string()),
+            view_box: None,
+            children: vec![],
+            text_ctx: crate::parser::svg::SvgTextContext::default(),
+        };
+
+        assert_eq!(resolve_svg_size(&tree, 400.0, 400.0, true), (100.0, 200.0));
+    }
+
+    #[test]
+    fn root_svg_percent_height_does_not_use_page_height_fallback() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 150.0,
+            width_attr: Some("100".to_string()),
+            height_attr: Some("50%".to_string()),
+            view_box: None,
+            children: vec![],
+            text_ctx: crate::parser::svg::SvgTextContext::default(),
+        };
+
+        assert_eq!(resolve_svg_size(&tree, 400.0, 400.0, false), (100.0, 150.0));
+    }
+
+    #[test]
+    fn svg_width_is_clamped_to_available_width() {
+        let tree = SvgTree {
+            width: 500.0,
+            height: 150.0,
+            width_attr: Some("500".to_string()),
+            height_attr: None,
+            view_box: None,
+            children: vec![],
+            text_ctx: crate::parser::svg::SvgTextContext::default(),
+        };
+
+        assert_eq!(resolve_svg_size(&tree, 320.0, 400.0, true), (320.0, 96.0));
+    }
+
+    #[test]
+    fn nested_svg_percent_height_uses_parent_height() {
+        let html = r#"<div style="height: 200pt"><svg width="100" height="50%"></svg></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let svg = pages[0]
+            .elements
+            .iter()
+            .find_map(|(_, el)| match el {
+                LayoutElement::Svg { width, height, .. } => Some((*width, *height)),
+                _ => None,
+            })
+            .expect("expected nested svg element");
+        assert!((svg.0 - 100.0).abs() < 0.1);
+        assert!((svg.1 - 100.0).abs() < 0.1);
     }
 
     #[test]

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -5,11 +5,11 @@ use crate::parser::dom::{DomNode, ElementNode, HtmlTag};
 use crate::parser::png;
 use crate::parser::ttf::TtfFont;
 use crate::style::computed::{
-    AlignItems, BorderCollapse, BorderSides, BoxShadow, BoxSizing, Clear, ComputedStyle,
-    ContentItem, Display, FlexDirection, FlexWrap, Float, FontFamily, FontStyle, FontWeight,
-    GridTrack, JustifyContent, LinearGradient, ListStylePosition, ListStyleType, Overflow,
-    Position, RadialGradient, TextAlign, TextOverflow, Transform, VerticalAlign, Visibility,
-    WhiteSpace, compute_style_with_context,
+    AlignItems, BorderCollapse, BorderSide, BorderSides, BoxShadow, BoxSizing, Clear,
+    ComputedStyle, ContentItem, Display, FlexDirection, FlexWrap, Float, FontFamily, FontStyle,
+    FontWeight, GridTrack, JustifyContent, LinearGradient, ListStylePosition, ListStyleType,
+    Overflow, Position, RadialGradient, TextAlign, TextOverflow, Transform, VerticalAlign,
+    Visibility, WhiteSpace, compute_style_with_context,
 };
 use crate::types::{Margin, PageSize};
 use std::collections::HashMap;
@@ -35,23 +35,15 @@ pub struct LayoutBorder {
 #[allow(dead_code)]
 impl LayoutBorder {
     pub fn from_computed(b: &BorderSides) -> Self {
+        let side = |side: &BorderSide| LayoutBorderSide {
+            width: side.width,
+            color: side.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
+        };
         Self {
-            top: LayoutBorderSide {
-                width: b.top.width,
-                color: b.top.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
-            },
-            right: LayoutBorderSide {
-                width: b.right.width,
-                color: b.right.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
-            },
-            bottom: LayoutBorderSide {
-                width: b.bottom.width,
-                color: b.bottom.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
-            },
-            left: LayoutBorderSide {
-                width: b.left.width,
-                color: b.left.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
-            },
+            top: side(&b.top),
+            right: side(&b.right),
+            bottom: side(&b.bottom),
+            left: side(&b.left),
         }
     }
     pub fn has_any(&self) -> bool {
@@ -91,11 +83,10 @@ impl CounterState {
     fn apply_increments(&mut self, increments: &[(String, i32)]) {
         for (name, val) in increments {
             let stack = self.stacks.entry(name.clone()).or_default();
-            if stack.is_empty() {
-                stack.push(0);
-            }
             if let Some(top) = stack.last_mut() {
                 *top += val;
+            } else {
+                stack.push(*val);
             }
         }
     }
@@ -113,15 +104,16 @@ impl CounterState {
             .unwrap_or(0)
     }
     fn get_all(&self, name: &str, sep: &str) -> String {
-        self.stacks
-            .get(name)
-            .map(|s| {
-                s.iter()
-                    .map(|v| v.to_string())
+        self.stacks.get(name).map_or_else(
+            || "0".to_string(),
+            |stack| {
+                stack
+                    .iter()
+                    .map(i32::to_string)
                     .collect::<Vec<_>>()
                     .join(sep)
-            })
-            .unwrap_or_else(|| "0".to_string())
+            },
+        )
     }
 }
 
@@ -224,18 +216,24 @@ fn resolve_pseudo_content(
     counter_state: &CounterState,
 ) -> Option<String> {
     for rule in rules {
-        if rule.pseudo_element == Some(pseudo)
-            && selector_matches(&rule.selector, tag_name, classes, id)
+        if rule.pseudo_element != Some(pseudo)
+            || !selector_matches(&rule.selector, tag_name, classes, id)
         {
-            if let Some(CssValue::Keyword(k)) = rule.declarations.get("content") {
-                let items = crate::style::computed::parse_content_value_pub(k);
-                if !items.is_empty() {
-                    let text = resolve_content(&items, attributes, counter_state);
-                    if !text.is_empty() {
-                        return Some(text);
-                    }
-                }
-            }
+            continue;
+        }
+
+        let Some(CssValue::Keyword(k)) = rule.declarations.get("content") else {
+            continue;
+        };
+
+        let items = crate::style::computed::parse_content_value_pub(k);
+        if items.is_empty() {
+            continue;
+        }
+
+        let text = resolve_content(&items, attributes, counter_state);
+        if !text.is_empty() {
+            return Some(text);
         }
     }
     None

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -751,7 +751,11 @@ fn flatten_element(
 
     if el.tag == HtmlTag::Svg {
         let text_ctx = crate::parser::svg::SvgTextContext {
-            font_family: match (&style.font_family, style.font_weight == FontWeight::Bold, style.font_style == FontStyle::Italic) {
+            font_family: match (
+                &style.font_family,
+                style.font_weight == FontWeight::Bold,
+                style.font_style == FontStyle::Italic,
+            ) {
                 (FontFamily::Helvetica, true, true) => "Helvetica-BoldOblique",
                 (FontFamily::Helvetica, true, false) => "Helvetica-Bold",
                 (FontFamily::Helvetica, false, true) => "Helvetica-Oblique",
@@ -768,14 +772,20 @@ fn flatten_element(
                 (FontFamily::Custom(_), true, false) => "Helvetica-Bold",
                 (FontFamily::Custom(_), false, true) => "Helvetica-Oblique",
                 (FontFamily::Custom(_), false, false) => "Helvetica",
-            }.to_string(),
+            }
+            .to_string(),
             font_size: style.font_size,
             font_bold: style.font_weight == FontWeight::Bold,
             font_italic: style.font_style == FontStyle::Italic,
-            color: Some((style.color.r as f32 / 255.0, style.color.g as f32 / 255.0, style.color.b as f32 / 255.0)),
+            color: Some((
+                style.color.r as f32 / 255.0,
+                style.color.g as f32 / 255.0,
+                style.color.b as f32 / 255.0,
+            )),
         };
         if let Some(tree) = crate::parser::svg::parse_svg_from_element_with_ctx(el, text_ctx) {
-            let (svg_width, svg_height) = resolve_svg_size(&tree, available_width, available_height);
+            let (svg_width, svg_height) =
+                resolve_svg_size(&tree, available_width, available_height);
             output.push(LayoutElement::Svg {
                 tree,
                 width: svg_width,
@@ -1777,7 +1787,11 @@ fn resolve_svg_size(
     available_height: f32,
 ) -> (f32, f32) {
     let intrinsic_width = if tree.width > 0.0 { tree.width } else { 300.0 };
-    let intrinsic_height = if tree.height > 0.0 { tree.height } else { 150.0 };
+    let intrinsic_height = if tree.height > 0.0 {
+        tree.height
+    } else {
+        150.0
+    };
     let intrinsic_ratio = if let Some(vb) = &tree.view_box {
         if vb.width > 0.0 {
             vb.height / vb.width

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -783,9 +783,17 @@ fn flatten_element(
                 style.color.b as f32 / 255.0,
             )),
         };
-        if let Some(tree) = crate::parser::svg::parse_svg_from_element_with_ctx(el, text_ctx) {
+        if let Some(initial_tree) =
+            crate::parser::svg::parse_svg_from_element_with_ctx(el, text_ctx.clone())
+        {
             let (svg_width, svg_height) =
-                resolve_svg_size(&tree, available_width, available_height);
+                resolve_svg_size(&initial_tree, available_width, available_height);
+            let tree = crate::parser::svg::parse_svg_from_element_with_ctx_and_viewport(
+                el,
+                text_ctx,
+                Some((svg_width, svg_height)),
+            )
+            .unwrap_or(initial_tree);
             output.push(LayoutElement::Svg {
                 tree,
                 width: svg_width,

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -506,6 +506,7 @@ pub fn layout_with_rules_and_fonts(
         nodes,
         &parent_style,
         available_width,
+        content_height,
         &mut elements,
         None,
         rules,
@@ -522,6 +523,7 @@ fn flatten_nodes(
     nodes: &[DomNode],
     parent_style: &ComputedStyle,
     available_width: f32,
+    available_height: f32,
     output: &mut Vec<LayoutElement>,
     list_ctx: Option<&ListContext>,
     rules: &[CssRule],
@@ -601,6 +603,7 @@ fn flatten_nodes(
                     el,
                     parent_style,
                     available_width,
+                    available_height,
                     output,
                     list_ctx,
                     rules,
@@ -640,6 +643,7 @@ fn flatten_element(
     el: &ElementNode,
     parent_style: &ComputedStyle,
     available_width: f32,
+    available_height: f32,
     output: &mut Vec<LayoutElement>,
     list_ctx: Option<&ListContext>,
     rules: &[CssRule],
@@ -667,6 +671,7 @@ fn flatten_element(
         &el.attributes,
         &selector_ctx,
     );
+    let available_height = style.height.unwrap_or(available_height);
 
     // display: none — skip this element entirely
     if style.display == Display::None {
@@ -770,8 +775,7 @@ fn flatten_element(
             color: Some((style.color.r as f32 / 255.0, style.color.g as f32 / 255.0, style.color.b as f32 / 255.0)),
         };
         if let Some(tree) = crate::parser::svg::parse_svg_from_element_with_ctx(el, text_ctx) {
-            let svg_width = tree.width.min(available_width);
-            let svg_height = tree.height;
+            let (svg_width, svg_height) = resolve_svg_size(&tree, available_width, available_height);
             output.push(LayoutElement::Svg {
                 tree,
                 width: svg_width,
@@ -1124,6 +1128,7 @@ fn flatten_element(
                         child_el,
                         &style,
                         inner_width,
+                        available_height,
                         output,
                         Some(&ctx),
                         rules,
@@ -1141,6 +1146,7 @@ fn flatten_element(
                         child_el,
                         &style,
                         inner_width,
+                        available_height,
                         output,
                         None,
                         rules,
@@ -1258,6 +1264,7 @@ fn flatten_element(
                         child_el,
                         &style,
                         inner_width,
+                        available_height,
                         output,
                         list_ctx,
                         rules,
@@ -1272,6 +1279,7 @@ fn flatten_element(
                         child_el,
                         &style,
                         available_width,
+                        available_height,
                         output,
                         None,
                         rules,
@@ -1559,6 +1567,7 @@ fn flatten_element(
                             child_el,
                             &style,
                             inner_width,
+                            available_height,
                             &mut child_elements,
                             None,
                             rules,
@@ -1727,6 +1736,7 @@ fn flatten_element(
                             child_el,
                             &style,
                             inner_width,
+                            available_height,
                             output,
                             None,
                             rules,
@@ -1747,6 +1757,7 @@ fn flatten_element(
             &el.children,
             &style,
             available_width,
+            available_height,
             output,
             None,
             rules,
@@ -1758,6 +1769,82 @@ fn flatten_element(
     if style.page_break_after {
         output.push(LayoutElement::PageBreak);
     }
+}
+
+fn resolve_svg_size(
+    tree: &crate::parser::svg::SvgTree,
+    available_width: f32,
+    available_height: f32,
+) -> (f32, f32) {
+    let intrinsic_width = if tree.width > 0.0 { tree.width } else { 300.0 };
+    let intrinsic_height = if tree.height > 0.0 { tree.height } else { 150.0 };
+    let intrinsic_ratio = if let Some(vb) = &tree.view_box {
+        if vb.width > 0.0 {
+            vb.height / vb.width
+        } else {
+            intrinsic_height / intrinsic_width.max(1.0)
+        }
+    } else {
+        intrinsic_height / intrinsic_width.max(1.0)
+    };
+
+    let width = resolve_svg_dimension(
+        tree.width_attr.as_deref(),
+        intrinsic_width,
+        available_width,
+        true,
+    );
+    let height = resolve_svg_dimension(
+        tree.height_attr.as_deref(),
+        intrinsic_height,
+        available_height,
+        true,
+    );
+
+    if matches!(
+        (tree.width_attr.as_deref(), tree.height_attr.as_deref()),
+        (Some(w_attr), None) if w_attr.trim_end().ends_with('%')
+    ) {
+        return (width, width * intrinsic_ratio);
+    }
+
+    if matches!(
+        (tree.width_attr.as_deref(), tree.height_attr.as_deref()),
+        (None, Some(h_attr)) if h_attr.trim_end().ends_with('%')
+    ) {
+        return (height / intrinsic_ratio.max(f32::EPSILON), height);
+    }
+
+    if tree.width_attr.is_none() && tree.height_attr.is_none() {
+        return (width.min(available_width), height);
+    }
+
+    (width, height)
+}
+
+fn resolve_svg_dimension(
+    raw: Option<&str>,
+    fallback: f32,
+    available_width: f32,
+    allow_percent: bool,
+) -> f32 {
+    let Some(raw) = raw else {
+        return fallback;
+    };
+    let raw = raw.trim();
+    if let Some(pct) = raw.strip_suffix('%') {
+        if allow_percent {
+            if let Ok(value) = pct.trim().parse::<f32>() {
+                if value >= 0.0 {
+                    return available_width * (value / 100.0);
+                }
+            }
+        }
+        return fallback;
+    }
+
+    let value = crate::parser::svg::parse_length(raw).unwrap_or(fallback);
+    if value >= 0.0 { value } else { fallback }
 }
 
 /// Lay out children of a `display: flex` container.
@@ -4098,6 +4185,7 @@ mod tests {
     use super::*;
     use crate::parser::css::parse_stylesheet;
     use crate::parser::html::{parse_html, parse_html_with_styles};
+    use crate::parser::svg::SvgTree;
 
     #[test]
     fn layout_simple_paragraph() {
@@ -4163,6 +4251,38 @@ mod tests {
         let nodes = parse_html(html).unwrap();
         let pages = layout(&nodes, PageSize::A4, Margin::default());
         assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn svg_size_percent_height_resolves_against_available_height() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 60.0,
+            width_attr: Some("100".to_string()),
+            height_attr: Some("50%".to_string()),
+            view_box: None,
+            children: vec![],
+            text_ctx: crate::parser::svg::SvgTextContext::default(),
+        };
+
+        assert_eq!(resolve_svg_size(&tree, 400.0, 400.0), (100.0, 200.0));
+    }
+
+    #[test]
+    fn nested_svg_percent_height_uses_parent_height() {
+        let html = r#"<div style="height: 200pt"><svg width="100" height="50%"></svg></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let svg = pages[0]
+            .elements
+            .iter()
+            .find_map(|(_, el)| match el {
+                LayoutElement::Svg { width, height, .. } => Some((*width, *height)),
+                _ => None,
+            })
+            .expect("expected nested svg element");
+        assert!((svg.0 - 100.0).abs() < 0.1);
+        assert!((svg.1 - 100.0).abs() < 0.1);
     }
 
     #[test]

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -505,6 +505,7 @@ pub fn layout_with_rules_and_fonts(
         &parent_style,
         available_width,
         content_height,
+        false,
         &mut elements,
         None,
         rules,
@@ -522,6 +523,7 @@ fn flatten_nodes(
     parent_style: &ComputedStyle,
     available_width: f32,
     available_height: f32,
+    available_height_is_definite: bool,
     output: &mut Vec<LayoutElement>,
     list_ctx: Option<&ListContext>,
     rules: &[CssRule],
@@ -602,6 +604,7 @@ fn flatten_nodes(
                     parent_style,
                     available_width,
                     available_height,
+                    available_height_is_definite,
                     output,
                     list_ctx,
                     rules,
@@ -642,6 +645,7 @@ fn flatten_element(
     parent_style: &ComputedStyle,
     available_width: f32,
     available_height: f32,
+    available_height_is_definite: bool,
     output: &mut Vec<LayoutElement>,
     list_ctx: Option<&ListContext>,
     rules: &[CssRule],
@@ -670,6 +674,7 @@ fn flatten_element(
         &selector_ctx,
     );
     let available_height = style.height.unwrap_or(available_height);
+    let available_height_is_definite = style.height.is_some() || available_height_is_definite;
 
     // display: none — skip this element entirely
     if style.display == Display::None {
@@ -784,8 +789,12 @@ fn flatten_element(
         if let Some(initial_tree) =
             crate::parser::svg::parse_svg_from_element_with_ctx(el, text_ctx.clone())
         {
-            let (svg_width, svg_height) =
-                resolve_svg_size(&initial_tree, available_width, available_height);
+            let (svg_width, svg_height) = resolve_svg_size(
+                &initial_tree,
+                available_width,
+                available_height,
+                available_height_is_definite,
+            );
             let tree = crate::parser::svg::parse_svg_from_element_with_ctx_and_viewport(
                 el,
                 text_ctx,
@@ -1145,6 +1154,7 @@ fn flatten_element(
                         &style,
                         inner_width,
                         available_height,
+                        available_height_is_definite,
                         output,
                         Some(&ctx),
                         rules,
@@ -1163,6 +1173,7 @@ fn flatten_element(
                         &style,
                         inner_width,
                         available_height,
+                        available_height_is_definite,
                         output,
                         None,
                         rules,
@@ -1281,6 +1292,7 @@ fn flatten_element(
                         &style,
                         inner_width,
                         available_height,
+                        available_height_is_definite,
                         output,
                         list_ctx,
                         rules,
@@ -1296,6 +1308,7 @@ fn flatten_element(
                         &style,
                         available_width,
                         available_height,
+                        available_height_is_definite,
                         output,
                         None,
                         rules,
@@ -1584,6 +1597,7 @@ fn flatten_element(
                             &style,
                             inner_width,
                             available_height,
+                            available_height_is_definite,
                             &mut child_elements,
                             None,
                             rules,
@@ -1753,6 +1767,7 @@ fn flatten_element(
                             &style,
                             inner_width,
                             available_height,
+                            available_height_is_definite,
                             output,
                             None,
                             rules,
@@ -1774,6 +1789,7 @@ fn flatten_element(
             &style,
             available_width,
             available_height,
+            available_height_is_definite,
             output,
             None,
             rules,
@@ -1791,6 +1807,7 @@ fn resolve_svg_size(
     tree: &crate::parser::svg::SvgTree,
     available_width: f32,
     available_height: f32,
+    available_height_is_definite: bool,
 ) -> (f32, f32) {
     let intrinsic_width = if tree.width > 0.0 { tree.width } else { 300.0 };
     let intrinsic_height = if tree.height > 0.0 {
@@ -1808,35 +1825,48 @@ fn resolve_svg_size(
         intrinsic_height / intrinsic_width.max(1.0)
     };
 
-    let width = resolve_svg_dimension(
+    let mut width = resolve_svg_dimension(
         tree.width_attr.as_deref(),
         intrinsic_width,
         available_width,
         true,
     );
-    let height = resolve_svg_dimension(
+    let mut height = resolve_svg_dimension(
         tree.height_attr.as_deref(),
         intrinsic_height,
         available_height,
-        true,
+        available_height_is_definite,
     );
+    let height_is_auto = match tree.height_attr.as_deref() {
+        None => true,
+        Some(raw) if raw.trim_end().ends_with('%') && !available_height_is_definite => true,
+        _ => false,
+    };
 
     if matches!(
         (tree.width_attr.as_deref(), tree.height_attr.as_deref()),
         (Some(w_attr), None) if w_attr.trim_end().ends_with('%')
     ) {
-        return (width, width * intrinsic_ratio);
+        height = width * intrinsic_ratio;
     }
 
     if matches!(
         (tree.width_attr.as_deref(), tree.height_attr.as_deref()),
         (None, Some(h_attr)) if h_attr.trim_end().ends_with('%')
     ) {
-        return (height / intrinsic_ratio.max(f32::EPSILON), height);
+        width = height / intrinsic_ratio.max(f32::EPSILON);
     }
 
-    if tree.width_attr.is_none() && tree.height_attr.is_none() {
-        return (width.min(available_width), height);
+    if width > available_width {
+        let scale = if width > 0.0 {
+            available_width / width
+        } else {
+            1.0
+        };
+        width = available_width;
+        if height_is_auto {
+            height *= scale;
+        }
     }
 
     (width, height)
@@ -4285,7 +4315,37 @@ mod tests {
             text_ctx: crate::parser::svg::SvgTextContext::default(),
         };
 
-        assert_eq!(resolve_svg_size(&tree, 400.0, 400.0), (100.0, 200.0));
+        assert_eq!(resolve_svg_size(&tree, 400.0, 400.0, true), (100.0, 200.0));
+    }
+
+    #[test]
+    fn root_svg_percent_height_does_not_use_page_height_fallback() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 150.0,
+            width_attr: Some("100".to_string()),
+            height_attr: Some("50%".to_string()),
+            view_box: None,
+            children: vec![],
+            text_ctx: crate::parser::svg::SvgTextContext::default(),
+        };
+
+        assert_eq!(resolve_svg_size(&tree, 400.0, 400.0, false), (100.0, 150.0));
+    }
+
+    #[test]
+    fn svg_width_is_clamped_to_available_width() {
+        let tree = SvgTree {
+            width: 500.0,
+            height: 150.0,
+            width_attr: Some("500".to_string()),
+            height_attr: None,
+            view_box: None,
+            children: vec![],
+            text_ctx: crate::parser::svg::SvgTextContext::default(),
+        };
+
+        assert_eq!(resolve_svg_size(&tree, 320.0, 400.0, true), (320.0, 96.0));
     }
 
     #[test]

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -4161,7 +4161,7 @@ fn load_image_data(src: &str) -> Option<(Vec<u8>, ImageFormat, Option<PngMetadat
         };
         // For PNG, we pass the IDAT data (already zlib-compressed) to PDF
         Some((png_info.idat_data, ImageFormat::Png, Some(metadata)))
-    } else if raw.len() >= 2 && raw[0] == 0xFF && raw[1] == 0xD8 {
+    } else if raw.starts_with(&[0xFF, 0xD8]) {
         // JPEG: pass entire file as-is
         Some((raw, ImageFormat::Jpeg, None))
     } else {

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -745,7 +745,31 @@ fn flatten_element(
     }
 
     if el.tag == HtmlTag::Svg {
-        if let Some(tree) = crate::parser::svg::parse_svg_from_element(el) {
+        let text_ctx = crate::parser::svg::SvgTextContext {
+            font_family: match (&style.font_family, style.font_weight == FontWeight::Bold, style.font_style == FontStyle::Italic) {
+                (FontFamily::Helvetica, true, true) => "Helvetica-BoldOblique",
+                (FontFamily::Helvetica, true, false) => "Helvetica-Bold",
+                (FontFamily::Helvetica, false, true) => "Helvetica-Oblique",
+                (FontFamily::Helvetica, false, false) => "Helvetica",
+                (FontFamily::TimesRoman, true, true) => "Times-BoldItalic",
+                (FontFamily::TimesRoman, true, false) => "Times-Bold",
+                (FontFamily::TimesRoman, false, true) => "Times-Italic",
+                (FontFamily::TimesRoman, false, false) => "Times-Roman",
+                (FontFamily::Courier, true, true) => "Courier-BoldOblique",
+                (FontFamily::Courier, true, false) => "Courier-Bold",
+                (FontFamily::Courier, false, true) => "Courier-Oblique",
+                (FontFamily::Courier, false, false) => "Courier",
+                (FontFamily::Custom(_), true, true) => "Helvetica-BoldOblique",
+                (FontFamily::Custom(_), true, false) => "Helvetica-Bold",
+                (FontFamily::Custom(_), false, true) => "Helvetica-Oblique",
+                (FontFamily::Custom(_), false, false) => "Helvetica",
+            }.to_string(),
+            font_size: style.font_size,
+            font_bold: style.font_weight == FontWeight::Bold,
+            font_italic: style.font_style == FontStyle::Italic,
+            color: Some((style.color.r as f32 / 255.0, style.color.g as f32 / 255.0, style.color.b as f32 / 255.0)),
+        };
+        if let Some(tree) = crate::parser::svg::parse_svg_from_element_with_ctx(el, text_ctx) {
             let svg_width = tree.width.min(available_width);
             let svg_height = tree.height;
             output.push(LayoutElement::Svg {

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -1,14 +1,85 @@
 //! SVG parser — converts DOM SVG elements into an SvgTree for PDF rendering.
 
-use crate::parser::dom::ElementNode;
+use crate::parser::dom::{DomNode, ElementNode};
+
+/// Split a style declaration string on `;`, respecting quoted strings and
+/// parenthesized function arguments.
+fn split_style_declarations(style: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let bytes = style.as_bytes();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut paren_depth = 0usize;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' if !in_double_quote && paren_depth > 0 => in_single_quote = !in_single_quote,
+            b'"' if !in_single_quote && paren_depth > 0 => in_double_quote = !in_double_quote,
+            b'(' if !in_single_quote && !in_double_quote => paren_depth += 1,
+            b')' if !in_single_quote && !in_double_quote && paren_depth > 0 => paren_depth -= 1,
+            b';' if !in_single_quote && !in_double_quote && paren_depth == 0 => {
+                parts.push(&style[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if start < style.len() {
+        parts.push(&style[start..]);
+    }
+    parts
+}
+
+fn style_property_value<'a>(el: &'a ElementNode, name: &str) -> Option<&'a str> {
+    let style_val = el.attributes.get("style")?;
+    let mut value = None;
+
+    for part in split_style_declarations(style_val) {
+        let part = part.trim();
+        if let Some((prop, val)) = part.split_once(':') {
+            if prop.trim() == name {
+                value = Some(val.trim());
+            }
+        }
+    }
+
+    value
+}
+
+/// Inherited CSS context for SVG text rendering.
+#[derive(Debug, Clone)]
+pub struct SvgTextContext {
+    pub font_family: String,
+    pub font_size: f32,
+    pub font_bold: bool,
+    pub font_italic: bool,
+    pub color: Option<(f32, f32, f32)>,
+}
+
+impl Default for SvgTextContext {
+    fn default() -> Self {
+        Self {
+            font_family: "Helvetica".to_string(),
+            font_size: 12.0,
+            font_bold: false,
+            font_italic: false,
+            color: None,
+        }
+    }
+}
 
 /// A parsed SVG tree ready for rendering.
 #[derive(Debug, Clone)]
 pub struct SvgTree {
     pub width: f32,
     pub height: f32,
+    pub width_attr: Option<String>,
+    pub height_attr: Option<String>,
     pub view_box: Option<ViewBox>,
     pub children: Vec<SvgNode>,
+    pub text_ctx: SvgTextContext,
 }
 
 #[derive(Debug, Clone)]
@@ -67,14 +138,68 @@ pub enum SvgNode {
         commands: Vec<PathCommand>,
         style: SvgStyle,
     },
+    Text {
+        x: f32,
+        y: f32,
+        font_size: Option<f32>,
+        font_size_attr: Option<String>,
+        /// True when the element explicitly set `fill` (including `none`).
+        fill_specified: bool,
+        fill_raw: Option<String>,
+        /// Per-element font-family override (resolved PDF name, e.g. "Helvetica-Bold").
+        font_family: Option<String>,
+        /// Per-element font-weight override (true = bold).
+        font_bold: Option<bool>,
+        /// Per-element font-style override (true = italic/oblique).
+        font_italic: Option<bool>,
+        content: String,
+        style: SvgStyle,
+    },
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum SvgPaint {
+    /// The property was not specified on this element (so it should inherit from its parent).
+    #[default]
+    Unspecified,
+    /// The property was explicitly set to `none`.
+    None,
+    /// `currentColor` keyword (resolves to the CSS `color` property).
+    CurrentColor,
+    /// An explicit sRGB color (0.0-1.0 per channel).
+    Color((f32, f32, f32)),
+}
+
+#[derive(Debug, Clone)]
 pub struct SvgStyle {
-    pub fill: Option<(f32, f32, f32)>,   // RGB 0.0-1.0, None = no fill
-    pub stroke: Option<(f32, f32, f32)>, // RGB 0.0-1.0, None = no stroke
-    pub stroke_width: f32,
+    pub color: Option<(f32, f32, f32)>,
+    pub fill: SvgPaint,
+    pub stroke: SvgPaint,
+    /// `stroke-width` is inherited in SVG.
+    pub stroke_width: Option<f32>,
+    /// Inherited SVG font-family, resolved to a PDF base family name.
+    pub font_family: Option<String>,
+    /// Inherited SVG font-weight.
+    pub font_bold: Option<bool>,
+    /// Inherited SVG font-style.
+    pub font_italic: Option<bool>,
+    // Opacity isn't wired through to PDF output yet; keep it simple until needed.
     pub opacity: f32,
+}
+
+impl Default for SvgStyle {
+    fn default() -> Self {
+        Self {
+            color: None,
+            fill: SvgPaint::Unspecified,
+            stroke: SvgPaint::Unspecified,
+            stroke_width: None,
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
+            opacity: 1.0,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -93,53 +218,106 @@ pub enum PathCommand {
 
 /// Entry point: parse an `<svg>` ElementNode into an SvgTree.
 pub fn parse_svg_from_element(el: &ElementNode) -> Option<SvgTree> {
-    let width = el
-        .attributes
-        .get("width")
-        .and_then(|v| parse_length(v))
+    parse_svg_from_element_with_ctx_and_viewport(el, SvgTextContext::default(), None)
+}
+
+pub fn parse_svg_from_element_with_ctx(
+    el: &ElementNode,
+    text_ctx: SvgTextContext,
+) -> Option<SvgTree> {
+    parse_svg_from_element_with_ctx_and_viewport(el, text_ctx, None)
+}
+
+pub fn parse_svg_from_element_with_ctx_and_viewport(
+    el: &ElementNode,
+    text_ctx: SvgTextContext,
+    root_viewport_override: Option<(f32, f32)>,
+) -> Option<SvgTree> {
+    let width_attr = el.attributes.get("width").cloned();
+    let height_attr = el.attributes.get("height").cloned();
+    let parsed_width = width_attr
+        .as_deref()
+        .and_then(parse_absolute_length)
         .unwrap_or(300.0);
-    let height = el
-        .attributes
-        .get("height")
-        .and_then(|v| parse_length(v))
+    let parsed_height = height_attr
+        .as_deref()
+        .and_then(parse_absolute_length)
         .unwrap_or(150.0);
+    let (width, height) = root_viewport_override.unwrap_or((parsed_width, parsed_height));
     let view_box = el.attributes.get("viewBox").and_then(|v| parse_viewbox(v));
 
-    let mut children = Vec::new();
-    for child in &el.children {
-        if let crate::parser::dom::DomNode::Element(child_el) = child {
-            if let Some(node) = parse_svg_node(child_el) {
-                children.push(node);
-            }
-        }
-    }
+    let root_style = parse_svg_style(el);
+    let root_transform = el
+        .attributes
+        .get("transform")
+        .and_then(|v| parse_transform(v));
+    let root_viewport = Some((width, height));
+    let children = parse_svg_children(&el.children, root_viewport);
+    let children = if root_transform.is_some() || !svg_style_is_default(&root_style) {
+        vec![SvgNode::Group {
+            transform: root_transform,
+            children,
+            style: root_style,
+        }]
+    } else {
+        children
+    };
 
     Some(SvgTree {
         width,
         height,
+        width_attr,
+        height_attr,
         view_box,
         children,
+        text_ctx,
     })
 }
 
 /// Parse a single SVG element node into an SvgNode.
 fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
+    parse_svg_node_with_viewport(el, None)
+}
+
+fn parse_svg_children(children: &[DomNode], viewport: Option<(f32, f32)>) -> Vec<SvgNode> {
+    children
+        .iter()
+        .filter_map(|child| match child {
+            DomNode::Element(child_el) => parse_svg_node_with_viewport(child_el, viewport),
+            _ => None,
+        })
+        .collect()
+}
+
+fn parse_svg_node_with_viewport(
+    el: &ElementNode,
+    parent_viewport: Option<(f32, f32)>,
+) -> Option<SvgNode> {
     let tag = el.raw_tag_name.as_str();
     match tag {
-        "g" | "svg" => {
+        "g" => {
             let transform = el
                 .attributes
                 .get("transform")
                 .and_then(|v| parse_transform(v));
             let style = parse_svg_style(el);
-            let mut children = Vec::new();
-            for child in &el.children {
-                if let crate::parser::dom::DomNode::Element(child_el) = child {
-                    if let Some(node) = parse_svg_node(child_el) {
-                        children.push(node);
-                    }
-                }
-            }
+            let children = parse_svg_children(&el.children, parent_viewport);
+            Some(SvgNode::Group {
+                transform,
+                children,
+                style,
+            })
+        }
+        "svg" => {
+            let child_viewport = resolve_nested_svg_viewport(el, parent_viewport);
+            let transform = compose_transform(
+                el.attributes
+                    .get("transform")
+                    .and_then(|v| parse_transform(v)),
+                nested_svg_viewport_transform(el, child_viewport),
+            );
+            let style = parse_svg_style(el);
+            let children = parse_svg_children(&el.children, child_viewport);
             Some(SvgNode::Group {
                 transform,
                 children,
@@ -226,7 +404,128 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
             let style = parse_svg_style(el);
             Some(SvgNode::Path { commands, style })
         }
+        "text" => {
+            let (x, y) = resolve_text_position(el, parent_viewport);
+            let font_size_attr = parse_font_size_attr(el);
+            let font_size = font_size_attr.as_deref().and_then(parse_absolute_length);
+            let fill_specified = has_fill_specified(el);
+            let fill_raw = parse_fill_raw(el);
+            let (font_family, font_bold, font_italic) = parse_svg_font_attrs(el);
+            let content = collect_text_content(el);
+            let style = parse_svg_style(el);
+            Some(SvgNode::Text {
+                x,
+                y,
+                font_size,
+                font_size_attr,
+                fill_specified,
+                fill_raw,
+                font_family,
+                font_bold,
+                font_italic,
+                content,
+                style,
+            })
+        }
         _ => None,
+    }
+}
+
+fn svg_style_is_default(style: &SvgStyle) -> bool {
+    style.color.is_none()
+        && matches!(style.fill, SvgPaint::Unspecified)
+        && matches!(style.stroke, SvgPaint::Unspecified)
+        && style.stroke_width.is_none()
+        && (style.opacity - 1.0).abs() < f32::EPSILON
+}
+
+fn compose_transform(
+    outer: Option<SvgTransform>,
+    inner: Option<SvgTransform>,
+) -> Option<SvgTransform> {
+    match (outer, inner) {
+        (
+            Some(SvgTransform::Matrix(a1, b1, c1, d1, e1, f1)),
+            Some(SvgTransform::Matrix(a2, b2, c2, d2, e2, f2)),
+        ) => Some(SvgTransform::Matrix(
+            a1 * a2 + c1 * b2,
+            b1 * a2 + d1 * b2,
+            a1 * c2 + c1 * d2,
+            b1 * c2 + d1 * d2,
+            a1 * e2 + c1 * f2 + e1,
+            b1 * e2 + d1 * f2 + f1,
+        )),
+        (Some(transform), None) | (None, Some(transform)) => Some(transform),
+        (None, None) => None,
+    }
+}
+
+fn resolve_nested_svg_viewport(
+    el: &ElementNode,
+    parent_viewport: Option<(f32, f32)>,
+) -> Option<(f32, f32)> {
+    let (parent_width, parent_height) = parent_viewport?;
+    Some((
+        resolve_svg_viewport_length(el.attributes.get("width"), Some(parent_width), 300.0),
+        resolve_svg_viewport_length(el.attributes.get("height"), Some(parent_height), 150.0),
+    ))
+}
+
+fn resolve_svg_viewport_length(
+    attr: Option<&String>,
+    parent_extent: Option<f32>,
+    fallback: f32,
+) -> f32 {
+    match attr.map(String::as_str) {
+        Some(value) => {
+            let trimmed = value.trim();
+            if let Some(pct) = trimmed.strip_suffix('%') {
+                pct.trim()
+                    .parse::<f32>()
+                    .ok()
+                    .and_then(|pct| parent_extent.map(|extent| extent * pct / 100.0))
+                    .unwrap_or(fallback)
+            } else {
+                parse_absolute_length(trimmed).unwrap_or(fallback)
+            }
+        }
+        None => parent_extent.unwrap_or(fallback),
+    }
+}
+
+fn nested_svg_viewport_transform(
+    el: &ElementNode,
+    viewport: Option<(f32, f32)>,
+) -> Option<SvgTransform> {
+    let x = attr_f32(el, "x");
+    let y = attr_f32(el, "y");
+    let view_box = el.attributes.get("viewBox").and_then(|v| parse_viewbox(v));
+
+    if let Some(vb) = view_box {
+        let (width, height) = viewport.unwrap_or_else(|| {
+            (
+                resolve_svg_viewport_length(el.attributes.get("width"), None, 300.0),
+                resolve_svg_viewport_length(el.attributes.get("height"), None, 150.0),
+            )
+        });
+        if vb.width > 0.0 && vb.height > 0.0 {
+            let scale_x = width / vb.width;
+            let scale_y = height / vb.height;
+            return Some(SvgTransform::Matrix(
+                scale_x,
+                0.0,
+                0.0,
+                scale_y,
+                x - vb.min_x * scale_x,
+                y - vb.min_y * scale_y,
+            ));
+        }
+    }
+
+    if x != 0.0 || y != 0.0 {
+        Some(SvgTransform::Matrix(1.0, 0.0, 0.0, 1.0, x, y))
+    } else {
+        None
     }
 }
 
@@ -238,53 +537,269 @@ fn attr_f32(el: &ElementNode, name: &str) -> f32 {
         .unwrap_or(0.0)
 }
 
+fn resolve_text_position(el: &ElementNode, viewport: Option<(f32, f32)>) -> (f32, f32) {
+    let x = resolve_svg_text_coordinate(
+        el.attributes.get("x").map(String::as_str),
+        viewport.map(|(w, _)| w),
+    );
+    let y = resolve_svg_text_coordinate(
+        el.attributes.get("y").map(String::as_str),
+        viewport.map(|(_, h)| h),
+    );
+    (x, y)
+}
+
+fn resolve_svg_text_coordinate(value: Option<&str>, viewport: Option<f32>) -> f32 {
+    let Some(raw) = value else {
+        return 0.0;
+    };
+    let trimmed = raw.trim();
+    if let Some(pct) = trimmed.strip_suffix('%') {
+        let Ok(percent) = pct.trim().parse::<f32>() else {
+            return 0.0;
+        };
+        return viewport.unwrap_or(0.0) * percent / 100.0;
+    }
+    parse_length(trimmed).unwrap_or(0.0)
+}
+
 /// Parse a length value (strip px/em/etc suffix, parse number).
-fn parse_length(val: &str) -> Option<f32> {
+pub(crate) fn parse_length(val: &str) -> Option<f32> {
     let trimmed = val.trim();
     let num_str = trimmed.trim_end_matches(|c: char| c.is_ascii_alphabetic() || c == '%');
     num_str.trim().parse::<f32>().ok()
 }
 
-/// Parse a viewBox attribute: "min-x min-y width height".
-fn parse_viewbox(val: &str) -> Option<ViewBox> {
-    let parts: Vec<f32> = val
-        .split(|c: char| c == ',' || c.is_whitespace())
-        .filter(|s| !s.is_empty())
-        .filter_map(|s| s.parse().ok())
-        .collect();
-    if parts.len() == 4 {
-        Some(ViewBox {
-            min_x: parts[0],
-            min_y: parts[1],
-            width: parts[2],
-            height: parts[3],
-        })
-    } else {
-        None
+fn parse_absolute_length(val: &str) -> Option<f32> {
+    let trimmed = val.trim();
+    if trimmed.ends_with('%') {
+        return None;
     }
+    parse_length(trimmed)
 }
 
-/// Parse fill, stroke, stroke-width, opacity from element attributes.
+/// Parse a viewBox attribute: "min-x min-y width height".
+fn parse_viewbox(val: &str) -> Option<ViewBox> {
+    let mut parts = val
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| s.parse().ok());
+    let view_box = ViewBox {
+        min_x: parts.next()?,
+        min_y: parts.next()?,
+        width: parts.next()?,
+        height: parts.next()?,
+    };
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(view_box)
+}
+
+/// Parse color, fill, stroke, stroke-width, font, opacity from element attributes.
 fn parse_svg_style(el: &ElementNode) -> SvgStyle {
-    let fill = el.attributes.get("fill").and_then(|v| parse_svg_color(v));
-    let stroke = el.attributes.get("stroke").and_then(|v| parse_svg_color(v));
-    let stroke_width = el
+    fn parse_svg_paint(val: &str) -> Option<SvgPaint> {
+        let val = val.trim();
+        if val.eq_ignore_ascii_case("none") {
+            return Some(SvgPaint::None);
+        }
+        if val.eq_ignore_ascii_case("inherit") {
+            return Some(SvgPaint::Unspecified);
+        }
+        if val.eq_ignore_ascii_case("currentColor") {
+            return Some(SvgPaint::CurrentColor);
+        }
+        parse_svg_color(val).map(SvgPaint::Color)
+    }
+
+    fn parse_svg_color_property(val: &str) -> Option<Option<(f32, f32, f32)>> {
+        let val = val.trim();
+        if val.eq_ignore_ascii_case("inherit") {
+            return Some(None);
+        }
+        parse_svg_color(val).map(Some)
+    }
+
+    let mut color = el
+        .attributes
+        .get("color")
+        .and_then(|v| parse_svg_color_property(v))
+        .flatten();
+    if let Some(val) = style_property_value(el, "color") {
+        if let Some(parsed) = parse_svg_color_property(val) {
+            color = parsed;
+        }
+    }
+    let mut fill = el
+        .attributes
+        .get("fill")
+        .and_then(|v| parse_svg_paint(v))
+        .unwrap_or(SvgPaint::Unspecified);
+    if let Some(paint) = style_property_value(el, "fill").and_then(parse_svg_paint) {
+        fill = paint;
+    }
+    let mut stroke = el
+        .attributes
+        .get("stroke")
+        .and_then(|v| parse_svg_paint(v))
+        .unwrap_or(SvgPaint::Unspecified);
+    if let Some(paint) = style_property_value(el, "stroke").and_then(parse_svg_paint) {
+        stroke = paint;
+    }
+    let mut stroke_width = el
         .attributes
         .get("stroke-width")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(1.0);
-    let opacity = el
+        .and_then(|v| v.trim().parse::<f32>().ok())
+        .filter(|v| *v >= 0.0);
+    if let Some(width) = style_property_value(el, "stroke-width")
+        .and_then(|v| v.parse::<f32>().ok())
+        .filter(|v| *v >= 0.0)
+    {
+        stroke_width = Some(width);
+    }
+    let mut opacity = el
         .attributes
         .get("opacity")
         .and_then(|v| v.parse().ok())
         .unwrap_or(1.0);
+    if let Some(val) = style_property_value(el, "opacity") {
+        opacity = val.trim().parse().ok().unwrap_or(opacity);
+    }
+    let (font_family, font_bold, font_italic) = parse_svg_font_attrs(el);
 
     SvgStyle {
+        color,
         fill,
         stroke,
         stroke_width,
+        font_family,
+        font_bold,
+        font_italic,
         opacity,
     }
+}
+
+/// Extract the raw `font-size` value from a `<text>` element.
+///
+/// Checks the `font-size` attribute first, then falls back to parsing
+/// `font-size:` from the inline `style` attribute.
+fn parse_font_size_attr(el: &ElementNode) -> Option<String> {
+    if let Some(val) = el.attributes.get("font-size") {
+        return Some(val.trim().to_string());
+    }
+    style_property_value(el, "font-size").map(|val| val.to_string())
+}
+
+fn parse_svg_font_family_value(val: &str) -> Option<String> {
+    let val = val.trim();
+    if val.eq_ignore_ascii_case("inherit") {
+        return None;
+    }
+    let val = val.trim_matches(|c| c == '\'' || c == '"');
+    if val.is_empty() {
+        None
+    } else {
+        Some(resolve_svg_font_family(val))
+    }
+}
+
+fn parse_svg_font_weight_value(val: &str) -> Option<bool> {
+    let val = val.trim();
+    if val.eq_ignore_ascii_case("inherit") {
+        return None;
+    }
+    Some(is_bold_value(val))
+}
+
+fn parse_svg_font_style_value(val: &str) -> Option<bool> {
+    let val = val.trim();
+    if val.eq_ignore_ascii_case("inherit") {
+        return None;
+    }
+    Some(is_italic_value(val))
+}
+
+fn parse_svg_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Option<bool>) {
+    let mut family: Option<String> = None;
+    let mut bold: Option<bool> = None;
+    let mut italic: Option<bool> = None;
+
+    if let Some(val) = el.attributes.get("font-family") {
+        family = parse_svg_font_family_value(val);
+    }
+    if let Some(val) = el.attributes.get("font-weight") {
+        bold = parse_svg_font_weight_value(val);
+    }
+    if let Some(val) = el.attributes.get("font-style") {
+        italic = parse_svg_font_style_value(val);
+    }
+
+    if let Some(val) = style_property_value(el, "font-family") {
+        family = parse_svg_font_family_value(val);
+    }
+    if let Some(val) = style_property_value(el, "font-weight") {
+        bold = parse_svg_font_weight_value(val);
+    }
+    if let Some(val) = style_property_value(el, "font-style") {
+        italic = parse_svg_font_style_value(val);
+    }
+
+    (family, bold, italic)
+}
+
+fn has_fill_specified(el: &ElementNode) -> bool {
+    el.attributes.contains_key("fill") || style_property_value(el, "fill").is_some()
+}
+
+fn parse_fill_raw(el: &ElementNode) -> Option<String> {
+    if let Some(raw) = style_property_value(el, "fill") {
+        if !raw.is_empty() {
+            return Some(raw.to_string());
+        }
+    }
+    if let Some(val) = el.attributes.get("fill") {
+        return Some(val.trim().to_string());
+    }
+    None
+}
+
+/// Map a CSS font-family value to a PDF base-font family name.
+fn resolve_svg_font_family(css_family: &str) -> String {
+    let lower = css_family.to_ascii_lowercase();
+    if lower.contains("times") || lower == "serif" {
+        "Times-Roman".to_string()
+    } else if lower.contains("courier") || lower == "monospace" {
+        "Courier".to_string()
+    } else {
+        // Default to Helvetica for sans-serif / Arial / Helvetica / anything else
+        "Helvetica".to_string()
+    }
+}
+
+fn is_bold_value(val: &str) -> bool {
+    let lower = val.to_ascii_lowercase();
+    lower == "bold" || lower == "bolder" || lower.parse::<u32>().is_ok_and(|w| w >= 700)
+}
+
+fn is_italic_value(val: &str) -> bool {
+    let lower = val.to_ascii_lowercase();
+    lower == "italic" || lower == "oblique"
+}
+
+/// Collect all text content from a `<text>` element, including `<tspan>` children.
+fn collect_text_content(el: &ElementNode) -> String {
+    let mut text = String::new();
+    for child in &el.children {
+        match child {
+            crate::parser::dom::DomNode::Text(s) => text.push_str(s),
+            crate::parser::dom::DomNode::Element(child_el) => {
+                if child_el.raw_tag_name == "tspan" {
+                    text.push_str(&collect_text_content(child_el));
+                }
+            }
+        }
+    }
+    text
 }
 
 /// Parse common SVG colors: named, hex (#rgb / #rrggbb), rgb(r,g,b), or "none".
@@ -316,13 +831,14 @@ pub fn parse_svg_color(val: &str) -> Option<(f32, f32, f32)> {
 
     // rgb(r, g, b)
     if let Some(inner) = val.strip_prefix("rgb(").and_then(|s| s.strip_suffix(')')) {
-        let parts: Vec<&str> = inner.split(',').collect();
-        if parts.len() == 3 {
-            let r = parts[0].trim().parse::<f32>().ok()?;
-            let g = parts[1].trim().parse::<f32>().ok()?;
-            let b = parts[2].trim().parse::<f32>().ok()?;
-            return Some((r / 255.0, g / 255.0, b / 255.0));
+        let mut parts = inner.split(',');
+        let r = parts.next()?.trim().parse::<f32>().ok()?;
+        let g = parts.next()?.trim().parse::<f32>().ok()?;
+        let b = parts.next()?.trim().parse::<f32>().ok()?;
+        if parts.next().is_some() {
+            return None;
         }
+        return Some((r / 255.0, g / 255.0, b / 255.0));
     }
 
     None
@@ -330,11 +846,19 @@ pub fn parse_svg_color(val: &str) -> Option<(f32, f32, f32)> {
 
 /// Parse a hex color string (without the #).
 fn parse_hex_color(hex: &str) -> Option<(f32, f32, f32)> {
+    fn hex_digit(c: char) -> Option<u8> {
+        c.to_digit(16).map(|d| d as u8)
+    }
+
     match hex.len() {
         3 => {
-            let r = u8::from_str_radix(&hex[0..1], 16).ok()?;
-            let g = u8::from_str_radix(&hex[1..2], 16).ok()?;
-            let b = u8::from_str_radix(&hex[2..3], 16).ok()?;
+            let mut chars = hex.chars();
+            let r = hex_digit(chars.next()?)?;
+            let g = hex_digit(chars.next()?)?;
+            let b = hex_digit(chars.next()?)?;
+            if chars.next().is_some() {
+                return None;
+            }
             Some((
                 (r * 17) as f32 / 255.0,
                 (g * 17) as f32 / 255.0,
@@ -342,9 +866,13 @@ fn parse_hex_color(hex: &str) -> Option<(f32, f32, f32)> {
             ))
         }
         6 => {
-            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            let mut chars = hex.chars();
+            let r = (hex_digit(chars.next()?)? << 4) | hex_digit(chars.next()?)?;
+            let g = (hex_digit(chars.next()?)? << 4) | hex_digit(chars.next()?)?;
+            let b = (hex_digit(chars.next()?)? << 4) | hex_digit(chars.next()?)?;
+            if chars.next().is_some() {
+                return None;
+            }
             Some((r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0))
         }
         _ => None,
@@ -368,16 +896,18 @@ pub fn parse_path_data(d: &str) -> Vec<PathCommand> {
         let token = &tokens[i];
 
         // Determine if this token is a command letter
-        let cmd_char = if token.len() == 1 && token.as_bytes()[0].is_ascii_alphabetic() {
-            let c = token.chars().next().unwrap();
-            i += 1;
-            c
-        } else {
-            // Implicit repeat of last command (L after M)
-            match last_cmd {
-                'M' => 'L',
-                'm' => 'l',
-                c => c,
+        let cmd_char = match token.as_bytes() {
+            [b] if b.is_ascii_alphabetic() => {
+                i += 1;
+                *b as char
+            }
+            _ => {
+                // Implicit repeat of last command (L after M)
+                match last_cmd {
+                    'M' => 'L',
+                    'm' => 'l',
+                    c => c,
+                }
             }
         };
 
@@ -824,6 +1354,54 @@ mod tests {
     fn parse_svg_color_none() {
         let color = parse_svg_color("none");
         assert_eq!(color, None);
+    }
+
+    #[test]
+    fn parse_svg_style_unparseable_style_fill_does_not_override_attribute() {
+        let el = make_el("rect", vec![("fill", "red"), ("style", "fill: ???;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::Color((1.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn parse_svg_style_style_fill_none_overrides_attribute() {
+        let el = make_el("rect", vec![("fill", "red"), ("style", "fill: none;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::None);
+    }
+
+    #[test]
+    fn parse_svg_style_style_fill_inherit_overrides_attribute() {
+        let el = make_el("rect", vec![("fill", "red"), ("style", "fill: inherit;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::Unspecified);
+    }
+
+    #[test]
+    fn parse_svg_style_unparseable_style_stroke_does_not_override_attribute() {
+        let el = make_el(
+            "rect",
+            vec![("stroke", "blue"), ("style", "stroke: not-a-color;")],
+        );
+        let style = parse_svg_style(&el);
+        assert_eq!(style.stroke, SvgPaint::Color((0.0, 0.0, 1.0)));
+    }
+
+    #[test]
+    fn parse_svg_style_style_stroke_inherit_overrides_attribute() {
+        let el = make_el(
+            "rect",
+            vec![("stroke", "blue"), ("style", "stroke: inherit;")],
+        );
+        let style = parse_svg_style(&el);
+        assert_eq!(style.stroke, SvgPaint::Unspecified);
+    }
+
+    #[test]
+    fn parse_svg_paint_current_color_keyword() {
+        let el = make_el("rect", vec![("fill", "currentColor")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::CurrentColor);
     }
 
     #[test]
@@ -1532,7 +2110,7 @@ mod tests {
 
     #[test]
     fn parse_node_unknown_tag_returns_none() {
-        let el = make_el("text", vec![]);
+        let el = make_el("defs", vec![]);
         assert!(parse_svg_node(&el).is_none());
     }
 
@@ -1542,9 +2120,10 @@ mod tests {
     fn parse_style_defaults() {
         let el = make_el("rect", vec![]);
         let style = parse_svg_style(&el);
-        assert!(style.fill.is_none());
-        assert!(style.stroke.is_none());
-        assert_eq!(style.stroke_width, 1.0);
+        assert_eq!(style.color, None);
+        assert_eq!(style.fill, SvgPaint::Unspecified);
+        assert_eq!(style.stroke, SvgPaint::Unspecified);
+        assert_eq!(style.stroke_width, None);
         assert_eq!(style.opacity, 1.0);
     }
 
@@ -1560,9 +2139,9 @@ mod tests {
             ],
         );
         let style = parse_svg_style(&el);
-        assert_eq!(style.fill, Some((1.0, 0.0, 0.0)));
-        assert_eq!(style.stroke, Some((0.0, 0.0, 1.0)));
-        assert!((style.stroke_width - 2.5).abs() < 0.001);
+        assert_eq!(style.fill, SvgPaint::Color((1.0, 0.0, 0.0)));
+        assert_eq!(style.stroke, SvgPaint::Color((0.0, 0.0, 1.0)));
+        assert_eq!(style.stroke_width, Some(2.5));
         assert!((style.opacity - 0.5).abs() < 0.001);
     }
 
@@ -1570,14 +2149,44 @@ mod tests {
     fn parse_style_fill_none() {
         let el = make_el("rect", vec![("fill", "none")]);
         let style = parse_svg_style(&el);
-        assert!(style.fill.is_none());
+        assert_eq!(style.fill, SvgPaint::None);
+    }
+
+    #[test]
+    fn parse_style_color_inherited_property() {
+        let el = make_el("g", vec![("style", "color: red;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.color, Some((1.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn parse_style_invalid_color_does_not_override_attribute() {
+        let el = make_el("g", vec![("color", "red"), ("style", "color: ???;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.color, Some((1.0, 0.0, 0.0)));
     }
 
     #[test]
     fn parse_style_stroke_none() {
         let el = make_el("rect", vec![("stroke", "none")]);
         let style = parse_svg_style(&el);
-        assert!(style.stroke.is_none());
+        assert_eq!(style.stroke, SvgPaint::None);
+    }
+
+    #[test]
+    fn parse_style_from_style_attribute() {
+        let el = make_el(
+            "rect",
+            vec![(
+                "style",
+                "fill: #00ff00; stroke: rgb(0,0,255); stroke-width: 3; opacity: 0.25;",
+            )],
+        );
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::Color((0.0, 1.0, 0.0)));
+        assert_eq!(style.stroke, SvgPaint::Color((0.0, 0.0, 1.0)));
+        assert_eq!(style.stroke_width, Some(3.0));
+        assert!((style.opacity - 0.25).abs() < 0.001);
     }
 
     // ── parse_svg_from_element ─────────────────────────────────────────
@@ -1611,6 +2220,104 @@ mod tests {
     }
 
     #[test]
+    fn parse_svg_from_element_wraps_root_style_and_transform() {
+        let rect = make_el("rect", vec![("width", "10"), ("height", "10")]);
+        let svg = make_svg_el(
+            vec![("fill", "red"), ("transform", "translate(5, 6)")],
+            vec![rect],
+        );
+        let tree = parse_svg_from_element(&svg).unwrap();
+        assert_eq!(tree.children.len(), 1);
+        match &tree.children[0] {
+            SvgNode::Group {
+                transform,
+                children,
+                style,
+            } => {
+                assert!(matches!(
+                    transform,
+                    Some(SvgTransform::Matrix(1.0, 0.0, 0.0, 1.0, 5.0, 6.0))
+                ));
+                assert!(matches!(style.fill, SvgPaint::Color((1.0, 0.0, 0.0))));
+                assert_eq!(children.len(), 1);
+            }
+            other => panic!("expected wrapped root group, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_text_style_ignores_font_size_adjust_prefix() {
+        let text = make_el(
+            "text",
+            vec![("style", "font-size-adjust: 0.5; font-size: 20px")],
+        );
+        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text]);
+        let tree = parse_svg_from_element(&svg).unwrap();
+        match &tree.children[0] {
+            SvgNode::Text {
+                font_size_attr,
+                font_size,
+                ..
+            } => {
+                assert_eq!(font_size_attr.as_deref(), Some("20px"));
+                assert_eq!(*font_size, Some(20.0));
+            }
+            other => panic!("expected text node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_text_style_ignores_fill_opacity_prefix() {
+        let text = make_el(
+            "text",
+            vec![("style", "fill-opacity: 0.5; fill: currentColor")],
+        );
+        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text]);
+        let tree = parse_svg_from_element(&svg).unwrap();
+        match &tree.children[0] {
+            SvgNode::Text {
+                fill_raw,
+                fill_specified,
+                ..
+            } => {
+                assert!(*fill_specified);
+                assert_eq!(fill_raw.as_deref(), Some("currentColor"));
+            }
+            other => panic!("expected text node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_text_raw_fill_prefers_inline_style_over_attribute() {
+        let text = make_el(
+            "text",
+            vec![("fill", "none"), ("style", "fill: currentColor")],
+        );
+        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text]);
+        let tree = parse_svg_from_element(&svg).unwrap();
+        match &tree.children[0] {
+            SvgNode::Text { fill_raw, .. } => {
+                assert_eq!(fill_raw.as_deref(), Some("currentColor"));
+            }
+            other => panic!("expected text node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_text_percentage_coordinates_use_viewport() {
+        let text = make_el("text", vec![("x", "50%"), ("y", "25%")]);
+        let svg = make_svg_el(vec![("width", "200"), ("height", "100")], vec![text]);
+        let tree = parse_svg_from_element(&svg).unwrap();
+        match &tree.children[0] {
+            SvgNode::Text { x, y, .. } => {
+                assert_eq!(*x, 100.0);
+                assert_eq!(*y, 25.0);
+            }
+            other => panic!("expected text node, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_svg_from_element_text_children_ignored() {
         let mut svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![]);
         svg.children.push(DomNode::Text("some text".to_string()));
@@ -1620,8 +2327,8 @@ mod tests {
 
     #[test]
     fn parse_svg_from_element_unknown_child_skipped() {
-        let text_el = make_el("text", vec![]);
-        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text_el]);
+        let defs_el = make_el("defs", vec![]);
+        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![defs_el]);
         let tree = parse_svg_from_element(&svg).unwrap();
         assert!(tree.children.is_empty());
     }
@@ -1773,6 +2480,87 @@ mod tests {
                 assert_eq!(children.len(), 1);
             }
             _ => panic!("Expected Group for inner svg"),
+        }
+    }
+
+    #[test]
+    fn parse_node_nested_svg_applies_viewport_transform() {
+        let inner = make_el("rect", vec![("width", "10"), ("height", "10")]);
+        let mut svg_inner = make_el(
+            "svg",
+            vec![
+                ("x", "10"),
+                ("y", "20"),
+                ("width", "100"),
+                ("height", "50"),
+                ("viewBox", "0 0 10 5"),
+            ],
+        );
+        svg_inner.children.push(DomNode::Element(inner));
+        let node = parse_svg_node(&svg_inner).unwrap();
+        match node {
+            SvgNode::Group { transform, .. } => {
+                assert!(matches!(
+                    transform,
+                    Some(SvgTransform::Matrix(10.0, 0.0, 0.0, 10.0, 10.0, 20.0))
+                ));
+            }
+            other => panic!("expected nested svg group, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_node_nested_svg_percent_viewport_uses_parent_size() {
+        let inner = make_el("rect", vec![("width", "10"), ("height", "10")]);
+        let mut svg_inner = make_el(
+            "svg",
+            vec![
+                ("width", "100%"),
+                ("height", "50%"),
+                ("viewBox", "0 0 20 10"),
+            ],
+        );
+        svg_inner.children.push(DomNode::Element(inner));
+        let outer = make_svg_el(vec![("width", "200"), ("height", "100")], vec![svg_inner]);
+        let tree = parse_svg_from_element(&outer).unwrap();
+        match &tree.children[0] {
+            SvgNode::Group { transform, .. } => {
+                assert!(matches!(
+                    transform,
+                    Some(SvgTransform::Matrix(10.0, 0.0, 0.0, 5.0, 0.0, 0.0))
+                ));
+            }
+            other => panic!("expected nested svg group, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_svg_with_viewport_override_resolves_nested_percentages() {
+        let inner = make_el("rect", vec![("width", "10"), ("height", "10")]);
+        let mut svg_inner = make_el(
+            "svg",
+            vec![
+                ("width", "50%"),
+                ("height", "50%"),
+                ("viewBox", "0 0 20 10"),
+            ],
+        );
+        svg_inner.children.push(DomNode::Element(inner));
+        let outer = make_svg_el(vec![("width", "100%"), ("height", "100%")], vec![svg_inner]);
+        let tree = parse_svg_from_element_with_ctx_and_viewport(
+            &outer,
+            SvgTextContext::default(),
+            Some((400.0, 200.0)),
+        )
+        .unwrap();
+        match &tree.children[0] {
+            SvgNode::Group { transform, .. } => {
+                assert!(matches!(
+                    transform,
+                    Some(SvgTransform::Matrix(10.0, 0.0, 0.0, 10.0, 0.0, 0.0))
+                ));
+            }
+            other => panic!("expected nested svg group, got {other:?}"),
         }
     }
 

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -1,6 +1,6 @@
 //! SVG parser — converts DOM SVG elements into an SvgTree for PDF rendering.
 
-use crate::parser::dom::ElementNode;
+use crate::parser::dom::{DomNode, ElementNode};
 
 /// Split a style declaration string on `;`, respecting quoted strings and
 /// parenthesized function arguments.
@@ -224,28 +224,22 @@ pub fn parse_svg_from_element_with_ctx_and_viewport(
     let (width, height) = root_viewport_override.unwrap_or((parsed_width, parsed_height));
     let view_box = el.attributes.get("viewBox").and_then(|v| parse_viewbox(v));
 
-    let mut children = Vec::new();
-    let root_viewport = Some((width, height));
-    for child in &el.children {
-        if let crate::parser::dom::DomNode::Element(child_el) = child {
-            if let Some(node) = parse_svg_node_with_viewport(child_el, root_viewport) {
-                children.push(node);
-            }
-        }
-    }
-
     let root_style = parse_svg_style(el);
     let root_transform = el
         .attributes
         .get("transform")
         .and_then(|v| parse_transform(v));
-    if root_transform.is_some() || !svg_style_is_default(&root_style) {
-        children = vec![SvgNode::Group {
+    let root_viewport = Some((width, height));
+    let children = parse_svg_children(&el.children, root_viewport);
+    let children = if root_transform.is_some() || !svg_style_is_default(&root_style) {
+        vec![SvgNode::Group {
             transform: root_transform,
             children,
             style: root_style,
-        }];
-    }
+        }]
+    } else {
+        children
+    };
 
     Some(SvgTree {
         width,
@@ -263,6 +257,16 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
     parse_svg_node_with_viewport(el, None)
 }
 
+fn parse_svg_children(children: &[DomNode], viewport: Option<(f32, f32)>) -> Vec<SvgNode> {
+    children
+        .iter()
+        .filter_map(|child| match child {
+            DomNode::Element(child_el) => parse_svg_node_with_viewport(child_el, viewport),
+            _ => None,
+        })
+        .collect()
+}
+
 fn parse_svg_node_with_viewport(
     el: &ElementNode,
     parent_viewport: Option<(f32, f32)>,
@@ -275,14 +279,7 @@ fn parse_svg_node_with_viewport(
                 .get("transform")
                 .and_then(|v| parse_transform(v));
             let style = parse_svg_style(el);
-            let mut children = Vec::new();
-            for child in &el.children {
-                if let crate::parser::dom::DomNode::Element(child_el) = child {
-                    if let Some(node) = parse_svg_node_with_viewport(child_el, parent_viewport) {
-                        children.push(node);
-                    }
-                }
-            }
+            let children = parse_svg_children(&el.children, parent_viewport);
             Some(SvgNode::Group {
                 transform,
                 children,
@@ -295,17 +292,10 @@ fn parse_svg_node_with_viewport(
                 el.attributes
                     .get("transform")
                     .and_then(|v| parse_transform(v)),
-                nested_svg_viewport_transform(el, parent_viewport),
+                nested_svg_viewport_transform(el, child_viewport),
             );
             let style = parse_svg_style(el);
-            let mut children = Vec::new();
-            for child in &el.children {
-                if let crate::parser::dom::DomNode::Element(child_el) = child {
-                    if let Some(node) = parse_svg_node_with_viewport(child_el, child_viewport) {
-                        children.push(node);
-                    }
-                }
-            }
+            let children = parse_svg_children(&el.children, child_viewport);
             Some(SvgNode::Group {
                 transform,
                 children,
@@ -483,32 +473,19 @@ fn resolve_svg_viewport_length(
 
 fn nested_svg_viewport_transform(
     el: &ElementNode,
-    parent_viewport: Option<(f32, f32)>,
+    viewport: Option<(f32, f32)>,
 ) -> Option<SvgTransform> {
     let x = attr_f32(el, "x");
     let y = attr_f32(el, "y");
     let view_box = el.attributes.get("viewBox").and_then(|v| parse_viewbox(v));
 
     if let Some(vb) = view_box {
-        let (width, height) = parent_viewport
-            .map(|(parent_width, parent_height)| {
-                (
-                    resolve_svg_viewport_length(
-                        el.attributes.get("width"),
-                        Some(parent_width),
-                        300.0,
-                    ),
-                    resolve_svg_viewport_length(
-                        el.attributes.get("height"),
-                        Some(parent_height),
-                        150.0,
-                    ),
-                )
-            })
-            .unwrap_or((
+        let (width, height) = viewport.unwrap_or_else(|| {
+            (
                 resolve_svg_viewport_length(el.attributes.get("width"), None, 300.0),
                 resolve_svg_viewport_length(el.attributes.get("height"), None, 150.0),
-            ));
+            )
+        });
         if vb.width > 0.0 && vb.height > 0.0 {
             let scale_x = width / vb.width;
             let scale_y = height / vb.height;
@@ -2475,10 +2452,7 @@ mod tests {
             ],
         );
         svg_inner.children.push(DomNode::Element(inner));
-        let outer = make_svg_el(
-            vec![("width", "100%"), ("height", "100%")],
-            vec![svg_inner],
-        );
+        let outer = make_svg_el(vec![("width", "100%"), ("height", "100%")], vec![svg_inner]);
         let tree = parse_svg_from_element_with_ctx_and_viewport(
             &outer,
             SvgTextContext::default(),

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -182,6 +182,12 @@ pub struct SvgStyle {
     pub stroke: SvgPaint,
     /// `stroke-width` is inherited in SVG.
     pub stroke_width: Option<f32>,
+    /// Inherited SVG font-family, resolved to a PDF base family name.
+    pub font_family: Option<String>,
+    /// Inherited SVG font-weight.
+    pub font_bold: Option<bool>,
+    /// Inherited SVG font-style.
+    pub font_italic: Option<bool>,
     // Opacity isn't wired through to PDF output yet; keep it simple until needed.
     pub opacity: f32,
 }
@@ -193,6 +199,9 @@ impl Default for SvgStyle {
             fill: SvgPaint::Unspecified,
             stroke: SvgPaint::Unspecified,
             stroke_width: None,
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
@@ -401,8 +410,7 @@ fn parse_svg_node_with_viewport(
             Some(SvgNode::Path { commands, style })
         }
         "text" => {
-            let x = attr_f32(el, "x");
-            let y = attr_f32(el, "y");
+            let (x, y) = resolve_text_position(el, parent_viewport);
             let font_size_attr = parse_font_size_attr(el);
             let font_size = font_size_attr.as_deref().and_then(parse_absolute_length);
             let fill_specified = has_fill_specified(el);
@@ -534,6 +542,32 @@ fn attr_f32(el: &ElementNode, name: &str) -> f32 {
         .unwrap_or(0.0)
 }
 
+fn resolve_text_position(el: &ElementNode, viewport: Option<(f32, f32)>) -> (f32, f32) {
+    let x = resolve_svg_text_coordinate(
+        el.attributes.get("x").map(String::as_str),
+        viewport.map(|(w, _)| w),
+    );
+    let y = resolve_svg_text_coordinate(
+        el.attributes.get("y").map(String::as_str),
+        viewport.map(|(_, h)| h),
+    );
+    (x, y)
+}
+
+fn resolve_svg_text_coordinate(value: Option<&str>, viewport: Option<f32>) -> f32 {
+    let Some(raw) = value else {
+        return 0.0;
+    };
+    let trimmed = raw.trim();
+    if let Some(pct) = trimmed.strip_suffix('%') {
+        let Ok(percent) = pct.trim().parse::<f32>() else {
+            return 0.0;
+        };
+        return viewport.unwrap_or(0.0) * percent / 100.0;
+    }
+    parse_length(trimmed).unwrap_or(0.0)
+}
+
 /// Parse a length value (strip px/em/etc suffix, parse number).
 pub(crate) fn parse_length(val: &str) -> Option<f32> {
     let trimmed = val.trim();
@@ -567,7 +601,7 @@ fn parse_viewbox(val: &str) -> Option<ViewBox> {
     Some(view_box)
 }
 
-/// Parse color, fill, stroke, stroke-width, opacity from element attributes.
+/// Parse color, fill, stroke, stroke-width, font, opacity from element attributes.
 fn parse_svg_style(el: &ElementNode) -> SvgStyle {
     fn parse_svg_paint(val: &str) -> Option<SvgPaint> {
         let val = val.trim();
@@ -636,12 +670,16 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
     if let Some(val) = style_property_value(el, "opacity") {
         opacity = val.trim().parse().ok().unwrap_or(opacity);
     }
+    let (font_family, font_bold, font_italic) = parse_svg_font_attrs(el);
 
     SvgStyle {
         color,
         fill,
         stroke,
         stroke_width,
+        font_family,
+        font_bold,
+        font_italic,
         opacity,
     }
 }
@@ -657,48 +695,70 @@ fn parse_font_size_attr(el: &ElementNode) -> Option<String> {
     style_property_value(el, "font-size").map(|val| val.to_string())
 }
 
-/// Parse per-element font-family, font-weight, and font-style from a `<text>` element.
+fn parse_svg_font_family_value(val: &str) -> Option<String> {
+    let val = val.trim();
+    if val.eq_ignore_ascii_case("inherit") {
+        return None;
+    }
+    let val = val.trim_matches(|c| c == '\'' || c == '"');
+    if val.is_empty() {
+        None
+    } else {
+        Some(resolve_svg_font_family(val))
+    }
+}
+
+fn parse_svg_font_weight_value(val: &str) -> Option<bool> {
+    let val = val.trim();
+    if val.eq_ignore_ascii_case("inherit") {
+        return None;
+    }
+    Some(is_bold_value(val))
+}
+
+fn parse_svg_font_style_value(val: &str) -> Option<bool> {
+    let val = val.trim();
+    if val.eq_ignore_ascii_case("inherit") {
+        return None;
+    }
+    Some(is_italic_value(val))
+}
+
+fn parse_svg_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Option<bool>) {
+    let mut family: Option<String> = None;
+    let mut bold: Option<bool> = None;
+    let mut italic: Option<bool> = None;
+
+    if let Some(val) = el.attributes.get("font-family") {
+        family = parse_svg_font_family_value(val);
+    }
+    if let Some(val) = el.attributes.get("font-weight") {
+        bold = parse_svg_font_weight_value(val);
+    }
+    if let Some(val) = el.attributes.get("font-style") {
+        italic = parse_svg_font_style_value(val);
+    }
+
+    if let Some(val) = style_property_value(el, "font-family") {
+        family = parse_svg_font_family_value(val);
+    }
+    if let Some(val) = style_property_value(el, "font-weight") {
+        bold = parse_svg_font_weight_value(val);
+    }
+    if let Some(val) = style_property_value(el, "font-style") {
+        italic = parse_svg_font_style_value(val);
+    }
+
+    (family, bold, italic)
+}
+
+/// Parse per-element font-family, font-weight, and font-style from an element.
 ///
 /// Checks both XML attributes (`font-family`, `font-weight`, `font-style`) and
 /// properties inside the `style` attribute.  Returns `(font_family, font_bold, font_italic)`,
 /// each `None` when no explicit value was found on the element.
 fn parse_text_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Option<bool>) {
-    let mut family: Option<String> = None;
-    let mut bold: Option<bool> = None;
-    let mut italic: Option<bool> = None;
-
-    // 1) Direct XML attributes
-    if let Some(val) = el.attributes.get("font-family") {
-        let val = val.trim().trim_matches(|c| c == '\'' || c == '"');
-        if !val.is_empty() {
-            family = Some(val.to_string());
-        }
-    }
-    if let Some(val) = el.attributes.get("font-weight") {
-        bold = Some(is_bold_value(val.trim()));
-    }
-    if let Some(val) = el.attributes.get("font-style") {
-        italic = Some(is_italic_value(val.trim()));
-    }
-
-    // 2) Inline `style` attribute (overrides XML attributes when present)
-    if let Some(val) = style_property_value(el, "font-family") {
-        let val = val.trim_matches(|c| c == '\'' || c == '"');
-        if !val.is_empty() {
-            family = Some(val.to_string());
-        }
-    }
-    if let Some(val) = style_property_value(el, "font-weight") {
-        bold = Some(is_bold_value(val));
-    }
-    if let Some(val) = style_property_value(el, "font-style") {
-        italic = Some(is_italic_value(val));
-    }
-
-    // Resolve family to a PDF base name (sans bold/italic suffix -- that's applied at render time)
-    let family = family.map(|f| resolve_svg_font_family(&f));
-
-    (family, bold, italic)
+    parse_svg_font_attrs(el)
 }
 
 fn has_fill_specified(el: &ElementNode) -> bool {
@@ -2255,6 +2315,20 @@ mod tests {
         match &tree.children[0] {
             SvgNode::Text { fill_raw, .. } => {
                 assert_eq!(fill_raw.as_deref(), Some("currentColor"));
+            }
+            other => panic!("expected text node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_text_percentage_coordinates_use_viewport() {
+        let text = make_el("text", vec![("x", "50%"), ("y", "25%")]);
+        let svg = make_svg_el(vec![("width", "200"), ("height", "100")], vec![text]);
+        let tree = parse_svg_from_element(&svg).unwrap();
+        match &tree.children[0] {
+            SvgNode::Text { x, y, .. } => {
+                assert_eq!(*x, 100.0);
+                assert_eq!(*y, 25.0);
             }
             other => panic!("expected text node, got {other:?}"),
         }

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -216,12 +216,26 @@ pub fn parse_svg_from_element_with_ctx(
     let view_box = el.attributes.get("viewBox").and_then(|v| parse_viewbox(v));
 
     let mut children = Vec::new();
+    let root_viewport = Some((width, height));
     for child in &el.children {
         if let crate::parser::dom::DomNode::Element(child_el) = child {
-            if let Some(node) = parse_svg_node(child_el) {
+            if let Some(node) = parse_svg_node_with_viewport(child_el, root_viewport) {
                 children.push(node);
             }
         }
+    }
+
+    let root_style = parse_svg_style(el);
+    let root_transform = el
+        .attributes
+        .get("transform")
+        .and_then(|v| parse_transform(v));
+    if root_transform.is_some() || !svg_style_is_default(&root_style) {
+        children = vec![SvgNode::Group {
+            transform: root_transform,
+            children,
+            style: root_style,
+        }];
     }
 
     Some(SvgTree {
@@ -237,9 +251,16 @@ pub fn parse_svg_from_element_with_ctx(
 
 /// Parse a single SVG element node into an SvgNode.
 fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
+    parse_svg_node_with_viewport(el, None)
+}
+
+fn parse_svg_node_with_viewport(
+    el: &ElementNode,
+    parent_viewport: Option<(f32, f32)>,
+) -> Option<SvgNode> {
     let tag = el.raw_tag_name.as_str();
     match tag {
-        "g" | "svg" => {
+        "g" => {
             let transform = el
                 .attributes
                 .get("transform")
@@ -248,7 +269,30 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
             let mut children = Vec::new();
             for child in &el.children {
                 if let crate::parser::dom::DomNode::Element(child_el) = child {
-                    if let Some(node) = parse_svg_node(child_el) {
+                    if let Some(node) = parse_svg_node_with_viewport(child_el, parent_viewport) {
+                        children.push(node);
+                    }
+                }
+            }
+            Some(SvgNode::Group {
+                transform,
+                children,
+                style,
+            })
+        }
+        "svg" => {
+            let child_viewport = resolve_nested_svg_viewport(el, parent_viewport);
+            let transform = compose_transform(
+                el.attributes
+                    .get("transform")
+                    .and_then(|v| parse_transform(v)),
+                nested_svg_viewport_transform(el, parent_viewport),
+            );
+            let style = parse_svg_style(el);
+            let mut children = Vec::new();
+            for child in &el.children {
+                if let crate::parser::dom::DomNode::Element(child_el) = child {
+                    if let Some(node) = parse_svg_node_with_viewport(child_el, child_viewport) {
                         children.push(node);
                     }
                 }
@@ -343,9 +387,7 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
             let x = attr_f32(el, "x");
             let y = attr_f32(el, "y");
             let font_size_attr = parse_font_size_attr(el);
-            let font_size = font_size_attr
-                .as_deref()
-                .and_then(parse_absolute_length);
+            let font_size = font_size_attr.as_deref().and_then(parse_absolute_length);
             let fill_specified = has_fill_specified(el);
             let fill_raw = parse_fill_raw(el);
             let (font_family, font_bold, font_italic) = parse_text_font_attrs(el);
@@ -366,6 +408,116 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
             })
         }
         _ => None,
+    }
+}
+
+fn svg_style_is_default(style: &SvgStyle) -> bool {
+    matches!(style.fill, SvgPaint::Unspecified)
+        && matches!(style.stroke, SvgPaint::Unspecified)
+        && style.stroke_width.is_none()
+        && (style.opacity - 1.0).abs() < f32::EPSILON
+}
+
+fn compose_transform(
+    outer: Option<SvgTransform>,
+    inner: Option<SvgTransform>,
+) -> Option<SvgTransform> {
+    match (outer, inner) {
+        (
+            Some(SvgTransform::Matrix(a1, b1, c1, d1, e1, f1)),
+            Some(SvgTransform::Matrix(a2, b2, c2, d2, e2, f2)),
+        ) => Some(SvgTransform::Matrix(
+            a1 * a2 + c1 * b2,
+            b1 * a2 + d1 * b2,
+            a1 * c2 + c1 * d2,
+            b1 * c2 + d1 * d2,
+            a1 * e2 + c1 * f2 + e1,
+            b1 * e2 + d1 * f2 + f1,
+        )),
+        (Some(transform), None) | (None, Some(transform)) => Some(transform),
+        (None, None) => None,
+    }
+}
+
+fn resolve_nested_svg_viewport(
+    el: &ElementNode,
+    parent_viewport: Option<(f32, f32)>,
+) -> Option<(f32, f32)> {
+    let (parent_width, parent_height) = parent_viewport?;
+    Some((
+        resolve_svg_viewport_length(el.attributes.get("width"), Some(parent_width), 300.0),
+        resolve_svg_viewport_length(el.attributes.get("height"), Some(parent_height), 150.0),
+    ))
+}
+
+fn resolve_svg_viewport_length(
+    attr: Option<&String>,
+    parent_extent: Option<f32>,
+    fallback: f32,
+) -> f32 {
+    match attr.map(String::as_str) {
+        Some(value) => {
+            let trimmed = value.trim();
+            if let Some(pct) = trimmed.strip_suffix('%') {
+                pct.trim()
+                    .parse::<f32>()
+                    .ok()
+                    .and_then(|pct| parent_extent.map(|extent| extent * pct / 100.0))
+                    .unwrap_or(fallback)
+            } else {
+                parse_absolute_length(trimmed).unwrap_or(fallback)
+            }
+        }
+        None => parent_extent.unwrap_or(fallback),
+    }
+}
+
+fn nested_svg_viewport_transform(
+    el: &ElementNode,
+    parent_viewport: Option<(f32, f32)>,
+) -> Option<SvgTransform> {
+    let x = attr_f32(el, "x");
+    let y = attr_f32(el, "y");
+    let view_box = el.attributes.get("viewBox").and_then(|v| parse_viewbox(v));
+
+    if let Some(vb) = view_box {
+        let (width, height) = parent_viewport
+            .map(|(parent_width, parent_height)| {
+                (
+                    resolve_svg_viewport_length(
+                        el.attributes.get("width"),
+                        Some(parent_width),
+                        300.0,
+                    ),
+                    resolve_svg_viewport_length(
+                        el.attributes.get("height"),
+                        Some(parent_height),
+                        150.0,
+                    ),
+                )
+            })
+            .unwrap_or((
+                resolve_svg_viewport_length(el.attributes.get("width"), None, 300.0),
+                resolve_svg_viewport_length(el.attributes.get("height"), None, 150.0),
+            ));
+        if vb.width > 0.0 && vb.height > 0.0 {
+            let scale_x = width / vb.width;
+            let scale_y = height / vb.height;
+            return Some(SvgTransform::Matrix(
+                scale_x,
+                0.0,
+                0.0,
+                scale_y,
+                x - vb.min_x * scale_x,
+                y - vb.min_y * scale_y,
+            ));
+        }
+    }
+
+    if x != 0.0 || y != 0.0 {
+        Some(SvgTransform::Matrix(1.0, 0.0, 0.0, 1.0, x, y))
+    } else {
+        None
     }
 }
 
@@ -2002,13 +2154,36 @@ mod tests {
     }
 
     #[test]
+    fn parse_svg_from_element_wraps_root_style_and_transform() {
+        let rect = make_el("rect", vec![("width", "10"), ("height", "10")]);
+        let svg = make_svg_el(
+            vec![("fill", "red"), ("transform", "translate(5, 6)")],
+            vec![rect],
+        );
+        let tree = parse_svg_from_element(&svg).unwrap();
+        assert_eq!(tree.children.len(), 1);
+        match &tree.children[0] {
+            SvgNode::Group {
+                transform,
+                children,
+                style,
+            } => {
+                assert!(matches!(
+                    transform,
+                    Some(SvgTransform::Matrix(1.0, 0.0, 0.0, 1.0, 5.0, 6.0))
+                ));
+                assert!(matches!(style.fill, SvgPaint::Color((1.0, 0.0, 0.0))));
+                assert_eq!(children.len(), 1);
+            }
+            other => panic!("expected wrapped root group, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_text_style_ignores_font_size_adjust_prefix() {
         let text = make_el(
             "text",
-            vec![(
-                "style",
-                "font-size-adjust: 0.5; font-size: 20px",
-            )],
+            vec![("style", "font-size-adjust: 0.5; font-size: 20px")],
         );
         let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text]);
         let tree = parse_svg_from_element(&svg).unwrap();
@@ -2029,10 +2204,7 @@ mod tests {
     fn parse_text_style_ignores_fill_opacity_prefix() {
         let text = make_el(
             "text",
-            vec![(
-                "style",
-                "fill-opacity: 0.5; fill: currentColor",
-            )],
+            vec![("style", "fill-opacity: 0.5; fill: currentColor")],
         );
         let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text]);
         let tree = parse_svg_from_element(&svg).unwrap();
@@ -2228,6 +2400,57 @@ mod tests {
                 assert_eq!(children.len(), 1);
             }
             _ => panic!("Expected Group for inner svg"),
+        }
+    }
+
+    #[test]
+    fn parse_node_nested_svg_applies_viewport_transform() {
+        let inner = make_el("rect", vec![("width", "10"), ("height", "10")]);
+        let mut svg_inner = make_el(
+            "svg",
+            vec![
+                ("x", "10"),
+                ("y", "20"),
+                ("width", "100"),
+                ("height", "50"),
+                ("viewBox", "0 0 10 5"),
+            ],
+        );
+        svg_inner.children.push(DomNode::Element(inner));
+        let node = parse_svg_node(&svg_inner).unwrap();
+        match node {
+            SvgNode::Group { transform, .. } => {
+                assert!(matches!(
+                    transform,
+                    Some(SvgTransform::Matrix(10.0, 0.0, 0.0, 10.0, 10.0, 20.0))
+                ));
+            }
+            other => panic!("expected nested svg group, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_node_nested_svg_percent_viewport_uses_parent_size() {
+        let inner = make_el("rect", vec![("width", "10"), ("height", "10")]);
+        let mut svg_inner = make_el(
+            "svg",
+            vec![
+                ("width", "100%"),
+                ("height", "50%"),
+                ("viewBox", "0 0 20 10"),
+            ],
+        );
+        svg_inner.children.push(DomNode::Element(inner));
+        let outer = make_svg_el(vec![("width", "200"), ("height", "100")], vec![svg_inner]);
+        let tree = parse_svg_from_element(&outer).unwrap();
+        match &tree.children[0] {
+            SvgNode::Group { transform, .. } => {
+                assert!(matches!(
+                    transform,
+                    Some(SvgTransform::Matrix(10.0, 0.0, 0.0, 5.0, 0.0, 0.0))
+                ));
+            }
+            other => panic!("expected nested svg group, got {other:?}"),
         }
     }
 

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -196,23 +196,32 @@ pub enum PathCommand {
 
 /// Entry point: parse an `<svg>` ElementNode into an SvgTree.
 pub fn parse_svg_from_element(el: &ElementNode) -> Option<SvgTree> {
-    parse_svg_from_element_with_ctx(el, SvgTextContext::default())
+    parse_svg_from_element_with_ctx_and_viewport(el, SvgTextContext::default(), None)
 }
 
 pub fn parse_svg_from_element_with_ctx(
     el: &ElementNode,
     text_ctx: SvgTextContext,
 ) -> Option<SvgTree> {
+    parse_svg_from_element_with_ctx_and_viewport(el, text_ctx, None)
+}
+
+pub fn parse_svg_from_element_with_ctx_and_viewport(
+    el: &ElementNode,
+    text_ctx: SvgTextContext,
+    root_viewport_override: Option<(f32, f32)>,
+) -> Option<SvgTree> {
     let width_attr = el.attributes.get("width").cloned();
     let height_attr = el.attributes.get("height").cloned();
-    let width = width_attr
+    let parsed_width = width_attr
         .as_deref()
         .and_then(parse_absolute_length)
         .unwrap_or(300.0);
-    let height = height_attr
+    let parsed_height = height_attr
         .as_deref()
         .and_then(parse_absolute_length)
         .unwrap_or(150.0);
+    let (width, height) = root_viewport_override.unwrap_or((parsed_width, parsed_height));
     let view_box = el.attributes.get("viewBox").and_then(|v| parse_viewbox(v));
 
     let mut children = Vec::new();
@@ -2448,6 +2457,39 @@ mod tests {
                 assert!(matches!(
                     transform,
                     Some(SvgTransform::Matrix(10.0, 0.0, 0.0, 5.0, 0.0, 0.0))
+                ));
+            }
+            other => panic!("expected nested svg group, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_svg_with_viewport_override_resolves_nested_percentages() {
+        let inner = make_el("rect", vec![("width", "10"), ("height", "10")]);
+        let mut svg_inner = make_el(
+            "svg",
+            vec![
+                ("width", "50%"),
+                ("height", "50%"),
+                ("viewBox", "0 0 20 10"),
+            ],
+        );
+        svg_inner.children.push(DomNode::Element(inner));
+        let outer = make_svg_el(
+            vec![("width", "100%"), ("height", "100%")],
+            vec![svg_inner],
+        );
+        let tree = parse_svg_from_element_with_ctx_and_viewport(
+            &outer,
+            SvgTextContext::default(),
+            Some((400.0, 200.0)),
+        )
+        .unwrap();
+        match &tree.children[0] {
+            SvgNode::Group { transform, .. } => {
+                assert!(matches!(
+                    transform,
+                    Some(SvgTransform::Matrix(10.0, 0.0, 0.0, 10.0, 0.0, 0.0))
                 ));
             }
             other => panic!("expected nested svg group, got {other:?}"),

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -559,6 +559,9 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
         if val.eq_ignore_ascii_case("none") {
             return Some(SvgPaint::None);
         }
+        if val.eq_ignore_ascii_case("inherit") {
+            return Some(SvgPaint::Unspecified);
+        }
         if val.eq_ignore_ascii_case("currentColor") {
             return Some(SvgPaint::CurrentColor);
         }

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -415,7 +415,7 @@ fn parse_svg_node_with_viewport(
             let font_size = font_size_attr.as_deref().and_then(parse_absolute_length);
             let fill_specified = has_fill_specified(el);
             let fill_raw = parse_fill_raw(el);
-            let (font_family, font_bold, font_italic) = parse_text_font_attrs(el);
+            let (font_family, font_bold, font_italic) = parse_svg_font_attrs(el);
             let content = collect_text_content(el);
             let style = parse_svg_style(el);
             Some(SvgNode::Text {
@@ -750,15 +750,6 @@ fn parse_svg_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Opti
     }
 
     (family, bold, italic)
-}
-
-/// Parse per-element font-family, font-weight, and font-style from an element.
-///
-/// Checks both XML attributes (`font-family`, `font-weight`, `font-style`) and
-/// properties inside the `style` attribute.  Returns `(font_family, font_bold, font_italic)`,
-/// each `None` when no explicit value was found on the element.
-fn parse_text_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Option<bool>) {
-    parse_svg_font_attrs(el)
 }
 
 fn has_fill_specified(el: &ElementNode) -> bool {

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -141,12 +141,43 @@ pub enum SvgNode {
     },
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SvgPaint {
+    /// The property was not specified on this element (so it should inherit from its parent).
+    Unspecified,
+    /// The property was explicitly set to `none`.
+    None,
+    /// `currentColor` keyword (resolves to the CSS `color` property).
+    CurrentColor,
+    /// An explicit sRGB color (0.0-1.0 per channel).
+    Color((f32, f32, f32)),
+}
+
+impl Default for SvgPaint {
+    fn default() -> Self {
+        Self::Unspecified
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct SvgStyle {
-    pub fill: Option<(f32, f32, f32)>,   // RGB 0.0-1.0, None = no fill
-    pub stroke: Option<(f32, f32, f32)>, // RGB 0.0-1.0, None = no stroke
-    pub stroke_width: f32,
+    pub fill: SvgPaint,
+    pub stroke: SvgPaint,
+    /// `stroke-width` is inherited in SVG.
+    pub stroke_width: Option<f32>,
+    // Opacity isn't wired through to PDF output yet; keep it simple until needed.
     pub opacity: f32,
+}
+
+impl Default for SvgStyle {
+    fn default() -> Self {
+        Self {
+            fill: SvgPaint::Unspecified,
+            stroke: SvgPaint::Unspecified,
+            stroke_width: None,
+            opacity: 1.0,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -382,13 +413,32 @@ fn parse_viewbox(val: &str) -> Option<ViewBox> {
 
 /// Parse fill, stroke, stroke-width, opacity from element attributes.
 fn parse_svg_style(el: &ElementNode) -> SvgStyle {
-    let mut fill = el.attributes.get("fill").and_then(|v| parse_svg_color(v));
-    let mut stroke = el.attributes.get("stroke").and_then(|v| parse_svg_color(v));
+    fn parse_svg_paint(val: &str) -> Option<SvgPaint> {
+        let val = val.trim();
+        if val.eq_ignore_ascii_case("none") {
+            return Some(SvgPaint::None);
+        }
+        if val.eq_ignore_ascii_case("currentColor") {
+            return Some(SvgPaint::CurrentColor);
+        }
+        parse_svg_color(val).map(SvgPaint::Color)
+    }
+
+    let mut fill = el
+        .attributes
+        .get("fill")
+        .and_then(|v| parse_svg_paint(v))
+        .unwrap_or(SvgPaint::Unspecified);
+    let mut stroke = el
+        .attributes
+        .get("stroke")
+        .and_then(|v| parse_svg_paint(v))
+        .unwrap_or(SvgPaint::Unspecified);
     let mut stroke_width = el
         .attributes
         .get("stroke-width")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(1.0);
+        .and_then(|v| v.trim().parse::<f32>().ok())
+        .filter(|v| *v >= 0.0);
     let mut opacity = el
         .attributes
         .get("opacity")
@@ -400,10 +450,22 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
             let part = part.trim();
             if let Some((prop, val)) = part.split_once(':') {
                 match prop.trim() {
-                    "fill" => fill = parse_svg_color(val.trim()),
-                    "stroke" => stroke = parse_svg_color(val.trim()),
+                    "fill" => {
+                        if let Some(paint) = parse_svg_paint(val) {
+                            fill = paint;
+                        }
+                    }
+                    "stroke" => {
+                        if let Some(paint) = parse_svg_paint(val) {
+                            stroke = paint;
+                        }
+                    }
                     "stroke-width" => {
-                        stroke_width = val.trim().parse().ok().unwrap_or(stroke_width)
+                        if let Ok(v) = val.trim().parse::<f32>() {
+                            if v >= 0.0 {
+                                stroke_width = Some(v);
+                            }
+                        }
                     }
                     "opacity" => opacity = val.trim().parse().ok().unwrap_or(opacity),
                     _ => {}
@@ -511,18 +573,21 @@ fn has_fill_specified(el: &ElementNode) -> bool {
 }
 
 fn parse_fill_raw(el: &ElementNode) -> Option<String> {
-    if let Some(val) = el.attributes.get("fill") {
-        return Some(val.trim().to_string());
-    }
     if let Some(style_val) = el.attributes.get("style") {
         for part in split_style_declarations(style_val) {
             let part = part.trim();
             if let Some((prop, val)) = part.split_once(':') {
                 if prop.trim() == "fill" {
-                    return Some(val.trim().to_string());
+                    let raw = val.trim();
+                    if !raw.is_empty() {
+                        return Some(raw.to_string());
+                    }
                 }
             }
         }
+    }
+    if let Some(val) = el.attributes.get("fill") {
+        return Some(val.trim().to_string());
     }
     None
 }
@@ -1103,6 +1168,37 @@ mod tests {
     fn parse_svg_color_none() {
         let color = parse_svg_color("none");
         assert_eq!(color, None);
+    }
+
+    #[test]
+    fn parse_svg_style_unparseable_style_fill_does_not_override_attribute() {
+        let el = make_el("rect", vec![("fill", "red"), ("style", "fill: ???;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::Color((1.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn parse_svg_style_style_fill_none_overrides_attribute() {
+        let el = make_el("rect", vec![("fill", "red"), ("style", "fill: none;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::None);
+    }
+
+    #[test]
+    fn parse_svg_style_unparseable_style_stroke_does_not_override_attribute() {
+        let el = make_el(
+            "rect",
+            vec![("stroke", "blue"), ("style", "stroke: not-a-color;")],
+        );
+        let style = parse_svg_style(&el);
+        assert_eq!(style.stroke, SvgPaint::Color((0.0, 0.0, 1.0)));
+    }
+
+    #[test]
+    fn parse_svg_paint_current_color_keyword() {
+        let el = make_el("rect", vec![("fill", "currentColor")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::CurrentColor);
     }
 
     #[test]
@@ -1821,9 +1917,9 @@ mod tests {
     fn parse_style_defaults() {
         let el = make_el("rect", vec![]);
         let style = parse_svg_style(&el);
-        assert!(style.fill.is_none());
-        assert!(style.stroke.is_none());
-        assert_eq!(style.stroke_width, 1.0);
+        assert_eq!(style.fill, SvgPaint::Unspecified);
+        assert_eq!(style.stroke, SvgPaint::Unspecified);
+        assert_eq!(style.stroke_width, None);
         assert_eq!(style.opacity, 1.0);
     }
 
@@ -1839,9 +1935,9 @@ mod tests {
             ],
         );
         let style = parse_svg_style(&el);
-        assert_eq!(style.fill, Some((1.0, 0.0, 0.0)));
-        assert_eq!(style.stroke, Some((0.0, 0.0, 1.0)));
-        assert!((style.stroke_width - 2.5).abs() < 0.001);
+        assert_eq!(style.fill, SvgPaint::Color((1.0, 0.0, 0.0)));
+        assert_eq!(style.stroke, SvgPaint::Color((0.0, 0.0, 1.0)));
+        assert_eq!(style.stroke_width, Some(2.5));
         assert!((style.opacity - 0.5).abs() < 0.001);
     }
 
@@ -1849,14 +1945,14 @@ mod tests {
     fn parse_style_fill_none() {
         let el = make_el("rect", vec![("fill", "none")]);
         let style = parse_svg_style(&el);
-        assert!(style.fill.is_none());
+        assert_eq!(style.fill, SvgPaint::None);
     }
 
     #[test]
     fn parse_style_stroke_none() {
         let el = make_el("rect", vec![("stroke", "none")]);
         let style = parse_svg_style(&el);
-        assert!(style.stroke.is_none());
+        assert_eq!(style.stroke, SvgPaint::None);
     }
 
     #[test]
@@ -1869,9 +1965,9 @@ mod tests {
             )],
         );
         let style = parse_svg_style(&el);
-        assert_eq!(style.fill, Some((0.0, 1.0, 0.0)));
-        assert_eq!(style.stroke, Some((0.0, 0.0, 1.0)));
-        assert!((style.stroke_width - 3.0).abs() < 0.001);
+        assert_eq!(style.fill, SvgPaint::Color((0.0, 1.0, 0.0)));
+        assert_eq!(style.stroke, SvgPaint::Color((0.0, 0.0, 1.0)));
+        assert_eq!(style.stroke_width, Some(3.0));
         assert!((style.opacity - 0.25).abs() < 0.001);
     }
 
@@ -1947,6 +2043,22 @@ mod tests {
                 ..
             } => {
                 assert!(*fill_specified);
+                assert_eq!(fill_raw.as_deref(), Some("currentColor"));
+            }
+            other => panic!("expected text node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_text_raw_fill_prefers_inline_style_over_attribute() {
+        let text = make_el(
+            "text",
+            vec![("fill", "none"), ("style", "fill: currentColor")],
+        );
+        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text]);
+        let tree = parse_svg_from_element(&svg).unwrap();
+        match &tree.children[0] {
+            SvgNode::Text { fill_raw, .. } => {
                 assert_eq!(fill_raw.as_deref(), Some("currentColor"));
             }
             other => panic!("expected text node, got {other:?}"),

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -2,6 +2,36 @@
 
 use crate::parser::dom::ElementNode;
 
+/// Split a style declaration string on `;`, respecting quoted strings and
+/// parenthesized function arguments.
+fn split_style_declarations(style: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let bytes = style.as_bytes();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut paren_depth = 0usize;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' if !in_double_quote && paren_depth > 0 => in_single_quote = !in_single_quote,
+            b'"' if !in_single_quote && paren_depth > 0 => in_double_quote = !in_double_quote,
+            b'(' if !in_single_quote && !in_double_quote => paren_depth += 1,
+            b')' if !in_single_quote && !in_double_quote && paren_depth > 0 => paren_depth -= 1,
+            b';' if !in_single_quote && !in_double_quote && paren_depth == 0 => {
+                parts.push(&style[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if start < style.len() {
+        parts.push(&style[start..]);
+    }
+    parts
+}
+
 /// Inherited CSS context for SVG text rendering.
 #[derive(Debug, Clone)]
 pub struct SvgTextContext {
@@ -29,6 +59,8 @@ impl Default for SvgTextContext {
 pub struct SvgTree {
     pub width: f32,
     pub height: f32,
+    pub width_attr: Option<String>,
+    pub height_attr: Option<String>,
     pub view_box: Option<ViewBox>,
     pub children: Vec<SvgNode>,
     pub text_ctx: SvgTextContext,
@@ -94,6 +126,10 @@ pub enum SvgNode {
         x: f32,
         y: f32,
         font_size: Option<f32>,
+        font_size_attr: Option<String>,
+        /// True when the element explicitly set `fill` (including `none`).
+        fill_specified: bool,
+        fill_raw: Option<String>,
         /// Per-element font-family override (resolved PDF name, e.g. "Helvetica-Bold").
         font_family: Option<String>,
         /// Per-element font-weight override (true = bold).
@@ -136,15 +172,15 @@ pub fn parse_svg_from_element_with_ctx(
     el: &ElementNode,
     text_ctx: SvgTextContext,
 ) -> Option<SvgTree> {
-    let width = el
-        .attributes
-        .get("width")
-        .and_then(|v| parse_length(v))
+    let width_attr = el.attributes.get("width").cloned();
+    let height_attr = el.attributes.get("height").cloned();
+    let width = width_attr
+        .as_deref()
+        .and_then(parse_absolute_length)
         .unwrap_or(300.0);
-    let height = el
-        .attributes
-        .get("height")
-        .and_then(|v| parse_length(v))
+    let height = height_attr
+        .as_deref()
+        .and_then(parse_absolute_length)
         .unwrap_or(150.0);
     let view_box = el.attributes.get("viewBox").and_then(|v| parse_viewbox(v));
 
@@ -160,6 +196,8 @@ pub fn parse_svg_from_element_with_ctx(
     Some(SvgTree {
         width,
         height,
+        width_attr,
+        height_attr,
         view_box,
         children,
         text_ctx,
@@ -273,7 +311,12 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
         "text" => {
             let x = attr_f32(el, "x");
             let y = attr_f32(el, "y");
-            let font_size = parse_font_size(el);
+            let font_size_attr = parse_font_size_attr(el);
+            let font_size = font_size_attr
+                .as_deref()
+                .and_then(parse_absolute_length);
+            let fill_specified = has_fill_specified(el);
+            let fill_raw = parse_fill_raw(el);
             let (font_family, font_bold, font_italic) = parse_text_font_attrs(el);
             let content = collect_text_content(el);
             let style = parse_svg_style(el);
@@ -281,6 +324,9 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
                 x,
                 y,
                 font_size,
+                font_size_attr,
+                fill_specified,
+                fill_raw,
                 font_family,
                 font_bold,
                 font_italic,
@@ -301,10 +347,18 @@ fn attr_f32(el: &ElementNode, name: &str) -> f32 {
 }
 
 /// Parse a length value (strip px/em/etc suffix, parse number).
-fn parse_length(val: &str) -> Option<f32> {
+pub(crate) fn parse_length(val: &str) -> Option<f32> {
     let trimmed = val.trim();
     let num_str = trimmed.trim_end_matches(|c: char| c.is_ascii_alphabetic() || c == '%');
     num_str.trim().parse::<f32>().ok()
+}
+
+fn parse_absolute_length(val: &str) -> Option<f32> {
+    let trimmed = val.trim();
+    if trimmed.ends_with('%') {
+        return None;
+    }
+    parse_length(trimmed)
 }
 
 /// Parse a viewBox attribute: "min-x min-y width height".
@@ -328,18 +382,35 @@ fn parse_viewbox(val: &str) -> Option<ViewBox> {
 
 /// Parse fill, stroke, stroke-width, opacity from element attributes.
 fn parse_svg_style(el: &ElementNode) -> SvgStyle {
-    let fill = el.attributes.get("fill").and_then(|v| parse_svg_color(v));
-    let stroke = el.attributes.get("stroke").and_then(|v| parse_svg_color(v));
-    let stroke_width = el
+    let mut fill = el.attributes.get("fill").and_then(|v| parse_svg_color(v));
+    let mut stroke = el.attributes.get("stroke").and_then(|v| parse_svg_color(v));
+    let mut stroke_width = el
         .attributes
         .get("stroke-width")
         .and_then(|v| v.parse().ok())
         .unwrap_or(1.0);
-    let opacity = el
+    let mut opacity = el
         .attributes
         .get("opacity")
         .and_then(|v| v.parse().ok())
         .unwrap_or(1.0);
+
+    if let Some(style_val) = el.attributes.get("style") {
+        for part in split_style_declarations(style_val) {
+            let part = part.trim();
+            if let Some((prop, val)) = part.split_once(':') {
+                match prop.trim() {
+                    "fill" => fill = parse_svg_color(val.trim()),
+                    "stroke" => stroke = parse_svg_color(val.trim()),
+                    "stroke-width" => {
+                        stroke_width = val.trim().parse().ok().unwrap_or(stroke_width)
+                    }
+                    "opacity" => opacity = val.trim().parse().ok().unwrap_or(opacity),
+                    _ => {}
+                }
+            }
+        }
+    }
 
     SvgStyle {
         fill,
@@ -349,25 +420,21 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
     }
 }
 
-/// Extract font-size from a `<text>` element.
+/// Extract the raw `font-size` value from a `<text>` element.
 ///
 /// Checks the `font-size` attribute first, then falls back to parsing
 /// `font-size:` from the inline `style` attribute.
-fn parse_font_size(el: &ElementNode) -> Option<f32> {
-    // 1) Direct attribute: font-size="20"
+fn parse_font_size_attr(el: &ElementNode) -> Option<String> {
     if let Some(val) = el.attributes.get("font-size") {
-        if let Some(size) = parse_length(val) {
-            return Some(size);
-        }
+        return Some(val.trim().to_string());
     }
     // 2) Inline style: style="font-size:20px"
     if let Some(style_val) = el.attributes.get("style") {
-        for part in style_val.split(';') {
+        for part in split_style_declarations(style_val) {
             let part = part.trim();
-            if let Some(val) = part.strip_prefix("font-size") {
-                let val = val.trim_start().strip_prefix(':').unwrap_or(val).trim();
-                if let Some(size) = parse_length(val) {
-                    return Some(size);
+            if let Some((prop, val)) = part.split_once(':') {
+                if prop.trim() == "font-size" {
+                    return Some(val.trim().to_string());
                 }
             }
         }
@@ -401,20 +468,21 @@ fn parse_text_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Opt
 
     // 2) Inline `style` attribute (overrides XML attributes when present)
     if let Some(style_val) = el.attributes.get("style") {
-        for part in style_val.split(';') {
+        for part in split_style_declarations(style_val) {
             let part = part.trim();
-            if let Some(val) = part.strip_prefix("font-family") {
-                let val = val.trim_start().strip_prefix(':').unwrap_or(val).trim();
-                let val = val.trim_matches(|c| c == '\'' || c == '"');
-                if !val.is_empty() {
-                    family = Some(val.to_string());
+            if let Some((prop, val)) = part.split_once(':') {
+                let prop = prop.trim();
+                let val = val.trim();
+                if prop == "font-family" {
+                    let val = val.trim_matches(|c| c == '\'' || c == '"');
+                    if !val.is_empty() {
+                        family = Some(val.to_string());
+                    }
+                } else if prop == "font-weight" {
+                    bold = Some(is_bold_value(val));
+                } else if prop == "font-style" {
+                    italic = Some(is_italic_value(val));
                 }
-            } else if let Some(val) = part.strip_prefix("font-weight") {
-                let val = val.trim_start().strip_prefix(':').unwrap_or(val).trim();
-                bold = Some(is_bold_value(val));
-            } else if let Some(val) = part.strip_prefix("font-style") {
-                let val = val.trim_start().strip_prefix(':').unwrap_or(val).trim();
-                italic = Some(is_italic_value(val));
             }
         }
     }
@@ -423,6 +491,40 @@ fn parse_text_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Opt
     let family = family.map(|f| resolve_svg_font_family(&f));
 
     (family, bold, italic)
+}
+
+fn has_fill_specified(el: &ElementNode) -> bool {
+    if el.attributes.contains_key("fill") {
+        return true;
+    }
+    if let Some(style_val) = el.attributes.get("style") {
+        for part in split_style_declarations(style_val) {
+            let part = part.trim();
+            if let Some((prop, _val)) = part.split_once(':') {
+                if prop.trim() == "fill" {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn parse_fill_raw(el: &ElementNode) -> Option<String> {
+    if let Some(val) = el.attributes.get("fill") {
+        return Some(val.trim().to_string());
+    }
+    if let Some(style_val) = el.attributes.get("style") {
+        for part in split_style_declarations(style_val) {
+            let part = part.trim();
+            if let Some((prop, val)) = part.split_once(':') {
+                if prop.trim() == "fill" {
+                    return Some(val.trim().to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Map a CSS font-family value to a PDF base-font family name.
@@ -1757,6 +1859,22 @@ mod tests {
         assert!(style.stroke.is_none());
     }
 
+    #[test]
+    fn parse_style_from_style_attribute() {
+        let el = make_el(
+            "rect",
+            vec![(
+                "style",
+                "fill: #00ff00; stroke: rgb(0,0,255); stroke-width: 3; opacity: 0.25;",
+            )],
+        );
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, Some((0.0, 1.0, 0.0)));
+        assert_eq!(style.stroke, Some((0.0, 0.0, 1.0)));
+        assert!((style.stroke_width - 3.0).abs() < 0.001);
+        assert!((style.opacity - 0.25).abs() < 0.001);
+    }
+
     // ── parse_svg_from_element ─────────────────────────────────────────
 
     #[test]
@@ -1785,6 +1903,54 @@ mod tests {
         assert_eq!(tree.height, 150.0);
         assert!(tree.view_box.is_none());
         assert!(tree.children.is_empty());
+    }
+
+    #[test]
+    fn parse_text_style_ignores_font_size_adjust_prefix() {
+        let text = make_el(
+            "text",
+            vec![(
+                "style",
+                "font-size-adjust: 0.5; font-size: 20px",
+            )],
+        );
+        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text]);
+        let tree = parse_svg_from_element(&svg).unwrap();
+        match &tree.children[0] {
+            SvgNode::Text {
+                font_size_attr,
+                font_size,
+                ..
+            } => {
+                assert_eq!(font_size_attr.as_deref(), Some("20px"));
+                assert_eq!(*font_size, Some(20.0));
+            }
+            other => panic!("expected text node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_text_style_ignores_fill_opacity_prefix() {
+        let text = make_el(
+            "text",
+            vec![(
+                "style",
+                "fill-opacity: 0.5; fill: currentColor",
+            )],
+        );
+        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text]);
+        let tree = parse_svg_from_element(&svg).unwrap();
+        match &tree.children[0] {
+            SvgNode::Text {
+                fill_raw,
+                fill_specified,
+                ..
+            } => {
+                assert!(*fill_specified);
+                assert_eq!(fill_raw.as_deref(), Some("currentColor"));
+            }
+            other => panic!("expected text node, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -161,6 +161,7 @@ impl Default for SvgPaint {
 
 #[derive(Debug, Clone)]
 pub struct SvgStyle {
+    pub color: Option<(f32, f32, f32)>,
     pub fill: SvgPaint,
     pub stroke: SvgPaint,
     /// `stroke-width` is inherited in SVG.
@@ -172,6 +173,7 @@ pub struct SvgStyle {
 impl Default for SvgStyle {
     fn default() -> Self {
         Self {
+            color: None,
             fill: SvgPaint::Unspecified,
             stroke: SvgPaint::Unspecified,
             stroke_width: None,
@@ -411,7 +413,8 @@ fn parse_svg_node_with_viewport(
 }
 
 fn svg_style_is_default(style: &SvgStyle) -> bool {
-    matches!(style.fill, SvgPaint::Unspecified)
+    style.color.is_none()
+        && matches!(style.fill, SvgPaint::Unspecified)
         && matches!(style.stroke, SvgPaint::Unspecified)
         && style.stroke_width.is_none()
         && (style.opacity - 1.0).abs() < f32::EPSILON
@@ -549,7 +552,7 @@ fn parse_viewbox(val: &str) -> Option<ViewBox> {
     }
 }
 
-/// Parse fill, stroke, stroke-width, opacity from element attributes.
+/// Parse color, fill, stroke, stroke-width, opacity from element attributes.
 fn parse_svg_style(el: &ElementNode) -> SvgStyle {
     fn parse_svg_paint(val: &str) -> Option<SvgPaint> {
         let val = val.trim();
@@ -562,6 +565,19 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
         parse_svg_color(val).map(SvgPaint::Color)
     }
 
+    fn parse_svg_color_property(val: &str) -> Option<Option<(f32, f32, f32)>> {
+        let val = val.trim();
+        if val.eq_ignore_ascii_case("inherit") {
+            return Some(None);
+        }
+        parse_svg_color(val).map(Some)
+    }
+
+    let mut color = el
+        .attributes
+        .get("color")
+        .and_then(|v| parse_svg_color_property(v))
+        .flatten();
     let mut fill = el
         .attributes
         .get("fill")
@@ -588,6 +604,11 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
             let part = part.trim();
             if let Some((prop, val)) = part.split_once(':') {
                 match prop.trim() {
+                    "color" => {
+                        if let Some(parsed) = parse_svg_color_property(val) {
+                            color = parsed;
+                        }
+                    }
                     "fill" => {
                         if let Some(paint) = parse_svg_paint(val) {
                             fill = paint;
@@ -613,6 +634,7 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
     }
 
     SvgStyle {
+        color,
         fill,
         stroke,
         stroke_width,
@@ -2055,6 +2077,7 @@ mod tests {
     fn parse_style_defaults() {
         let el = make_el("rect", vec![]);
         let style = parse_svg_style(&el);
+        assert_eq!(style.color, None);
         assert_eq!(style.fill, SvgPaint::Unspecified);
         assert_eq!(style.stroke, SvgPaint::Unspecified);
         assert_eq!(style.stroke_width, None);
@@ -2084,6 +2107,20 @@ mod tests {
         let el = make_el("rect", vec![("fill", "none")]);
         let style = parse_svg_style(&el);
         assert_eq!(style.fill, SvgPaint::None);
+    }
+
+    #[test]
+    fn parse_style_color_inherited_property() {
+        let el = make_el("g", vec![("style", "color: red;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.color, Some((1.0, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn parse_style_invalid_color_does_not_override_attribute() {
+        let el = make_el("g", vec![("color", "red"), ("style", "color: ???;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.color, Some((1.0, 0.0, 0.0)));
     }
 
     #[test]

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -2,6 +2,28 @@
 
 use crate::parser::dom::ElementNode;
 
+/// Inherited CSS context for SVG text rendering.
+#[derive(Debug, Clone)]
+pub struct SvgTextContext {
+    pub font_family: String,
+    pub font_size: f32,
+    pub font_bold: bool,
+    pub font_italic: bool,
+    pub color: Option<(f32, f32, f32)>,
+}
+
+impl Default for SvgTextContext {
+    fn default() -> Self {
+        Self {
+            font_family: "Helvetica".to_string(),
+            font_size: 12.0,
+            font_bold: false,
+            font_italic: false,
+            color: None,
+        }
+    }
+}
+
 /// A parsed SVG tree ready for rendering.
 #[derive(Debug, Clone)]
 pub struct SvgTree {
@@ -9,6 +31,7 @@ pub struct SvgTree {
     pub height: f32,
     pub view_box: Option<ViewBox>,
     pub children: Vec<SvgNode>,
+    pub text_ctx: SvgTextContext,
 }
 
 #[derive(Debug, Clone)]
@@ -67,6 +90,13 @@ pub enum SvgNode {
         commands: Vec<PathCommand>,
         style: SvgStyle,
     },
+    Text {
+        x: f32,
+        y: f32,
+        font_size: Option<f32>,
+        content: String,
+        style: SvgStyle,
+    },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -93,6 +123,13 @@ pub enum PathCommand {
 
 /// Entry point: parse an `<svg>` ElementNode into an SvgTree.
 pub fn parse_svg_from_element(el: &ElementNode) -> Option<SvgTree> {
+    parse_svg_from_element_with_ctx(el, SvgTextContext::default())
+}
+
+pub fn parse_svg_from_element_with_ctx(
+    el: &ElementNode,
+    text_ctx: SvgTextContext,
+) -> Option<SvgTree> {
     let width = el
         .attributes
         .get("width")
@@ -119,6 +156,7 @@ pub fn parse_svg_from_element(el: &ElementNode) -> Option<SvgTree> {
         height,
         view_box,
         children,
+        text_ctx,
     })
 }
 
@@ -226,6 +264,20 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
             let style = parse_svg_style(el);
             Some(SvgNode::Path { commands, style })
         }
+        "text" => {
+            let x = attr_f32(el, "x");
+            let y = attr_f32(el, "y");
+            let font_size = parse_font_size(el);
+            let content = collect_text_content(el);
+            let style = parse_svg_style(el);
+            Some(SvgNode::Text {
+                x,
+                y,
+                font_size,
+                content,
+                style,
+            })
+        }
         _ => None,
     }
 }
@@ -285,6 +337,48 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
         stroke_width,
         opacity,
     }
+}
+
+/// Extract font-size from a `<text>` element.
+///
+/// Checks the `font-size` attribute first, then falls back to parsing
+/// `font-size:` from the inline `style` attribute.
+fn parse_font_size(el: &ElementNode) -> Option<f32> {
+    // 1) Direct attribute: font-size="20"
+    if let Some(val) = el.attributes.get("font-size") {
+        if let Some(size) = parse_length(val) {
+            return Some(size);
+        }
+    }
+    // 2) Inline style: style="font-size:20px"
+    if let Some(style_val) = el.attributes.get("style") {
+        for part in style_val.split(';') {
+            let part = part.trim();
+            if let Some(val) = part.strip_prefix("font-size") {
+                let val = val.trim_start().strip_prefix(':').unwrap_or(val).trim();
+                if let Some(size) = parse_length(val) {
+                    return Some(size);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Collect all text content from a `<text>` element, including `<tspan>` children.
+fn collect_text_content(el: &ElementNode) -> String {
+    let mut text = String::new();
+    for child in &el.children {
+        match child {
+            crate::parser::dom::DomNode::Text(s) => text.push_str(s),
+            crate::parser::dom::DomNode::Element(child_el) => {
+                if child_el.raw_tag_name == "tspan" {
+                    text.push_str(&collect_text_content(child_el));
+                }
+            }
+        }
+    }
+    text
 }
 
 /// Parse common SVG colors: named, hex (#rgb / #rrggbb), rgb(r,g,b), or "none".
@@ -1532,7 +1626,7 @@ mod tests {
 
     #[test]
     fn parse_node_unknown_tag_returns_none() {
-        let el = make_el("text", vec![]);
+        let el = make_el("defs", vec![]);
         assert!(parse_svg_node(&el).is_none());
     }
 
@@ -1620,8 +1714,8 @@ mod tests {
 
     #[test]
     fn parse_svg_from_element_unknown_child_skipped() {
-        let text_el = make_el("text", vec![]);
-        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![text_el]);
+        let defs_el = make_el("defs", vec![]);
+        let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![defs_el]);
         let tree = parse_svg_from_element(&svg).unwrap();
         assert!(tree.children.is_empty());
     }

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -901,21 +901,18 @@ pub fn parse_path_data(d: &str) -> Vec<PathCommand> {
         let token = &tokens[i];
 
         // Determine if this token is a command letter
-        let cmd_char = if token.len() == 1
-            && token
-                .chars()
-                .next()
-                .is_some_and(|c| c.is_ascii_alphabetic())
-        {
-            let c = token.chars().next().unwrap();
-            i += 1;
-            c
-        } else {
-            // Implicit repeat of last command (L after M)
-            match last_cmd {
-                'M' => 'L',
-                'm' => 'l',
-                c => c,
+        let cmd_char = match token.as_bytes() {
+            [b] if b.is_ascii_alphabetic() => {
+                i += 1;
+                *b as char
+            }
+            _ => {
+                // Implicit repeat of last command (L after M)
+                match last_cmd {
+                    'M' => 'L',
+                    'm' => 'l',
+                    c => c,
+                }
             }
         };
 

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -94,6 +94,12 @@ pub enum SvgNode {
         x: f32,
         y: f32,
         font_size: Option<f32>,
+        /// Per-element font-family override (resolved PDF name, e.g. "Helvetica-Bold").
+        font_family: Option<String>,
+        /// Per-element font-weight override (true = bold).
+        font_bold: Option<bool>,
+        /// Per-element font-style override (true = italic/oblique).
+        font_italic: Option<bool>,
         content: String,
         style: SvgStyle,
     },
@@ -268,12 +274,16 @@ fn parse_svg_node(el: &ElementNode) -> Option<SvgNode> {
             let x = attr_f32(el, "x");
             let y = attr_f32(el, "y");
             let font_size = parse_font_size(el);
+            let (font_family, font_bold, font_italic) = parse_text_font_attrs(el);
             let content = collect_text_content(el);
             let style = parse_svg_style(el);
             Some(SvgNode::Text {
                 x,
                 y,
                 font_size,
+                font_family,
+                font_bold,
+                font_italic,
                 content,
                 style,
             })
@@ -363,6 +373,79 @@ fn parse_font_size(el: &ElementNode) -> Option<f32> {
         }
     }
     None
+}
+
+/// Parse per-element font-family, font-weight, and font-style from a `<text>` element.
+///
+/// Checks both XML attributes (`font-family`, `font-weight`, `font-style`) and
+/// properties inside the `style` attribute.  Returns `(font_family, font_bold, font_italic)`,
+/// each `None` when no explicit value was found on the element.
+fn parse_text_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Option<bool>) {
+    let mut family: Option<String> = None;
+    let mut bold: Option<bool> = None;
+    let mut italic: Option<bool> = None;
+
+    // 1) Direct XML attributes
+    if let Some(val) = el.attributes.get("font-family") {
+        let val = val.trim().trim_matches(|c| c == '\'' || c == '"');
+        if !val.is_empty() {
+            family = Some(val.to_string());
+        }
+    }
+    if let Some(val) = el.attributes.get("font-weight") {
+        bold = Some(is_bold_value(val.trim()));
+    }
+    if let Some(val) = el.attributes.get("font-style") {
+        italic = Some(is_italic_value(val.trim()));
+    }
+
+    // 2) Inline `style` attribute (overrides XML attributes when present)
+    if let Some(style_val) = el.attributes.get("style") {
+        for part in style_val.split(';') {
+            let part = part.trim();
+            if let Some(val) = part.strip_prefix("font-family") {
+                let val = val.trim_start().strip_prefix(':').unwrap_or(val).trim();
+                let val = val.trim_matches(|c| c == '\'' || c == '"');
+                if !val.is_empty() {
+                    family = Some(val.to_string());
+                }
+            } else if let Some(val) = part.strip_prefix("font-weight") {
+                let val = val.trim_start().strip_prefix(':').unwrap_or(val).trim();
+                bold = Some(is_bold_value(val));
+            } else if let Some(val) = part.strip_prefix("font-style") {
+                let val = val.trim_start().strip_prefix(':').unwrap_or(val).trim();
+                italic = Some(is_italic_value(val));
+            }
+        }
+    }
+
+    // Resolve family to a PDF base name (sans bold/italic suffix -- that's applied at render time)
+    let family = family.map(|f| resolve_svg_font_family(&f));
+
+    (family, bold, italic)
+}
+
+/// Map a CSS font-family value to a PDF base-font family name.
+fn resolve_svg_font_family(css_family: &str) -> String {
+    let lower = css_family.to_ascii_lowercase();
+    if lower.contains("times") || lower == "serif" {
+        "Times-Roman".to_string()
+    } else if lower.contains("courier") || lower == "monospace" {
+        "Courier".to_string()
+    } else {
+        // Default to Helvetica for sans-serif / Arial / Helvetica / anything else
+        "Helvetica".to_string()
+    }
+}
+
+fn is_bold_value(val: &str) -> bool {
+    let lower = val.to_ascii_lowercase();
+    lower == "bold" || lower == "bolder" || lower.parse::<u32>().map_or(false, |w| w >= 700)
+}
+
+fn is_italic_value(val: &str) -> bool {
+    let lower = val.to_ascii_lowercase();
+    lower == "italic" || lower == "oblique"
 }
 
 /// Collect all text content from a `<text>` element, including `<tspan>` children.

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -32,6 +32,22 @@ fn split_style_declarations(style: &str) -> Vec<&str> {
     parts
 }
 
+fn style_property_value<'a>(el: &'a ElementNode, name: &str) -> Option<&'a str> {
+    let style_val = el.attributes.get("style")?;
+    let mut value = None;
+
+    for part in split_style_declarations(style_val) {
+        let part = part.trim();
+        if let Some((prop, val)) = part.split_once(':') {
+            if prop.trim() == name {
+                value = Some(val.trim());
+            }
+        }
+    }
+
+    value
+}
+
 /// Inherited CSS context for SVG text rendering.
 #[derive(Debug, Clone)]
 pub struct SvgTextContext {
@@ -535,21 +551,20 @@ fn parse_absolute_length(val: &str) -> Option<f32> {
 
 /// Parse a viewBox attribute: "min-x min-y width height".
 fn parse_viewbox(val: &str) -> Option<ViewBox> {
-    let parts: Vec<f32> = val
+    let mut parts = val
         .split(|c: char| c == ',' || c.is_whitespace())
         .filter(|s| !s.is_empty())
-        .filter_map(|s| s.parse().ok())
-        .collect();
-    if parts.len() == 4 {
-        Some(ViewBox {
-            min_x: parts[0],
-            min_y: parts[1],
-            width: parts[2],
-            height: parts[3],
-        })
-    } else {
-        None
+        .filter_map(|s| s.parse().ok());
+    let view_box = ViewBox {
+        min_x: parts.next()?,
+        min_y: parts.next()?,
+        width: parts.next()?,
+        height: parts.next()?,
+    };
+    if parts.next().is_some() {
+        return None;
     }
+    Some(view_box)
 }
 
 /// Parse color, fill, stroke, stroke-width, opacity from element attributes.
@@ -581,59 +596,45 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
         .get("color")
         .and_then(|v| parse_svg_color_property(v))
         .flatten();
+    if let Some(val) = style_property_value(el, "color") {
+        if let Some(parsed) = parse_svg_color_property(val) {
+            color = parsed;
+        }
+    }
     let mut fill = el
         .attributes
         .get("fill")
         .and_then(|v| parse_svg_paint(v))
         .unwrap_or(SvgPaint::Unspecified);
+    if let Some(paint) = style_property_value(el, "fill").and_then(parse_svg_paint) {
+        fill = paint;
+    }
     let mut stroke = el
         .attributes
         .get("stroke")
         .and_then(|v| parse_svg_paint(v))
         .unwrap_or(SvgPaint::Unspecified);
+    if let Some(paint) = style_property_value(el, "stroke").and_then(parse_svg_paint) {
+        stroke = paint;
+    }
     let mut stroke_width = el
         .attributes
         .get("stroke-width")
         .and_then(|v| v.trim().parse::<f32>().ok())
         .filter(|v| *v >= 0.0);
+    if let Some(width) = style_property_value(el, "stroke-width")
+        .and_then(|v| v.parse::<f32>().ok())
+        .filter(|v| *v >= 0.0)
+    {
+        stroke_width = Some(width);
+    }
     let mut opacity = el
         .attributes
         .get("opacity")
         .and_then(|v| v.parse().ok())
         .unwrap_or(1.0);
-
-    if let Some(style_val) = el.attributes.get("style") {
-        for part in split_style_declarations(style_val) {
-            let part = part.trim();
-            if let Some((prop, val)) = part.split_once(':') {
-                match prop.trim() {
-                    "color" => {
-                        if let Some(parsed) = parse_svg_color_property(val) {
-                            color = parsed;
-                        }
-                    }
-                    "fill" => {
-                        if let Some(paint) = parse_svg_paint(val) {
-                            fill = paint;
-                        }
-                    }
-                    "stroke" => {
-                        if let Some(paint) = parse_svg_paint(val) {
-                            stroke = paint;
-                        }
-                    }
-                    "stroke-width" => {
-                        if let Ok(v) = val.trim().parse::<f32>() {
-                            if v >= 0.0 {
-                                stroke_width = Some(v);
-                            }
-                        }
-                    }
-                    "opacity" => opacity = val.trim().parse().ok().unwrap_or(opacity),
-                    _ => {}
-                }
-            }
-        }
+    if let Some(val) = style_property_value(el, "opacity") {
+        opacity = val.trim().parse().ok().unwrap_or(opacity);
     }
 
     SvgStyle {
@@ -653,18 +654,7 @@ fn parse_font_size_attr(el: &ElementNode) -> Option<String> {
     if let Some(val) = el.attributes.get("font-size") {
         return Some(val.trim().to_string());
     }
-    // 2) Inline style: style="font-size:20px"
-    if let Some(style_val) = el.attributes.get("style") {
-        for part in split_style_declarations(style_val) {
-            let part = part.trim();
-            if let Some((prop, val)) = part.split_once(':') {
-                if prop.trim() == "font-size" {
-                    return Some(val.trim().to_string());
-                }
-            }
-        }
-    }
-    None
+    style_property_value(el, "font-size").map(|val| val.to_string())
 }
 
 /// Parse per-element font-family, font-weight, and font-style from a `<text>` element.
@@ -692,24 +682,17 @@ fn parse_text_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Opt
     }
 
     // 2) Inline `style` attribute (overrides XML attributes when present)
-    if let Some(style_val) = el.attributes.get("style") {
-        for part in split_style_declarations(style_val) {
-            let part = part.trim();
-            if let Some((prop, val)) = part.split_once(':') {
-                let prop = prop.trim();
-                let val = val.trim();
-                if prop == "font-family" {
-                    let val = val.trim_matches(|c| c == '\'' || c == '"');
-                    if !val.is_empty() {
-                        family = Some(val.to_string());
-                    }
-                } else if prop == "font-weight" {
-                    bold = Some(is_bold_value(val));
-                } else if prop == "font-style" {
-                    italic = Some(is_italic_value(val));
-                }
-            }
+    if let Some(val) = style_property_value(el, "font-family") {
+        let val = val.trim_matches(|c| c == '\'' || c == '"');
+        if !val.is_empty() {
+            family = Some(val.to_string());
         }
+    }
+    if let Some(val) = style_property_value(el, "font-weight") {
+        bold = Some(is_bold_value(val));
+    }
+    if let Some(val) = style_property_value(el, "font-style") {
+        italic = Some(is_italic_value(val));
     }
 
     // Resolve family to a PDF base name (sans bold/italic suffix -- that's applied at render time)
@@ -719,34 +702,13 @@ fn parse_text_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Opt
 }
 
 fn has_fill_specified(el: &ElementNode) -> bool {
-    if el.attributes.contains_key("fill") {
-        return true;
-    }
-    if let Some(style_val) = el.attributes.get("style") {
-        for part in split_style_declarations(style_val) {
-            let part = part.trim();
-            if let Some((prop, _val)) = part.split_once(':') {
-                if prop.trim() == "fill" {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+    el.attributes.contains_key("fill") || style_property_value(el, "fill").is_some()
 }
 
 fn parse_fill_raw(el: &ElementNode) -> Option<String> {
-    if let Some(style_val) = el.attributes.get("style") {
-        for part in split_style_declarations(style_val) {
-            let part = part.trim();
-            if let Some((prop, val)) = part.split_once(':') {
-                if prop.trim() == "fill" {
-                    let raw = val.trim();
-                    if !raw.is_empty() {
-                        return Some(raw.to_string());
-                    }
-                }
-            }
+    if let Some(raw) = style_property_value(el, "fill") {
+        if !raw.is_empty() {
+            return Some(raw.to_string());
         }
     }
     if let Some(val) = el.attributes.get("fill") {
@@ -823,13 +785,14 @@ pub fn parse_svg_color(val: &str) -> Option<(f32, f32, f32)> {
 
     // rgb(r, g, b)
     if let Some(inner) = val.strip_prefix("rgb(").and_then(|s| s.strip_suffix(')')) {
-        let parts: Vec<&str> = inner.split(',').collect();
-        if parts.len() == 3 {
-            let r = parts[0].trim().parse::<f32>().ok()?;
-            let g = parts[1].trim().parse::<f32>().ok()?;
-            let b = parts[2].trim().parse::<f32>().ok()?;
-            return Some((r / 255.0, g / 255.0, b / 255.0));
+        let mut parts = inner.split(',');
+        let r = parts.next()?.trim().parse::<f32>().ok()?;
+        let g = parts.next()?.trim().parse::<f32>().ok()?;
+        let b = parts.next()?.trim().parse::<f32>().ok()?;
+        if parts.next().is_some() {
+            return None;
         }
+        return Some((r / 255.0, g / 255.0, b / 255.0));
     }
 
     None
@@ -837,11 +800,19 @@ pub fn parse_svg_color(val: &str) -> Option<(f32, f32, f32)> {
 
 /// Parse a hex color string (without the #).
 fn parse_hex_color(hex: &str) -> Option<(f32, f32, f32)> {
+    fn hex_digit(c: char) -> Option<u8> {
+        c.to_digit(16).map(|d| d as u8)
+    }
+
     match hex.len() {
         3 => {
-            let r = u8::from_str_radix(&hex[0..1], 16).ok()?;
-            let g = u8::from_str_radix(&hex[1..2], 16).ok()?;
-            let b = u8::from_str_radix(&hex[2..3], 16).ok()?;
+            let mut chars = hex.chars();
+            let r = hex_digit(chars.next()?)?;
+            let g = hex_digit(chars.next()?)?;
+            let b = hex_digit(chars.next()?)?;
+            if chars.next().is_some() {
+                return None;
+            }
             Some((
                 (r * 17) as f32 / 255.0,
                 (g * 17) as f32 / 255.0,
@@ -849,9 +820,13 @@ fn parse_hex_color(hex: &str) -> Option<(f32, f32, f32)> {
             ))
         }
         6 => {
-            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            let mut chars = hex.chars();
+            let r = (hex_digit(chars.next()?)? << 4) | hex_digit(chars.next()?)?;
+            let g = (hex_digit(chars.next()?)? << 4) | hex_digit(chars.next()?)?;
+            let b = (hex_digit(chars.next()?)? << 4) | hex_digit(chars.next()?)?;
+            if chars.next().is_some() {
+                return None;
+            }
             Some((r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0))
         }
         _ => None,
@@ -875,7 +850,12 @@ pub fn parse_path_data(d: &str) -> Vec<PathCommand> {
         let token = &tokens[i];
 
         // Determine if this token is a command letter
-        let cmd_char = if token.len() == 1 && token.as_bytes()[0].is_ascii_alphabetic() {
+        let cmd_char = if token.len() == 1
+            && token
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic())
+        {
             let c = token.chars().next().unwrap();
             i += 1;
             c
@@ -1348,6 +1328,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_svg_style_style_fill_inherit_overrides_attribute() {
+        let el = make_el("rect", vec![("fill", "red"), ("style", "fill: inherit;")]);
+        let style = parse_svg_style(&el);
+        assert_eq!(style.fill, SvgPaint::Unspecified);
+    }
+
+    #[test]
     fn parse_svg_style_unparseable_style_stroke_does_not_override_attribute() {
         let el = make_el(
             "rect",
@@ -1355,6 +1342,16 @@ mod tests {
         );
         let style = parse_svg_style(&el);
         assert_eq!(style.stroke, SvgPaint::Color((0.0, 0.0, 1.0)));
+    }
+
+    #[test]
+    fn parse_svg_style_style_stroke_inherit_overrides_attribute() {
+        let el = make_el(
+            "rect",
+            vec![("stroke", "blue"), ("style", "stroke: inherit;")],
+        );
+        let style = parse_svg_style(&el);
+        assert_eq!(style.stroke, SvgPaint::Unspecified);
     }
 
     #[test]

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -2093,7 +2093,7 @@ fn rounded_rect_path(x: f32, y: f32, w: f32, h: f32, r: f32) -> String {
 /// not UTF-8. Writing raw UTF-8 bytes causes multi-byte characters like em dash
 /// to appear as mojibake. This function maps Unicode code points to their
 /// WinAnsi byte equivalents.
-fn utf8_to_winansi(text: &str) -> Vec<u8> {
+pub(crate) fn utf8_to_winansi(text: &str) -> Vec<u8> {
     let mut result = Vec::with_capacity(text.len());
     for ch in text.chars() {
         let code = ch as u32;
@@ -2147,7 +2147,7 @@ fn utf8_to_winansi(text: &str) -> Vec<u8> {
 /// - All other bytes (0x00..=0x1F, 0x7F..=0xFF) are written as octal escapes `\NNN`
 ///
 /// The returned string is safe to embed in a PDF content stream as `(encoded) Tj`.
-fn encode_pdf_text(text: &str) -> String {
+pub(crate) fn encode_pdf_text(text: &str) -> String {
     let winansi = utf8_to_winansi(text);
     let mut result = String::with_capacity(winansi.len() * 2);
     for &b in &winansi {

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1812,7 +1812,7 @@ fn rounded_rect_path(x: f32, y: f32, w: f32, h: f32, r: f32) -> String {
 /// not UTF-8. Writing raw UTF-8 bytes causes multi-byte characters like em dash
 /// to appear as mojibake. This function maps Unicode code points to their
 /// WinAnsi byte equivalents.
-fn utf8_to_winansi(text: &str) -> Vec<u8> {
+pub(crate) fn utf8_to_winansi(text: &str) -> Vec<u8> {
     let mut result = Vec::with_capacity(text.len());
     for ch in text.chars() {
         let code = ch as u32;
@@ -1866,7 +1866,7 @@ fn utf8_to_winansi(text: &str) -> Vec<u8> {
 /// - All other bytes (0x00..=0x1F, 0x7F..=0xFF) are written as octal escapes `\NNN`
 ///
 /// The returned string is safe to embed in a PDF content stream as `(encoded) Tj`.
-fn encode_pdf_text(text: &str) -> String {
+pub(crate) fn encode_pdf_text(text: &str) -> String {
     let winansi = utf8_to_winansi(text);
     let mut result = String::with_capacity(winansi.len() * 2);
     for &b in &winansi {

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -1,30 +1,92 @@
 //! SVG tree to PDF content stream renderer.
 
-use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTransform, SvgTree};
+use crate::parser::svg::{
+    PathCommand, SvgNode, SvgPaint, SvgStyle, SvgTextContext, SvgTransform, SvgTree,
+};
+use crate::render::pdf::encode_pdf_text;
 
 /// Render an SVG tree to PDF content stream operators.
 ///
 /// The caller must wrap this in a `q ... Q` block and set up the coordinate
 /// transform (position on page + y-axis flip).
 pub fn render_svg_tree(tree: &SvgTree, out: &mut String) {
+    // SVG initial values: fill=black, stroke=none, stroke-width=1.
+    let root_style = ResolvedStyle {
+        color: tree.text_ctx.color,
+        fill: SvgPaint::Color((0.0, 0.0, 0.0)),
+        stroke: SvgPaint::None,
+        stroke_width: 1.0,
+        font_family: None,
+        font_bold: None,
+        font_italic: None,
+    };
     for node in &tree.children {
-        render_node(node, out);
+        render_node(node, root_style.clone(), &tree.text_ctx, out);
     }
 }
 
-fn render_node(node: &SvgNode, out: &mut String) {
+#[derive(Debug, Clone)]
+struct ResolvedStyle {
+    color: Option<(f32, f32, f32)>,
+    fill: SvgPaint,
+    stroke: SvgPaint,
+    stroke_width: f32,
+    font_family: Option<String>,
+    font_bold: Option<bool>,
+    font_italic: Option<bool>,
+}
+
+fn resolve_style(parent: ResolvedStyle, local: &SvgStyle) -> ResolvedStyle {
+    let fill = match local.fill {
+        SvgPaint::Unspecified => parent.fill,
+        other => other,
+    };
+    let color = local.color.or(parent.color);
+    let stroke = match local.stroke {
+        SvgPaint::Unspecified => parent.stroke,
+        other => other,
+    };
+    let stroke_width = local.stroke_width.unwrap_or(parent.stroke_width);
+    ResolvedStyle {
+        color,
+        fill,
+        stroke,
+        stroke_width,
+        font_family: local.font_family.clone().or(parent.font_family),
+        font_bold: local.font_bold.or(parent.font_bold),
+        font_italic: local.font_italic.or(parent.font_italic),
+    }
+}
+
+fn paint_to_rgb(paint: SvgPaint, color: Option<(f32, f32, f32)>) -> Option<(f32, f32, f32)> {
+    match paint {
+        SvgPaint::None => None,
+        SvgPaint::Color(c) => Some(c),
+        SvgPaint::CurrentColor => Some(color.unwrap_or((0.0, 0.0, 0.0))),
+        SvgPaint::Unspecified => None,
+    }
+}
+
+fn render_node(
+    node: &SvgNode,
+    inherited: ResolvedStyle,
+    text_ctx: &SvgTextContext,
+    out: &mut String,
+) {
     match node {
         SvgNode::Group {
             transform,
             children,
+            style,
             ..
         } => {
+            let inherited = resolve_style(inherited, style);
             out.push_str("q\n");
             if let Some(SvgTransform::Matrix(a, b, c, d, e, f)) = transform {
                 out.push_str(&format!("{a} {b} {c} {d} {e} {f} cm\n"));
             }
             for child in children {
-                render_node(child, out);
+                render_node(child, inherited.clone(), text_ctx, out);
             }
             out.push_str("Q\n");
         }
@@ -36,15 +98,16 @@ fn render_node(node: &SvgNode, out: &mut String) {
             style,
             ..
         } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(&style, out);
             out.push_str(&format!("{x} {y} {width} {height} re\n"));
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Circle { cx, cy, r, style } => {
-            apply_style(style, out);
-            // Approximate circle with 4 cubic bezier curves
+            let style = resolve_style(inherited, style);
+            apply_style(&style, out);
             emit_circle(*cx, *cy, *r, out);
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Ellipse {
             cx,
@@ -53,9 +116,10 @@ fn render_node(node: &SvgNode, out: &mut String) {
             ry,
             style,
         } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(&style, out);
             emit_ellipse(*cx, *cy, *rx, *ry, out);
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Line {
             x1,
@@ -64,50 +128,221 @@ fn render_node(node: &SvgNode, out: &mut String) {
             y2,
             style,
         } => {
-            apply_style(style, out);
-            out.push_str(&format!("{x1} {y1} m {x2} {y2} l S\n"));
+            let style = resolve_style(inherited, style);
+            apply_stroke_style(&style, out);
+            out.push_str(&format!("{x1} {y1} m {x2} {y2} l\n"));
+            paint_stroke_only(&style, out);
         }
         SvgNode::Polyline { points, style } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_stroke_style(&style, out);
             emit_polyline(points, false, out);
-            out.push_str("S\n"); // stroke only for polyline
+            paint_stroke_only(&style, out);
         }
         SvgNode::Polygon { points, style } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(&style, out);
             emit_polyline(points, true, out);
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Path { commands, style } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(&style, out);
             emit_path(commands, out);
-            paint(style, out);
+            paint(&style, out);
+        }
+        SvgNode::Text {
+            x,
+            y,
+            font_size,
+            font_size_attr,
+            fill_specified: _fill_specified,
+            fill_raw: _fill_raw,
+            font_family,
+            font_bold,
+            font_italic,
+            content,
+            style,
+        } => {
+            let style = resolve_style(inherited, style);
+            // Use SVG-explicit font_size if set, otherwise inherit from CSS context
+            let size = font_size_attr
+                .as_deref()
+                .and_then(|raw| resolve_svg_font_size(raw, text_ctx.font_size))
+                .or(*font_size)
+                .unwrap_or(text_ctx.font_size);
+            let fill = paint_to_rgb(style.fill, style.color);
+            let stroke = paint_to_rgb(style.stroke, style.color);
+            let has_stroke = has_visible_stroke(&style);
+            let stroke = stroke.filter(|_| has_stroke);
+            let font = resolve_svg_text_font(
+                style.font_family.as_deref(),
+                style.font_bold,
+                style.font_italic,
+                font_family.as_deref(),
+                *font_bold,
+                *font_italic,
+                text_ctx,
+            );
+            let text_render_mode = match (fill.is_some(), stroke.is_some()) {
+                (true, true) => 2,
+                (true, false) => 0,
+                (false, true) => 1,
+                (false, false) => 3,
+            };
+
+            out.push_str("BT\n");
+            out.push_str(&format!("/{font} {size} Tf\n"));
+            out.push_str(&format!("{text_render_mode} Tr\n"));
+            if let Some((r, g, b)) = fill {
+                out.push_str(&format!("{r} {g} {b} rg\n"));
+            }
+            if let Some((r, g, b)) = stroke {
+                out.push_str(&format!("{r} {g} {b} RG\n"));
+                out.push_str(&format!("{} w\n", style.stroke_width));
+            }
+            // The parent SVG content stream has a y-flip (scale 1,-1) to convert
+            // SVG coordinates to PDF coordinates. Text must counter this flip via
+            // the text matrix, otherwise glyphs render upside-down.
+            out.push_str(&format!("1 0 0 -1 {x} {y} Tm\n"));
+            let encoded = encode_pdf_text(content);
+            out.push_str(&format!("({encoded}) Tj\n"));
+            out.push_str("ET\n");
         }
     }
 }
 
-fn apply_style(style: &SvgStyle, out: &mut String) {
+fn resolve_svg_font_size(raw: &str, inherited_size: f32) -> Option<f32> {
+    let raw = raw.trim();
+    if let Some(pct) = raw.strip_suffix('%') {
+        let pct = pct.trim().parse::<f32>().ok()?;
+        return Some(inherited_size * pct / 100.0);
+    }
+    if let Some(em) = raw.strip_suffix("em") {
+        let em = em.trim().parse::<f32>().ok()?;
+        return Some(inherited_size * em);
+    }
+    if let Some(px) = raw.strip_suffix("px") {
+        let px = px.trim().parse::<f32>().ok()?;
+        return Some(px * 0.75);
+    }
+    if let Some(pt) = raw.strip_suffix("pt") {
+        return pt.trim().parse::<f32>().ok();
+    }
+    raw.parse::<f32>().ok().map(|px| px * 0.75)
+}
+
+fn apply_style(style: &ResolvedStyle, out: &mut String) {
     // Fill color
-    if let Some((r, g, b)) = style.fill {
+    if let Some((r, g, b)) = paint_to_rgb(style.fill, style.color) {
         out.push_str(&format!("{r} {g} {b} rg\n"));
     }
-    // Stroke color
-    if let Some((r, g, b)) = style.stroke {
+    apply_stroke_style(style, out);
+}
+
+fn apply_stroke_style(style: &ResolvedStyle, out: &mut String) {
+    if let Some((r, g, b)) = paint_to_rgb(style.stroke, style.color) {
         out.push_str(&format!("{r} {g} {b} RG\n"));
     }
-    // Stroke width
     if style.stroke_width > 0.0 {
         out.push_str(&format!("{} w\n", style.stroke_width));
     }
 }
 
-fn paint(style: &SvgStyle, out: &mut String) {
-    let has_fill = style.fill.is_some();
-    let has_stroke = style.stroke.is_some() && style.stroke_width > 0.0;
+fn paint(style: &ResolvedStyle, out: &mut String) {
+    let has_fill = paint_to_rgb(style.fill, style.color).is_some();
+    let has_stroke = has_visible_stroke(style);
     match (has_fill, has_stroke) {
         (true, true) => out.push_str("B\n"),   // fill + stroke
         (true, false) => out.push_str("f\n"),  // fill only
         (false, true) => out.push_str("S\n"),  // stroke only
         (false, false) => out.push_str("n\n"), // no paint
+    }
+}
+
+fn paint_stroke_only(style: &ResolvedStyle, out: &mut String) {
+    let has_stroke = has_visible_stroke(style);
+    if has_stroke {
+        out.push_str("S\n");
+    } else {
+        out.push_str("n\n");
+    }
+}
+
+fn has_visible_stroke(style: &ResolvedStyle) -> bool {
+    !matches!(style.stroke, SvgPaint::None | SvgPaint::Unspecified) && style.stroke_width > 0.0
+}
+
+/// Resolve the PDF font name for an SVG `<text>` element.
+///
+/// Precedence is:
+/// 1. per-element `<text>` font attributes
+/// 2. inherited SVG style from ancestor groups / the text element itself
+/// 3. the outer HTML/SVG text context
+fn resolve_svg_text_font(
+    inherited_font_family: Option<&str>,
+    inherited_font_bold: Option<bool>,
+    inherited_font_italic: Option<bool>,
+    font_family: Option<&str>,
+    font_bold: Option<bool>,
+    font_italic: Option<bool>,
+    text_ctx: &SvgTextContext,
+) -> String {
+    let bold = font_bold
+        .or(inherited_font_bold)
+        .unwrap_or(text_ctx.font_bold);
+    let italic = font_italic
+        .or(inherited_font_italic)
+        .unwrap_or(text_ctx.font_italic);
+
+    if let Some(base) = font_family.or(inherited_font_family) {
+        pdf_font_name(base, bold, italic).to_string()
+    } else if font_bold.is_some()
+        || font_italic.is_some()
+        || inherited_font_bold.is_some()
+        || inherited_font_italic.is_some()
+    {
+        let base = base_family_from_pdf_name(&text_ctx.font_family);
+        pdf_font_name(base, bold, italic).to_string()
+    } else {
+        text_ctx.font_family.clone()
+    }
+}
+
+/// Extract the base family name from a fully-qualified PDF font name.
+fn base_family_from_pdf_name(name: &str) -> &str {
+    if name.starts_with("Times") {
+        "Times-Roman"
+    } else if name.starts_with("Courier") {
+        "Courier"
+    } else {
+        "Helvetica"
+    }
+}
+
+/// Map (base_family, bold, italic) to a concrete PDF built-in font name.
+fn pdf_font_name(base: &str, bold: bool, italic: bool) -> &'static str {
+    if base.starts_with("Times") {
+        match (bold, italic) {
+            (true, true) => "Times-BoldItalic",
+            (true, false) => "Times-Bold",
+            (false, true) => "Times-Italic",
+            (false, false) => "Times-Roman",
+        }
+    } else if base.starts_with("Courier") {
+        match (bold, italic) {
+            (true, true) => "Courier-BoldOblique",
+            (true, false) => "Courier-Bold",
+            (false, true) => "Courier-Oblique",
+            (false, false) => "Courier",
+        }
+    } else {
+        match (bold, italic) {
+            (true, true) => "Helvetica-BoldOblique",
+            (true, false) => "Helvetica-Bold",
+            (false, true) => "Helvetica-Oblique",
+            (false, false) => "Helvetica",
+        }
     }
 }
 
@@ -199,40 +434,58 @@ fn emit_path(commands: &[PathCommand], out: &mut String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTransform, SvgTree};
+    use crate::parser::svg::{
+        PathCommand, SvgNode, SvgPaint, SvgStyle, SvgTextContext, SvgTransform, SvgTree,
+    };
 
     fn style_fill(r: f32, g: f32, b: f32) -> SvgStyle {
         SvgStyle {
-            fill: Some((r, g, b)),
-            stroke: None,
-            stroke_width: 0.0,
+            color: None,
+            fill: SvgPaint::Color((r, g, b)),
+            stroke: SvgPaint::Unspecified,
+            stroke_width: None,
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
 
     fn style_stroke(r: f32, g: f32, b: f32, w: f32) -> SvgStyle {
         SvgStyle {
-            fill: None,
-            stroke: Some((r, g, b)),
-            stroke_width: w,
+            color: None,
+            fill: SvgPaint::None,
+            stroke: SvgPaint::Color((r, g, b)),
+            stroke_width: Some(w),
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
 
     fn style_fill_and_stroke() -> SvgStyle {
         SvgStyle {
-            fill: Some((1.0, 0.0, 0.0)),
-            stroke: Some((0.0, 0.0, 1.0)),
-            stroke_width: 2.0,
+            color: None,
+            fill: SvgPaint::Color((1.0, 0.0, 0.0)),
+            stroke: SvgPaint::Color((0.0, 0.0, 1.0)),
+            stroke_width: Some(2.0),
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
 
     fn style_none() -> SvgStyle {
         SvgStyle {
-            fill: None,
-            stroke: None,
-            stroke_width: 0.0,
+            color: None,
+            fill: SvgPaint::None,
+            stroke: SvgPaint::None,
+            stroke_width: None,
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
@@ -241,8 +494,11 @@ mod tests {
         SvgTree {
             width: 100.0,
             height: 100.0,
+            width_attr: None,
+            height_attr: None,
             view_box: None,
             children,
+            text_ctx: SvgTextContext::default(),
         }
     }
 
@@ -405,14 +661,14 @@ mod tests {
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
         assert!(
-            out.contains("0 0 m 100 100 l S\n"),
+            out.contains("0 0 m 100 100 l\nS\n"),
             "should emit line with stroke"
         );
     }
 
     #[test]
     fn render_line_with_fill_style() {
-        // Lines use apply_style but always stroke via the inline S operator
+        // Fill does not apply to <line>; without a stroke, the line is not painted.
         let tree = tree_with(vec![SvgNode::Line {
             x1: 5.0,
             y1: 10.0,
@@ -422,8 +678,30 @@ mod tests {
         }]);
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
-        assert!(out.contains("1 1 0 rg\n"), "should apply fill style");
-        assert!(out.contains("5 10 m 50 60 l S\n"), "should emit line");
+        assert!(
+            !out.contains(" rg\n"),
+            "should not set fill color for <line>"
+        );
+        assert!(out.contains("5 10 m 50 60 l\n"), "should emit line path");
+        assert!(
+            out.contains("n\n"),
+            "should not stroke without a stroke paint"
+        );
+    }
+
+    #[test]
+    fn render_line_without_stroke_is_not_painted() {
+        let tree = tree_with(vec![SvgNode::Line {
+            x1: 0.0,
+            y1: 0.0,
+            x2: 10.0,
+            y2: 10.0,
+            style: SvgStyle::default(),
+        }]);
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("n\n"));
+        assert!(!out.contains("S\n"));
     }
 
     // ---- Polyline tests ----
@@ -453,6 +731,51 @@ mod tests {
         render_svg_tree(&tree, &mut out);
         // Should still emit S even with no points
         assert!(out.contains("S\n"));
+    }
+
+    #[test]
+    fn render_polyline_without_stroke_is_not_painted() {
+        let tree = tree_with(vec![SvgNode::Polyline {
+            points: vec![(0.0, 0.0), (10.0, 10.0)],
+            style: SvgStyle::default(),
+        }]);
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("n\n"));
+        assert!(!out.contains("S\n"));
+    }
+
+    #[test]
+    fn group_fill_is_inherited_by_children() {
+        let tree = tree_with(vec![SvgNode::Group {
+            transform: None,
+            children: vec![SvgNode::Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+                rx: 0.0,
+                ry: 0.0,
+                style: SvgStyle::default(),
+            }],
+            style: SvgStyle {
+                color: None,
+                fill: SvgPaint::Color((1.0, 0.0, 0.0)),
+                stroke: SvgPaint::Unspecified,
+                stroke_width: None,
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                ..SvgStyle::default()
+            },
+        }]);
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("1 0 0 rg\n"),
+            "child should inherit group fill"
+        );
+        assert!(out.contains("f\n"), "rect should be filled");
     }
 
     // ---- Polygon tests ----
@@ -700,9 +1023,13 @@ mod tests {
             rx: 0.0,
             ry: 0.0,
             style: SvgStyle {
-                fill: Some((1.0, 0.0, 0.0)),
-                stroke: Some((0.0, 0.0, 0.0)),
-                stroke_width: 0.0,
+                color: None,
+                fill: SvgPaint::Color((1.0, 0.0, 0.0)),
+                stroke: SvgPaint::Color((0.0, 0.0, 0.0)),
+                stroke_width: Some(0.0),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
                 opacity: 1.0,
             },
         }]);
@@ -747,5 +1074,377 @@ mod tests {
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
         assert!(out.contains("n\n"), "should emit no-paint");
+    }
+
+    #[test]
+    fn text_fill_none_does_not_fallback_to_context_color() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: true,
+                fill_raw: Some("none".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    color: None,
+                    fill: SvgPaint::None,
+                    stroke: SvgPaint::Unspecified,
+                    stroke_width: None,
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((1.0, 0.0, 0.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("3 Tr\n"),
+            "fill:none should disable text painting"
+        );
+        assert!(
+            !out.contains(" rg\n"),
+            "explicit fill:none should not fall back to inherited text color"
+        );
+        assert!(out.contains("(Hello) Tj\n"));
+    }
+
+    #[test]
+    fn text_fill_none_with_stroke_renders_stroked_glyphs() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: true,
+                fill_raw: Some("none".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    color: None,
+                    fill: SvgPaint::None,
+                    stroke: SvgPaint::Color((1.0, 0.0, 0.0)),
+                    stroke_width: Some(1.5),
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext::default(),
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("1 Tr\n"),
+            "stroke-only text should use stroke render mode"
+        );
+        assert!(
+            out.contains("1 0 0 RG\n"),
+            "stroke-only text should set the stroke color"
+        );
+        assert!(
+            out.contains("1.5 w\n"),
+            "stroke-only text should set the stroke width"
+        );
+        assert!(
+            !out.contains("3 Tr\n"),
+            "stroke-only text must not be invisible"
+        );
+    }
+
+    #[test]
+    fn text_fill_defaults_to_black_when_unspecified() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: false,
+                fill_raw: None,
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle::default(),
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((1.0, 0.0, 0.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("0 0 0 rg\n"),
+            "unspecified SVG text fill should default to black"
+        );
+    }
+
+    #[test]
+    fn text_font_size_percent_scales_from_context() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: Some("150%".to_string()),
+                fill_specified: true,
+                fill_raw: Some("currentColor".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    color: None,
+                    fill: SvgPaint::Color((0.0, 0.0, 0.0)),
+                    stroke: SvgPaint::Unspecified,
+                    stroke_width: None,
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext {
+                font_size: 12.0,
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("/Helvetica 18 Tf\n"),
+            "150% font-size should resolve from the inherited SVG text size"
+        );
+    }
+
+    #[test]
+    fn text_font_size_unitless_number_treated_as_px() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: Some("12".to_string()),
+                fill_specified: true,
+                fill_raw: Some("currentColor".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    color: None,
+                    fill: SvgPaint::Color((0.0, 0.0, 0.0)),
+                    stroke: SvgPaint::Unspecified,
+                    stroke_width: None,
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext::default(),
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("/Helvetica 9 Tf\n"),
+            "unitless SVG font-size should resolve like px"
+        );
+    }
+
+    #[test]
+    fn text_inherits_group_font_family_and_style() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Group {
+                transform: None,
+                style: SvgStyle {
+                    font_family: Some("Courier".to_string()),
+                    font_bold: Some(true),
+                    font_italic: Some(true),
+                    ..SvgStyle::default()
+                },
+                children: vec![SvgNode::Text {
+                    x: 10.0,
+                    y: 20.0,
+                    font_size: None,
+                    font_size_attr: None,
+                    fill_specified: true,
+                    fill_raw: Some("currentColor".to_string()),
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    content: "Hello".to_string(),
+                    style: SvgStyle {
+                        fill: SvgPaint::CurrentColor,
+                        ..SvgStyle::default()
+                    },
+                }],
+            }],
+            text_ctx: SvgTextContext::default(),
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("/Courier-BoldOblique 12 Tf\n"),
+            "group font inheritance should reach SVG text rendering"
+        );
+    }
+
+    #[test]
+    fn text_fill_current_color_uses_context_color() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: true,
+                fill_raw: Some("currentColor".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    color: None,
+                    fill: SvgPaint::CurrentColor,
+                    stroke: SvgPaint::Unspecified,
+                    stroke_width: None,
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((0.0, 0.5, 1.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("0 0.5 1 rg\n"));
+    }
+
+    #[test]
+    fn text_fill_current_color_inherits_nested_svg_color() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Group {
+                transform: None,
+                style: SvgStyle {
+                    color: Some((1.0, 0.0, 0.0)),
+                    ..SvgStyle::default()
+                },
+                children: vec![SvgNode::Text {
+                    x: 10.0,
+                    y: 20.0,
+                    font_size: None,
+                    font_size_attr: None,
+                    fill_specified: true,
+                    fill_raw: Some("currentColor".to_string()),
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    content: "Hello".to_string(),
+                    style: SvgStyle {
+                        fill: SvgPaint::CurrentColor,
+                        ..SvgStyle::default()
+                    },
+                }],
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((0.0, 0.5, 1.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("1 0 0 rg\n"));
+    }
+
+    #[test]
+    fn text_invalid_fill_defaults_to_black() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: true,
+                fill_raw: Some("bogus".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle::default(),
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((1.0, 0.0, 0.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("0 0 0 rg\n"));
     }
 }

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -54,7 +54,12 @@ fn paint_to_rgb(paint: SvgPaint, text_ctx: &SvgTextContext) -> Option<(f32, f32,
     }
 }
 
-fn render_node(node: &SvgNode, inherited: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
+fn render_node(
+    node: &SvgNode,
+    inherited: ResolvedStyle,
+    text_ctx: &SvgTextContext,
+    out: &mut String,
+) {
     match node {
         SvgNode::Group {
             transform,
@@ -154,24 +159,26 @@ fn render_node(node: &SvgNode, inherited: ResolvedStyle, text_ctx: &SvgTextConte
                 .or(*font_size)
                 .unwrap_or(text_ctx.font_size);
             let fill = paint_to_rgb(style.fill, text_ctx);
+            let stroke = paint_to_rgb(style.stroke, text_ctx).filter(|_| style.stroke_width > 0.0);
             // Use per-element font if specified, falling back to inherited CSS font
-            let font = resolve_svg_text_font(
-                font_family.as_deref(),
-                *font_bold,
-                *font_italic,
-                text_ctx,
-            );
+            let font =
+                resolve_svg_text_font(font_family.as_deref(), *font_bold, *font_italic, text_ctx);
+            let text_render_mode = match (fill.is_some(), stroke.is_some()) {
+                (true, true) => 2,
+                (true, false) => 0,
+                (false, true) => 1,
+                (false, false) => 3,
+            };
 
             out.push_str("BT\n");
             out.push_str(&format!("/{font} {size} Tf\n"));
-            if fill.is_some() {
-                out.push_str("0 Tr\n");
-            } else {
-                // PDF "invisible" text rendering mode; keeps layout operators but disables painting.
-                out.push_str("3 Tr\n");
-            }
+            out.push_str(&format!("{text_render_mode} Tr\n"));
             if let Some((r, g, b)) = fill {
                 out.push_str(&format!("{r} {g} {b} rg\n"));
+            }
+            if let Some((r, g, b)) = stroke {
+                out.push_str(&format!("{r} {g} {b} RG\n"));
+                out.push_str(&format!("{} w\n", style.stroke_width));
             }
             // The parent SVG content stream has a y-flip (scale 1,-1) to convert
             // SVG coordinates to PDF coordinates. Text must counter this flip via
@@ -388,7 +395,6 @@ fn emit_path(commands: &[PathCommand], out: &mut String) {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -621,9 +627,15 @@ mod tests {
         }]);
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
-        assert!(!out.contains(" rg\n"), "should not set fill color for <line>");
+        assert!(
+            !out.contains(" rg\n"),
+            "should not set fill color for <line>"
+        );
         assert!(out.contains("5 10 m 50 60 l\n"), "should emit line path");
-        assert!(out.contains("n\n"), "should not stroke without a stroke paint");
+        assert!(
+            out.contains("n\n"),
+            "should not stroke without a stroke paint"
+        );
     }
 
     #[test]
@@ -702,7 +714,10 @@ mod tests {
         }]);
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
-        assert!(out.contains("1 0 0 rg\n"), "child should inherit group fill");
+        assert!(
+            out.contains("1 0 0 rg\n"),
+            "child should inherit group fill"
+        );
         assert!(out.contains("f\n"), "rect should be filled");
     }
 
@@ -1033,12 +1048,63 @@ mod tests {
         };
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
-        assert!(out.contains("3 Tr\n"), "fill:none should disable text painting");
+        assert!(
+            out.contains("3 Tr\n"),
+            "fill:none should disable text painting"
+        );
         assert!(
             !out.contains(" rg\n"),
             "explicit fill:none should not fall back to inherited text color"
         );
         assert!(out.contains("(Hello) Tj\n"));
+    }
+
+    #[test]
+    fn text_fill_none_with_stroke_renders_stroked_glyphs() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: true,
+                fill_raw: Some("none".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    fill: SvgPaint::None,
+                    stroke: SvgPaint::Color((1.0, 0.0, 0.0)),
+                    stroke_width: Some(1.5),
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext::default(),
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("1 Tr\n"),
+            "stroke-only text should use stroke render mode"
+        );
+        assert!(
+            out.contains("1 0 0 RG\n"),
+            "stroke-only text should set the stroke color"
+        );
+        assert!(
+            out.contains("1.5 w\n"),
+            "stroke-only text should set the stroke width"
+        );
+        assert!(
+            !out.contains("3 Tr\n"),
+            "stroke-only text must not be invisible"
+        );
     }
 
     #[test]

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -118,13 +118,13 @@ fn render_node(
             let style = resolve_style(inherited, style);
             apply_stroke_style(style, text_ctx, out);
             out.push_str(&format!("{x1} {y1} m {x2} {y2} l\n"));
-            paint_stroke_only(style, text_ctx, out);
+            paint_stroke_only(style, out);
         }
         SvgNode::Polyline { points, style } => {
             let style = resolve_style(inherited, style);
             apply_stroke_style(style, text_ctx, out);
             emit_polyline(points, false, out);
-            paint_stroke_only(style, text_ctx, out);
+            paint_stroke_only(style, out);
         }
         SvgNode::Polygon { points, style } => {
             let style = resolve_style(inherited, style);
@@ -159,7 +159,9 @@ fn render_node(
                 .or(*font_size)
                 .unwrap_or(text_ctx.font_size);
             let fill = paint_to_rgb(style.fill, text_ctx);
-            let stroke = paint_to_rgb(style.stroke, text_ctx).filter(|_| style.stroke_width > 0.0);
+            let stroke = paint_to_rgb(style.stroke, text_ctx);
+            let has_stroke = has_visible_stroke(style);
+            let stroke = stroke.filter(|_| has_stroke);
             // Use per-element font if specified, falling back to inherited CSS font
             let font =
                 resolve_svg_text_font(font_family.as_deref(), *font_bold, *font_italic, text_ctx);
@@ -230,7 +232,7 @@ fn apply_stroke_style(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut
 
 fn paint(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
     let has_fill = paint_to_rgb(style.fill, text_ctx).is_some();
-    let has_stroke = paint_to_rgb(style.stroke, text_ctx).is_some() && style.stroke_width > 0.0;
+    let has_stroke = has_visible_stroke(style);
     match (has_fill, has_stroke) {
         (true, true) => out.push_str("B\n"),   // fill + stroke
         (true, false) => out.push_str("f\n"),  // fill only
@@ -239,13 +241,17 @@ fn paint(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
     }
 }
 
-fn paint_stroke_only(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
-    let has_stroke = paint_to_rgb(style.stroke, text_ctx).is_some() && style.stroke_width > 0.0;
+fn paint_stroke_only(style: ResolvedStyle, out: &mut String) {
+    let has_stroke = has_visible_stroke(style);
     if has_stroke {
         out.push_str("S\n");
     } else {
         out.push_str("n\n");
     }
+}
+
+fn has_visible_stroke(style: ResolvedStyle) -> bool {
+    !matches!(style.stroke, SvgPaint::None | SvgPaint::Unspecified) && style.stroke_width > 0.0
 }
 
 /// Resolve the PDF font name for an SVG `<text>` element.

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -16,18 +16,24 @@ pub fn render_svg_tree(tree: &SvgTree, out: &mut String) {
         fill: SvgPaint::Color((0.0, 0.0, 0.0)),
         stroke: SvgPaint::None,
         stroke_width: 1.0,
+        font_family: None,
+        font_bold: None,
+        font_italic: None,
     };
     for node in &tree.children {
-        render_node(node, root_style, &tree.text_ctx, out);
+        render_node(node, root_style.clone(), &tree.text_ctx, out);
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct ResolvedStyle {
     color: Option<(f32, f32, f32)>,
     fill: SvgPaint,
     stroke: SvgPaint,
     stroke_width: f32,
+    font_family: Option<String>,
+    font_bold: Option<bool>,
+    font_italic: Option<bool>,
 }
 
 fn resolve_style(parent: ResolvedStyle, local: &SvgStyle) -> ResolvedStyle {
@@ -46,6 +52,9 @@ fn resolve_style(parent: ResolvedStyle, local: &SvgStyle) -> ResolvedStyle {
         fill,
         stroke,
         stroke_width,
+        font_family: local.font_family.clone().or(parent.font_family),
+        font_bold: local.font_bold.or(parent.font_bold),
+        font_italic: local.font_italic.or(parent.font_italic),
     }
 }
 
@@ -77,7 +86,7 @@ fn render_node(
                 out.push_str(&format!("{a} {b} {c} {d} {e} {f} cm\n"));
             }
             for child in children {
-                render_node(child, inherited, text_ctx, out);
+                render_node(child, inherited.clone(), text_ctx, out);
             }
             out.push_str("Q\n");
         }
@@ -90,15 +99,15 @@ fn render_node(
             ..
         } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, out);
+            apply_style(&style, out);
             out.push_str(&format!("{x} {y} {width} {height} re\n"));
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Circle { cx, cy, r, style } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, out);
+            apply_style(&style, out);
             emit_circle(*cx, *cy, *r, out);
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Ellipse {
             cx,
@@ -108,9 +117,9 @@ fn render_node(
             style,
         } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, out);
+            apply_style(&style, out);
             emit_ellipse(*cx, *cy, *rx, *ry, out);
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Line {
             x1,
@@ -120,27 +129,27 @@ fn render_node(
             style,
         } => {
             let style = resolve_style(inherited, style);
-            apply_stroke_style(style, out);
+            apply_stroke_style(&style, out);
             out.push_str(&format!("{x1} {y1} m {x2} {y2} l\n"));
-            paint_stroke_only(style, out);
+            paint_stroke_only(&style, out);
         }
         SvgNode::Polyline { points, style } => {
             let style = resolve_style(inherited, style);
-            apply_stroke_style(style, out);
+            apply_stroke_style(&style, out);
             emit_polyline(points, false, out);
-            paint_stroke_only(style, out);
+            paint_stroke_only(&style, out);
         }
         SvgNode::Polygon { points, style } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, out);
+            apply_style(&style, out);
             emit_polyline(points, true, out);
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Path { commands, style } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, out);
+            apply_style(&style, out);
             emit_path(commands, out);
-            paint(style, out);
+            paint(&style, out);
         }
         SvgNode::Text {
             x,
@@ -164,11 +173,17 @@ fn render_node(
                 .unwrap_or(text_ctx.font_size);
             let fill = paint_to_rgb(style.fill, style.color);
             let stroke = paint_to_rgb(style.stroke, style.color);
-            let has_stroke = has_visible_stroke(style);
+            let has_stroke = has_visible_stroke(&style);
             let stroke = stroke.filter(|_| has_stroke);
-            // Use per-element font if specified, falling back to inherited CSS font
-            let font =
-                resolve_svg_text_font(font_family.as_deref(), *font_bold, *font_italic, text_ctx);
+            let font = resolve_svg_text_font(
+                style.font_family.as_deref(),
+                style.font_bold,
+                style.font_italic,
+                font_family.as_deref(),
+                *font_bold,
+                *font_italic,
+                text_ctx,
+            );
             let text_render_mode = match (fill.is_some(), stroke.is_some()) {
                 (true, true) => 2,
                 (true, false) => 0,
@@ -217,7 +232,7 @@ fn resolve_svg_font_size(raw: &str, inherited_size: f32) -> Option<f32> {
     raw.parse::<f32>().ok().map(|px| px * 0.75)
 }
 
-fn apply_style(style: ResolvedStyle, out: &mut String) {
+fn apply_style(style: &ResolvedStyle, out: &mut String) {
     // Fill color
     if let Some((r, g, b)) = paint_to_rgb(style.fill, style.color) {
         out.push_str(&format!("{r} {g} {b} rg\n"));
@@ -225,7 +240,7 @@ fn apply_style(style: ResolvedStyle, out: &mut String) {
     apply_stroke_style(style, out);
 }
 
-fn apply_stroke_style(style: ResolvedStyle, out: &mut String) {
+fn apply_stroke_style(style: &ResolvedStyle, out: &mut String) {
     if let Some((r, g, b)) = paint_to_rgb(style.stroke, style.color) {
         out.push_str(&format!("{r} {g} {b} RG\n"));
     }
@@ -234,7 +249,7 @@ fn apply_stroke_style(style: ResolvedStyle, out: &mut String) {
     }
 }
 
-fn paint(style: ResolvedStyle, out: &mut String) {
+fn paint(style: &ResolvedStyle, out: &mut String) {
     let has_fill = paint_to_rgb(style.fill, style.color).is_some();
     let has_stroke = has_visible_stroke(style);
     match (has_fill, has_stroke) {
@@ -245,7 +260,7 @@ fn paint(style: ResolvedStyle, out: &mut String) {
     }
 }
 
-fn paint_stroke_only(style: ResolvedStyle, out: &mut String) {
+fn paint_stroke_only(style: &ResolvedStyle, out: &mut String) {
     let has_stroke = has_visible_stroke(style);
     if has_stroke {
         out.push_str("S\n");
@@ -254,30 +269,40 @@ fn paint_stroke_only(style: ResolvedStyle, out: &mut String) {
     }
 }
 
-fn has_visible_stroke(style: ResolvedStyle) -> bool {
+fn has_visible_stroke(style: &ResolvedStyle) -> bool {
     !matches!(style.stroke, SvgPaint::None | SvgPaint::Unspecified) && style.stroke_width > 0.0
 }
 
 /// Resolve the PDF font name for an SVG `<text>` element.
 ///
-/// If the element has a per-element `font_family` override, combine it with
-/// bold/italic flags (falling back to the context flags when the element
-/// doesn't specify them).  Otherwise use the context font as-is.
+/// Precedence is:
+/// 1. per-element `<text>` font attributes
+/// 2. inherited SVG style from ancestor groups / the text element itself
+/// 3. the outer HTML/SVG text context
 fn resolve_svg_text_font(
+    inherited_font_family: Option<&str>,
+    inherited_font_bold: Option<bool>,
+    inherited_font_italic: Option<bool>,
     font_family: Option<&str>,
     font_bold: Option<bool>,
     font_italic: Option<bool>,
     text_ctx: &SvgTextContext,
 ) -> String {
-    if let Some(base) = font_family {
-        let bold = font_bold.unwrap_or(text_ctx.font_bold);
-        let italic = font_italic.unwrap_or(text_ctx.font_italic);
+    let bold = font_bold
+        .or(inherited_font_bold)
+        .unwrap_or(text_ctx.font_bold);
+    let italic = font_italic
+        .or(inherited_font_italic)
+        .unwrap_or(text_ctx.font_italic);
+
+    if let Some(base) = font_family.or(inherited_font_family) {
         pdf_font_name(base, bold, italic).to_string()
-    } else if font_bold.is_some() || font_italic.is_some() {
-        // No family override but bold/italic overrides -- derive from context family base name
+    } else if font_bold.is_some()
+        || font_italic.is_some()
+        || inherited_font_bold.is_some()
+        || inherited_font_italic.is_some()
+    {
         let base = base_family_from_pdf_name(&text_ctx.font_family);
-        let bold = font_bold.unwrap_or(text_ctx.font_bold);
-        let italic = font_italic.unwrap_or(text_ctx.font_italic);
         pdf_font_name(base, bold, italic).to_string()
     } else {
         text_ctx.font_family.clone()
@@ -419,6 +444,9 @@ mod tests {
             fill: SvgPaint::Color((r, g, b)),
             stroke: SvgPaint::Unspecified,
             stroke_width: None,
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
@@ -429,6 +457,9 @@ mod tests {
             fill: SvgPaint::None,
             stroke: SvgPaint::Color((r, g, b)),
             stroke_width: Some(w),
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
@@ -439,6 +470,9 @@ mod tests {
             fill: SvgPaint::Color((1.0, 0.0, 0.0)),
             stroke: SvgPaint::Color((0.0, 0.0, 1.0)),
             stroke_width: Some(2.0),
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
@@ -449,6 +483,9 @@ mod tests {
             fill: SvgPaint::None,
             stroke: SvgPaint::None,
             stroke_width: None,
+            font_family: None,
+            font_bold: None,
+            font_italic: None,
             opacity: 1.0,
         }
     }
@@ -724,6 +761,11 @@ mod tests {
             style: SvgStyle {
                 color: None,
                 fill: SvgPaint::Color((1.0, 0.0, 0.0)),
+                stroke: SvgPaint::Unspecified,
+                stroke_width: None,
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
                 ..SvgStyle::default()
             },
         }]);
@@ -985,6 +1027,9 @@ mod tests {
                 fill: SvgPaint::Color((1.0, 0.0, 0.0)),
                 stroke: SvgPaint::Color((0.0, 0.0, 0.0)),
                 stroke_width: Some(0.0),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
                 opacity: 1.0,
             },
         }]);
@@ -1055,6 +1100,9 @@ mod tests {
                     fill: SvgPaint::None,
                     stroke: SvgPaint::Unspecified,
                     stroke_width: None,
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
                     opacity: 1.0,
                 },
             }],
@@ -1100,6 +1148,9 @@ mod tests {
                     fill: SvgPaint::None,
                     stroke: SvgPaint::Color((1.0, 0.0, 0.0)),
                     stroke_width: Some(1.5),
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
                     opacity: 1.0,
                 },
             }],
@@ -1183,6 +1234,9 @@ mod tests {
                     fill: SvgPaint::Color((0.0, 0.0, 0.0)),
                     stroke: SvgPaint::Unspecified,
                     stroke_width: None,
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
                     opacity: 1.0,
                 },
             }],
@@ -1223,6 +1277,9 @@ mod tests {
                     fill: SvgPaint::Color((0.0, 0.0, 0.0)),
                     stroke: SvgPaint::Unspecified,
                     stroke_width: None,
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
                     opacity: 1.0,
                 },
             }],
@@ -1233,6 +1290,49 @@ mod tests {
         assert!(
             out.contains("/Helvetica 9 Tf\n"),
             "unitless SVG font-size should resolve like px"
+        );
+    }
+
+    #[test]
+    fn text_inherits_group_font_family_and_style() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Group {
+                transform: None,
+                style: SvgStyle {
+                    font_family: Some("Courier".to_string()),
+                    font_bold: Some(true),
+                    font_italic: Some(true),
+                    ..SvgStyle::default()
+                },
+                children: vec![SvgNode::Text {
+                    x: 10.0,
+                    y: 20.0,
+                    font_size: None,
+                    font_size_attr: None,
+                    fill_specified: true,
+                    fill_raw: Some("currentColor".to_string()),
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    content: "Hello".to_string(),
+                    style: SvgStyle {
+                        fill: SvgPaint::CurrentColor,
+                        ..SvgStyle::default()
+                    },
+                }],
+            }],
+            text_ctx: SvgTextContext::default(),
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("/Courier-BoldOblique 12 Tf\n"),
+            "group font inheritance should reach SVG text rendering"
         );
     }
 
@@ -1260,6 +1360,9 @@ mod tests {
                     fill: SvgPaint::CurrentColor,
                     stroke: SvgPaint::Unspecified,
                     stroke_width: None,
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
                     opacity: 1.0,
                 },
             }],

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -1,6 +1,8 @@
 //! SVG tree to PDF content stream renderer.
 
-use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTextContext, SvgTransform, SvgTree};
+use crate::parser::svg::{
+    PathCommand, SvgNode, SvgPaint, SvgStyle, SvgTextContext, SvgTransform, SvgTree,
+};
 use crate::render::pdf::encode_pdf_text;
 
 /// Render an SVG tree to PDF content stream operators.
@@ -8,24 +10,65 @@ use crate::render::pdf::encode_pdf_text;
 /// The caller must wrap this in a `q ... Q` block and set up the coordinate
 /// transform (position on page + y-axis flip).
 pub fn render_svg_tree(tree: &SvgTree, out: &mut String) {
+    // SVG initial values: fill=black, stroke=none, stroke-width=1.
+    let root_style = ResolvedStyle {
+        fill: SvgPaint::Color((0.0, 0.0, 0.0)),
+        stroke: SvgPaint::None,
+        stroke_width: 1.0,
+    };
     for node in &tree.children {
-        render_node(node, &tree.text_ctx, out);
+        render_node(node, root_style, &tree.text_ctx, out);
     }
 }
 
-fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
+#[derive(Debug, Clone, Copy)]
+struct ResolvedStyle {
+    fill: SvgPaint,
+    stroke: SvgPaint,
+    stroke_width: f32,
+}
+
+fn resolve_style(parent: ResolvedStyle, local: &SvgStyle) -> ResolvedStyle {
+    let fill = match local.fill {
+        SvgPaint::Unspecified => parent.fill,
+        other => other,
+    };
+    let stroke = match local.stroke {
+        SvgPaint::Unspecified => parent.stroke,
+        other => other,
+    };
+    let stroke_width = local.stroke_width.unwrap_or(parent.stroke_width);
+    ResolvedStyle {
+        fill,
+        stroke,
+        stroke_width,
+    }
+}
+
+fn paint_to_rgb(paint: SvgPaint, text_ctx: &SvgTextContext) -> Option<(f32, f32, f32)> {
+    match paint {
+        SvgPaint::None => None,
+        SvgPaint::Color(c) => Some(c),
+        SvgPaint::CurrentColor => Some(text_ctx.color.unwrap_or((0.0, 0.0, 0.0))),
+        SvgPaint::Unspecified => None,
+    }
+}
+
+fn render_node(node: &SvgNode, inherited: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
     match node {
         SvgNode::Group {
             transform,
             children,
+            style,
             ..
         } => {
+            let inherited = resolve_style(inherited, style);
             out.push_str("q\n");
             if let Some(SvgTransform::Matrix(a, b, c, d, e, f)) = transform {
                 out.push_str(&format!("{a} {b} {c} {d} {e} {f} cm\n"));
             }
             for child in children {
-                render_node(child, text_ctx, out);
+                render_node(child, inherited, text_ctx, out);
             }
             out.push_str("Q\n");
         }
@@ -37,14 +80,16 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             style,
             ..
         } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(style, text_ctx, out);
             out.push_str(&format!("{x} {y} {width} {height} re\n"));
-            paint(style, out);
+            paint(style, text_ctx, out);
         }
         SvgNode::Circle { cx, cy, r, style } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(style, text_ctx, out);
             emit_circle(*cx, *cy, *r, out);
-            paint(style, out);
+            paint(style, text_ctx, out);
         }
         SvgNode::Ellipse {
             cx,
@@ -53,9 +98,10 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             ry,
             style,
         } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(style, text_ctx, out);
             emit_ellipse(*cx, *cy, *rx, *ry, out);
-            paint(style, out);
+            paint(style, text_ctx, out);
         }
         SvgNode::Line {
             x1,
@@ -64,49 +110,50 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             y2,
             style,
         } => {
-            apply_style(style, out);
-            out.push_str(&format!("{x1} {y1} m {x2} {y2} l S\n"));
+            let style = resolve_style(inherited, style);
+            apply_stroke_style(style, text_ctx, out);
+            out.push_str(&format!("{x1} {y1} m {x2} {y2} l\n"));
+            paint_stroke_only(style, text_ctx, out);
         }
         SvgNode::Polyline { points, style } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_stroke_style(style, text_ctx, out);
             emit_polyline(points, false, out);
-            out.push_str("S\n");
+            paint_stroke_only(style, text_ctx, out);
         }
         SvgNode::Polygon { points, style } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(style, text_ctx, out);
             emit_polyline(points, true, out);
-            paint(style, out);
+            paint(style, text_ctx, out);
         }
         SvgNode::Path { commands, style } => {
-            apply_style(style, out);
+            let style = resolve_style(inherited, style);
+            apply_style(style, text_ctx, out);
             emit_path(commands, out);
-            paint(style, out);
+            paint(style, text_ctx, out);
         }
         SvgNode::Text {
             x,
             y,
             font_size,
             font_size_attr,
-            fill_specified,
-            fill_raw,
+            fill_specified: _fill_specified,
+            fill_raw: _fill_raw,
             font_family,
             font_bold,
             font_italic,
             content,
             style,
         } => {
+            let style = resolve_style(inherited, style);
             // Use SVG-explicit font_size if set, otherwise inherit from CSS context
             let size = font_size_attr
                 .as_deref()
                 .and_then(|raw| resolve_svg_font_size(raw, text_ctx.font_size))
                 .or(*font_size)
                 .unwrap_or(text_ctx.font_size);
-            let fill = resolve_svg_text_fill(
-                *fill_specified,
-                fill_raw.as_deref(),
-                style.fill,
-                text_ctx,
-            );
+            let fill = paint_to_rgb(style.fill, text_ctx);
             // Use per-element font if specified, falling back to inherited CSS font
             let font = resolve_svg_text_font(
                 font_family.as_deref(),
@@ -117,6 +164,12 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
 
             out.push_str("BT\n");
             out.push_str(&format!("/{font} {size} Tf\n"));
+            if fill.is_some() {
+                out.push_str("0 Tr\n");
+            } else {
+                // PDF "invisible" text rendering mode; keeps layout operators but disables painting.
+                out.push_str("3 Tr\n");
+            }
             if let Some((r, g, b)) = fill {
                 out.push_str(&format!("{r} {g} {b} rg\n"));
             }
@@ -151,51 +204,40 @@ fn resolve_svg_font_size(raw: &str, inherited_size: f32) -> Option<f32> {
     raw.parse::<f32>().ok().map(|px| px * 0.75)
 }
 
-fn resolve_svg_text_fill(
-    fill_specified: bool,
-    fill_raw: Option<&str>,
-    parsed_fill: Option<(f32, f32, f32)>,
-    text_ctx: &SvgTextContext,
-) -> Option<(f32, f32, f32)> {
-    if let Some(fill) = parsed_fill {
-        return Some(fill);
-    }
-
-    if !fill_specified {
-        return Some((0.0, 0.0, 0.0));
-    }
-
-    let raw = fill_raw?.trim().to_ascii_lowercase();
-    match raw.as_str() {
-        "none" => None,
-        "currentcolor" => text_ctx.color.or(Some((0.0, 0.0, 0.0))),
-        _ => Some((0.0, 0.0, 0.0)),
-    }
-}
-
-fn apply_style(style: &SvgStyle, out: &mut String) {
+fn apply_style(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
     // Fill color
-    if let Some((r, g, b)) = style.fill {
+    if let Some((r, g, b)) = paint_to_rgb(style.fill, text_ctx) {
         out.push_str(&format!("{r} {g} {b} rg\n"));
     }
-    // Stroke color
-    if let Some((r, g, b)) = style.stroke {
+    apply_stroke_style(style, text_ctx, out);
+}
+
+fn apply_stroke_style(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
+    if let Some((r, g, b)) = paint_to_rgb(style.stroke, text_ctx) {
         out.push_str(&format!("{r} {g} {b} RG\n"));
     }
-    // Stroke width
     if style.stroke_width > 0.0 {
         out.push_str(&format!("{} w\n", style.stroke_width));
     }
 }
 
-fn paint(style: &SvgStyle, out: &mut String) {
-    let has_fill = style.fill.is_some();
-    let has_stroke = style.stroke.is_some() && style.stroke_width > 0.0;
+fn paint(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
+    let has_fill = paint_to_rgb(style.fill, text_ctx).is_some();
+    let has_stroke = paint_to_rgb(style.stroke, text_ctx).is_some() && style.stroke_width > 0.0;
     match (has_fill, has_stroke) {
         (true, true) => out.push_str("B\n"),   // fill + stroke
         (true, false) => out.push_str("f\n"),  // fill only
         (false, true) => out.push_str("S\n"),  // stroke only
         (false, false) => out.push_str("n\n"), // no paint
+    }
+}
+
+fn paint_stroke_only(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
+    let has_stroke = paint_to_rgb(style.stroke, text_ctx).is_some() && style.stroke_width > 0.0;
+    if has_stroke {
+        out.push_str("S\n");
+    } else {
+        out.push_str("n\n");
     }
 }
 
@@ -351,40 +393,42 @@ fn emit_path(commands: &[PathCommand], out: &mut String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTextContext, SvgTransform, SvgTree};
+    use crate::parser::svg::{
+        PathCommand, SvgNode, SvgPaint, SvgStyle, SvgTextContext, SvgTransform, SvgTree,
+    };
 
     fn style_fill(r: f32, g: f32, b: f32) -> SvgStyle {
         SvgStyle {
-            fill: Some((r, g, b)),
-            stroke: None,
-            stroke_width: 0.0,
+            fill: SvgPaint::Color((r, g, b)),
+            stroke: SvgPaint::Unspecified,
+            stroke_width: None,
             opacity: 1.0,
         }
     }
 
     fn style_stroke(r: f32, g: f32, b: f32, w: f32) -> SvgStyle {
         SvgStyle {
-            fill: None,
-            stroke: Some((r, g, b)),
-            stroke_width: w,
+            fill: SvgPaint::None,
+            stroke: SvgPaint::Color((r, g, b)),
+            stroke_width: Some(w),
             opacity: 1.0,
         }
     }
 
     fn style_fill_and_stroke() -> SvgStyle {
         SvgStyle {
-            fill: Some((1.0, 0.0, 0.0)),
-            stroke: Some((0.0, 0.0, 1.0)),
-            stroke_width: 2.0,
+            fill: SvgPaint::Color((1.0, 0.0, 0.0)),
+            stroke: SvgPaint::Color((0.0, 0.0, 1.0)),
+            stroke_width: Some(2.0),
             opacity: 1.0,
         }
     }
 
     fn style_none() -> SvgStyle {
         SvgStyle {
-            fill: None,
-            stroke: None,
-            stroke_width: 0.0,
+            fill: SvgPaint::None,
+            stroke: SvgPaint::None,
+            stroke_width: None,
             opacity: 1.0,
         }
     }
@@ -560,14 +604,14 @@ mod tests {
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
         assert!(
-            out.contains("0 0 m 100 100 l S\n"),
+            out.contains("0 0 m 100 100 l\nS\n"),
             "should emit line with stroke"
         );
     }
 
     #[test]
     fn render_line_with_fill_style() {
-        // Lines use apply_style but always stroke via the inline S operator
+        // Fill does not apply to <line>; without a stroke, the line is not painted.
         let tree = tree_with(vec![SvgNode::Line {
             x1: 5.0,
             y1: 10.0,
@@ -577,8 +621,24 @@ mod tests {
         }]);
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
-        assert!(out.contains("1 1 0 rg\n"), "should apply fill style");
-        assert!(out.contains("5 10 m 50 60 l S\n"), "should emit line");
+        assert!(!out.contains(" rg\n"), "should not set fill color for <line>");
+        assert!(out.contains("5 10 m 50 60 l\n"), "should emit line path");
+        assert!(out.contains("n\n"), "should not stroke without a stroke paint");
+    }
+
+    #[test]
+    fn render_line_without_stroke_is_not_painted() {
+        let tree = tree_with(vec![SvgNode::Line {
+            x1: 0.0,
+            y1: 0.0,
+            x2: 10.0,
+            y2: 10.0,
+            style: SvgStyle::default(),
+        }]);
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("n\n"));
+        assert!(!out.contains("S\n"));
     }
 
     // ---- Polyline tests ----
@@ -608,6 +668,42 @@ mod tests {
         render_svg_tree(&tree, &mut out);
         // Should still emit S even with no points
         assert!(out.contains("S\n"));
+    }
+
+    #[test]
+    fn render_polyline_without_stroke_is_not_painted() {
+        let tree = tree_with(vec![SvgNode::Polyline {
+            points: vec![(0.0, 0.0), (10.0, 10.0)],
+            style: SvgStyle::default(),
+        }]);
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("n\n"));
+        assert!(!out.contains("S\n"));
+    }
+
+    #[test]
+    fn group_fill_is_inherited_by_children() {
+        let tree = tree_with(vec![SvgNode::Group {
+            transform: None,
+            children: vec![SvgNode::Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+                rx: 0.0,
+                ry: 0.0,
+                style: SvgStyle::default(),
+            }],
+            style: SvgStyle {
+                fill: SvgPaint::Color((1.0, 0.0, 0.0)),
+                ..SvgStyle::default()
+            },
+        }]);
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("1 0 0 rg\n"), "child should inherit group fill");
+        assert!(out.contains("f\n"), "rect should be filled");
     }
 
     // ---- Polygon tests ----
@@ -855,9 +951,9 @@ mod tests {
             rx: 0.0,
             ry: 0.0,
             style: SvgStyle {
-                fill: Some((1.0, 0.0, 0.0)),
-                stroke: Some((0.0, 0.0, 0.0)),
-                stroke_width: 0.0,
+                fill: SvgPaint::Color((1.0, 0.0, 0.0)),
+                stroke: SvgPaint::Color((0.0, 0.0, 0.0)),
+                stroke_width: Some(0.0),
                 opacity: 1.0,
             },
         }]);
@@ -924,9 +1020,9 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
-                    fill: None,
-                    stroke: None,
-                    stroke_width: 0.0,
+                    fill: SvgPaint::None,
+                    stroke: SvgPaint::Unspecified,
+                    stroke_width: None,
                     opacity: 1.0,
                 },
             }],
@@ -937,6 +1033,7 @@ mod tests {
         };
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
+        assert!(out.contains("3 Tr\n"), "fill:none should disable text painting");
         assert!(
             !out.contains(" rg\n"),
             "explicit fill:none should not fall back to inherited text color"
@@ -963,12 +1060,7 @@ mod tests {
                 font_bold: None,
                 font_italic: None,
                 content: "Hello".to_string(),
-                style: SvgStyle {
-                    fill: None,
-                    stroke: None,
-                    stroke_width: 0.0,
-                    opacity: 1.0,
-                },
+                style: SvgStyle::default(),
             }],
             text_ctx: SvgTextContext {
                 color: Some((1.0, 0.0, 0.0)),
@@ -1003,9 +1095,9 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
-                    fill: Some((0.0, 0.0, 0.0)),
-                    stroke: None,
-                    stroke_width: 0.0,
+                    fill: SvgPaint::Color((0.0, 0.0, 0.0)),
+                    stroke: SvgPaint::Unspecified,
+                    stroke_width: None,
                     opacity: 1.0,
                 },
             }],
@@ -1042,9 +1134,9 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
-                    fill: Some((0.0, 0.0, 0.0)),
-                    stroke: None,
-                    stroke_width: 0.0,
+                    fill: SvgPaint::Color((0.0, 0.0, 0.0)),
+                    stroke: SvgPaint::Unspecified,
+                    stroke_width: None,
                     opacity: 1.0,
                 },
             }],
@@ -1078,9 +1170,9 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
-                    fill: None,
-                    stroke: None,
-                    stroke_width: 0.0,
+                    fill: SvgPaint::CurrentColor,
+                    stroke: SvgPaint::Unspecified,
+                    stroke_width: None,
                     opacity: 1.0,
                 },
             }],
@@ -1113,12 +1205,7 @@ mod tests {
                 font_bold: None,
                 font_italic: None,
                 content: "Hello".to_string(),
-                style: SvgStyle {
-                    fill: None,
-                    stroke: None,
-                    stroke_width: 0.0,
-                    opacity: 1.0,
-                },
+                style: SvgStyle::default(),
             }],
             text_ctx: SvgTextContext {
                 color: Some((1.0, 0.0, 0.0)),

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -1,6 +1,7 @@
 //! SVG tree to PDF content stream renderer.
 
 use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTextContext, SvgTransform, SvgTree};
+use crate::render::pdf::encode_pdf_text;
 
 /// Render an SVG tree to PDF content stream operators.
 ///
@@ -85,6 +86,9 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             x,
             y,
             font_size,
+            font_family,
+            font_bold,
+            font_italic,
             content,
             style,
         } => {
@@ -92,8 +96,13 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             let size = font_size.unwrap_or(text_ctx.font_size);
             // Use SVG fill color if set, otherwise inherit CSS color
             let fill = style.fill.or(text_ctx.color);
-            // Use inherited CSS font family (already resolved to PDF name)
-            let font = &text_ctx.font_family;
+            // Use per-element font if specified, falling back to inherited CSS font
+            let font = resolve_svg_text_font(
+                font_family.as_deref(),
+                *font_bold,
+                *font_italic,
+                text_ctx,
+            );
 
             out.push_str("BT\n");
             out.push_str(&format!("/{font} {size} Tf\n"));
@@ -104,8 +113,8 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             // SVG coordinates to PDF coordinates. Text must counter this flip via
             // the text matrix, otherwise glyphs render upside-down.
             out.push_str(&format!("1 0 0 -1 {x} {y} Tm\n"));
-            let escaped = escape_pdf_text_simple(content);
-            out.push_str(&format!("({escaped}) Tj\n"));
+            let encoded = encode_pdf_text(content);
+            out.push_str(&format!("({encoded}) Tj\n"));
             out.push_str("ET\n");
         }
     }
@@ -134,6 +143,69 @@ fn paint(style: &SvgStyle, out: &mut String) {
         (true, false) => out.push_str("f\n"),  // fill only
         (false, true) => out.push_str("S\n"),  // stroke only
         (false, false) => out.push_str("n\n"), // no paint
+    }
+}
+
+/// Resolve the PDF font name for an SVG `<text>` element.
+///
+/// If the element has a per-element `font_family` override, combine it with
+/// bold/italic flags (falling back to the context flags when the element
+/// doesn't specify them).  Otherwise use the context font as-is.
+fn resolve_svg_text_font(
+    font_family: Option<&str>,
+    font_bold: Option<bool>,
+    font_italic: Option<bool>,
+    text_ctx: &SvgTextContext,
+) -> String {
+    if let Some(base) = font_family {
+        let bold = font_bold.unwrap_or(text_ctx.font_bold);
+        let italic = font_italic.unwrap_or(text_ctx.font_italic);
+        pdf_font_name(base, bold, italic).to_string()
+    } else if font_bold.is_some() || font_italic.is_some() {
+        // No family override but bold/italic overrides -- derive from context family base name
+        let base = base_family_from_pdf_name(&text_ctx.font_family);
+        let bold = font_bold.unwrap_or(text_ctx.font_bold);
+        let italic = font_italic.unwrap_or(text_ctx.font_italic);
+        pdf_font_name(base, bold, italic).to_string()
+    } else {
+        text_ctx.font_family.clone()
+    }
+}
+
+/// Extract the base family name from a fully-qualified PDF font name.
+fn base_family_from_pdf_name(name: &str) -> &str {
+    if name.starts_with("Times") {
+        "Times-Roman"
+    } else if name.starts_with("Courier") {
+        "Courier"
+    } else {
+        "Helvetica"
+    }
+}
+
+/// Map (base_family, bold, italic) to a concrete PDF built-in font name.
+fn pdf_font_name(base: &str, bold: bool, italic: bool) -> &'static str {
+    if base.starts_with("Times") {
+        match (bold, italic) {
+            (true, true) => "Times-BoldItalic",
+            (true, false) => "Times-Bold",
+            (false, true) => "Times-Italic",
+            (false, false) => "Times-Roman",
+        }
+    } else if base.starts_with("Courier") {
+        match (bold, italic) {
+            (true, true) => "Courier-BoldOblique",
+            (true, false) => "Courier-Bold",
+            (false, true) => "Courier-Oblique",
+            (false, false) => "Courier",
+        }
+    } else {
+        match (bold, italic) {
+            (true, true) => "Helvetica-BoldOblique",
+            (true, false) => "Helvetica-Bold",
+            (false, true) => "Helvetica-Oblique",
+            (false, false) => "Helvetica",
+        }
     }
 }
 
@@ -222,22 +294,6 @@ fn emit_path(commands: &[PathCommand], out: &mut String) {
     }
 }
 
-/// Escape a string for use inside a PDF text literal `(...)`.
-///
-/// Handles the three special characters that must be escaped in PDF
-/// parenthesised strings: backslash, open-paren, close-paren.
-fn escape_pdf_text_simple(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    for ch in text.chars() {
-        match ch {
-            '\\' => result.push_str("\\\\"),
-            '(' => result.push_str("\\("),
-            ')' => result.push_str("\\)"),
-            _ => result.push(ch),
-        }
-    }
-    result
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -12,6 +12,7 @@ use crate::render::pdf::encode_pdf_text;
 pub fn render_svg_tree(tree: &SvgTree, out: &mut String) {
     // SVG initial values: fill=black, stroke=none, stroke-width=1.
     let root_style = ResolvedStyle {
+        color: tree.text_ctx.color,
         fill: SvgPaint::Color((0.0, 0.0, 0.0)),
         stroke: SvgPaint::None,
         stroke_width: 1.0,
@@ -23,6 +24,7 @@ pub fn render_svg_tree(tree: &SvgTree, out: &mut String) {
 
 #[derive(Debug, Clone, Copy)]
 struct ResolvedStyle {
+    color: Option<(f32, f32, f32)>,
     fill: SvgPaint,
     stroke: SvgPaint,
     stroke_width: f32,
@@ -33,23 +35,25 @@ fn resolve_style(parent: ResolvedStyle, local: &SvgStyle) -> ResolvedStyle {
         SvgPaint::Unspecified => parent.fill,
         other => other,
     };
+    let color = local.color.or(parent.color);
     let stroke = match local.stroke {
         SvgPaint::Unspecified => parent.stroke,
         other => other,
     };
     let stroke_width = local.stroke_width.unwrap_or(parent.stroke_width);
     ResolvedStyle {
+        color,
         fill,
         stroke,
         stroke_width,
     }
 }
 
-fn paint_to_rgb(paint: SvgPaint, text_ctx: &SvgTextContext) -> Option<(f32, f32, f32)> {
+fn paint_to_rgb(paint: SvgPaint, color: Option<(f32, f32, f32)>) -> Option<(f32, f32, f32)> {
     match paint {
         SvgPaint::None => None,
         SvgPaint::Color(c) => Some(c),
-        SvgPaint::CurrentColor => Some(text_ctx.color.unwrap_or((0.0, 0.0, 0.0))),
+        SvgPaint::CurrentColor => Some(color.unwrap_or((0.0, 0.0, 0.0))),
         SvgPaint::Unspecified => None,
     }
 }
@@ -86,15 +90,15 @@ fn render_node(
             ..
         } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, text_ctx, out);
+            apply_style(style, out);
             out.push_str(&format!("{x} {y} {width} {height} re\n"));
-            paint(style, text_ctx, out);
+            paint(style, out);
         }
         SvgNode::Circle { cx, cy, r, style } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, text_ctx, out);
+            apply_style(style, out);
             emit_circle(*cx, *cy, *r, out);
-            paint(style, text_ctx, out);
+            paint(style, out);
         }
         SvgNode::Ellipse {
             cx,
@@ -104,9 +108,9 @@ fn render_node(
             style,
         } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, text_ctx, out);
+            apply_style(style, out);
             emit_ellipse(*cx, *cy, *rx, *ry, out);
-            paint(style, text_ctx, out);
+            paint(style, out);
         }
         SvgNode::Line {
             x1,
@@ -116,27 +120,27 @@ fn render_node(
             style,
         } => {
             let style = resolve_style(inherited, style);
-            apply_stroke_style(style, text_ctx, out);
+            apply_stroke_style(style, out);
             out.push_str(&format!("{x1} {y1} m {x2} {y2} l\n"));
             paint_stroke_only(style, out);
         }
         SvgNode::Polyline { points, style } => {
             let style = resolve_style(inherited, style);
-            apply_stroke_style(style, text_ctx, out);
+            apply_stroke_style(style, out);
             emit_polyline(points, false, out);
             paint_stroke_only(style, out);
         }
         SvgNode::Polygon { points, style } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, text_ctx, out);
+            apply_style(style, out);
             emit_polyline(points, true, out);
-            paint(style, text_ctx, out);
+            paint(style, out);
         }
         SvgNode::Path { commands, style } => {
             let style = resolve_style(inherited, style);
-            apply_style(style, text_ctx, out);
+            apply_style(style, out);
             emit_path(commands, out);
-            paint(style, text_ctx, out);
+            paint(style, out);
         }
         SvgNode::Text {
             x,
@@ -158,8 +162,8 @@ fn render_node(
                 .and_then(|raw| resolve_svg_font_size(raw, text_ctx.font_size))
                 .or(*font_size)
                 .unwrap_or(text_ctx.font_size);
-            let fill = paint_to_rgb(style.fill, text_ctx);
-            let stroke = paint_to_rgb(style.stroke, text_ctx);
+            let fill = paint_to_rgb(style.fill, style.color);
+            let stroke = paint_to_rgb(style.stroke, style.color);
             let has_stroke = has_visible_stroke(style);
             let stroke = stroke.filter(|_| has_stroke);
             // Use per-element font if specified, falling back to inherited CSS font
@@ -213,16 +217,16 @@ fn resolve_svg_font_size(raw: &str, inherited_size: f32) -> Option<f32> {
     raw.parse::<f32>().ok().map(|px| px * 0.75)
 }
 
-fn apply_style(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
+fn apply_style(style: ResolvedStyle, out: &mut String) {
     // Fill color
-    if let Some((r, g, b)) = paint_to_rgb(style.fill, text_ctx) {
+    if let Some((r, g, b)) = paint_to_rgb(style.fill, style.color) {
         out.push_str(&format!("{r} {g} {b} rg\n"));
     }
-    apply_stroke_style(style, text_ctx, out);
+    apply_stroke_style(style, out);
 }
 
-fn apply_stroke_style(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
-    if let Some((r, g, b)) = paint_to_rgb(style.stroke, text_ctx) {
+fn apply_stroke_style(style: ResolvedStyle, out: &mut String) {
+    if let Some((r, g, b)) = paint_to_rgb(style.stroke, style.color) {
         out.push_str(&format!("{r} {g} {b} RG\n"));
     }
     if style.stroke_width > 0.0 {
@@ -230,8 +234,8 @@ fn apply_stroke_style(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut
     }
 }
 
-fn paint(style: ResolvedStyle, text_ctx: &SvgTextContext, out: &mut String) {
-    let has_fill = paint_to_rgb(style.fill, text_ctx).is_some();
+fn paint(style: ResolvedStyle, out: &mut String) {
+    let has_fill = paint_to_rgb(style.fill, style.color).is_some();
     let has_stroke = has_visible_stroke(style);
     match (has_fill, has_stroke) {
         (true, true) => out.push_str("B\n"),   // fill + stroke
@@ -411,6 +415,7 @@ mod tests {
 
     fn style_fill(r: f32, g: f32, b: f32) -> SvgStyle {
         SvgStyle {
+            color: None,
             fill: SvgPaint::Color((r, g, b)),
             stroke: SvgPaint::Unspecified,
             stroke_width: None,
@@ -420,6 +425,7 @@ mod tests {
 
     fn style_stroke(r: f32, g: f32, b: f32, w: f32) -> SvgStyle {
         SvgStyle {
+            color: None,
             fill: SvgPaint::None,
             stroke: SvgPaint::Color((r, g, b)),
             stroke_width: Some(w),
@@ -429,6 +435,7 @@ mod tests {
 
     fn style_fill_and_stroke() -> SvgStyle {
         SvgStyle {
+            color: None,
             fill: SvgPaint::Color((1.0, 0.0, 0.0)),
             stroke: SvgPaint::Color((0.0, 0.0, 1.0)),
             stroke_width: Some(2.0),
@@ -438,6 +445,7 @@ mod tests {
 
     fn style_none() -> SvgStyle {
         SvgStyle {
+            color: None,
             fill: SvgPaint::None,
             stroke: SvgPaint::None,
             stroke_width: None,
@@ -714,6 +722,7 @@ mod tests {
                 style: SvgStyle::default(),
             }],
             style: SvgStyle {
+                color: None,
                 fill: SvgPaint::Color((1.0, 0.0, 0.0)),
                 ..SvgStyle::default()
             },
@@ -972,6 +981,7 @@ mod tests {
             rx: 0.0,
             ry: 0.0,
             style: SvgStyle {
+                color: None,
                 fill: SvgPaint::Color((1.0, 0.0, 0.0)),
                 stroke: SvgPaint::Color((0.0, 0.0, 0.0)),
                 stroke_width: Some(0.0),
@@ -1041,6 +1051,7 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
+                    color: None,
                     fill: SvgPaint::None,
                     stroke: SvgPaint::Unspecified,
                     stroke_width: None,
@@ -1085,6 +1096,7 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
+                    color: None,
                     fill: SvgPaint::None,
                     stroke: SvgPaint::Color((1.0, 0.0, 0.0)),
                     stroke_width: Some(1.5),
@@ -1167,6 +1179,7 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
+                    color: None,
                     fill: SvgPaint::Color((0.0, 0.0, 0.0)),
                     stroke: SvgPaint::Unspecified,
                     stroke_width: None,
@@ -1206,6 +1219,7 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
+                    color: None,
                     fill: SvgPaint::Color((0.0, 0.0, 0.0)),
                     stroke: SvgPaint::Unspecified,
                     stroke_width: None,
@@ -1242,6 +1256,7 @@ mod tests {
                 font_italic: None,
                 content: "Hello".to_string(),
                 style: SvgStyle {
+                    color: None,
                     fill: SvgPaint::CurrentColor,
                     stroke: SvgPaint::Unspecified,
                     stroke_width: None,
@@ -1256,6 +1271,47 @@ mod tests {
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
         assert!(out.contains("0 0.5 1 rg\n"));
+    }
+
+    #[test]
+    fn text_fill_current_color_inherits_nested_svg_color() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Group {
+                transform: None,
+                style: SvgStyle {
+                    color: Some((1.0, 0.0, 0.0)),
+                    ..SvgStyle::default()
+                },
+                children: vec![SvgNode::Text {
+                    x: 10.0,
+                    y: 20.0,
+                    font_size: None,
+                    font_size_attr: None,
+                    fill_specified: true,
+                    fill_raw: Some("currentColor".to_string()),
+                    font_family: None,
+                    font_bold: None,
+                    font_italic: None,
+                    content: "Hello".to_string(),
+                    style: SvgStyle {
+                        fill: SvgPaint::CurrentColor,
+                        ..SvgStyle::default()
+                    },
+                }],
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((0.0, 0.5, 1.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("1 0 0 rg\n"));
     }
 
     #[test]

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -86,6 +86,9 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             x,
             y,
             font_size,
+            font_size_attr,
+            fill_specified,
+            fill_raw,
             font_family,
             font_bold,
             font_italic,
@@ -93,9 +96,17 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             style,
         } => {
             // Use SVG-explicit font_size if set, otherwise inherit from CSS context
-            let size = font_size.unwrap_or(text_ctx.font_size);
-            // Use SVG fill color if set, otherwise inherit CSS color
-            let fill = style.fill.or(text_ctx.color);
+            let size = font_size_attr
+                .as_deref()
+                .and_then(|raw| resolve_svg_font_size(raw, text_ctx.font_size))
+                .or(*font_size)
+                .unwrap_or(text_ctx.font_size);
+            let fill = resolve_svg_text_fill(
+                *fill_specified,
+                fill_raw.as_deref(),
+                style.fill,
+                text_ctx,
+            );
             // Use per-element font if specified, falling back to inherited CSS font
             let font = resolve_svg_text_font(
                 font_family.as_deref(),
@@ -117,6 +128,48 @@ fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
             out.push_str(&format!("({encoded}) Tj\n"));
             out.push_str("ET\n");
         }
+    }
+}
+
+fn resolve_svg_font_size(raw: &str, inherited_size: f32) -> Option<f32> {
+    let raw = raw.trim();
+    if let Some(pct) = raw.strip_suffix('%') {
+        let pct = pct.trim().parse::<f32>().ok()?;
+        return Some(inherited_size * pct / 100.0);
+    }
+    if let Some(em) = raw.strip_suffix("em") {
+        let em = em.trim().parse::<f32>().ok()?;
+        return Some(inherited_size * em);
+    }
+    if let Some(px) = raw.strip_suffix("px") {
+        let px = px.trim().parse::<f32>().ok()?;
+        return Some(px * 0.75);
+    }
+    if let Some(pt) = raw.strip_suffix("pt") {
+        return pt.trim().parse::<f32>().ok();
+    }
+    raw.parse::<f32>().ok().map(|px| px * 0.75)
+}
+
+fn resolve_svg_text_fill(
+    fill_specified: bool,
+    fill_raw: Option<&str>,
+    parsed_fill: Option<(f32, f32, f32)>,
+    text_ctx: &SvgTextContext,
+) -> Option<(f32, f32, f32)> {
+    if let Some(fill) = parsed_fill {
+        return Some(fill);
+    }
+
+    if !fill_specified {
+        return Some((0.0, 0.0, 0.0));
+    }
+
+    let raw = fill_raw?.trim().to_ascii_lowercase();
+    match raw.as_str() {
+        "none" => None,
+        "currentcolor" => text_ctx.color.or(Some((0.0, 0.0, 0.0))),
+        _ => Some((0.0, 0.0, 0.0)),
     }
 }
 
@@ -340,6 +393,8 @@ mod tests {
         SvgTree {
             width: 100.0,
             height: 100.0,
+            width_attr: None,
+            height_attr: None,
             view_box: None,
             children,
             text_ctx: SvgTextContext::default(),
@@ -847,5 +902,231 @@ mod tests {
         let mut out = String::new();
         render_svg_tree(&tree, &mut out);
         assert!(out.contains("n\n"), "should emit no-paint");
+    }
+
+    #[test]
+    fn text_fill_none_does_not_fallback_to_context_color() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: true,
+                fill_raw: Some("none".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    fill: None,
+                    stroke: None,
+                    stroke_width: 0.0,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((1.0, 0.0, 0.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            !out.contains(" rg\n"),
+            "explicit fill:none should not fall back to inherited text color"
+        );
+        assert!(out.contains("(Hello) Tj\n"));
+    }
+
+    #[test]
+    fn text_fill_defaults_to_black_when_unspecified() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: false,
+                fill_raw: None,
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    fill: None,
+                    stroke: None,
+                    stroke_width: 0.0,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((1.0, 0.0, 0.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("0 0 0 rg\n"),
+            "unspecified SVG text fill should default to black"
+        );
+    }
+
+    #[test]
+    fn text_font_size_percent_scales_from_context() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: Some("150%".to_string()),
+                fill_specified: true,
+                fill_raw: Some("currentColor".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    fill: Some((0.0, 0.0, 0.0)),
+                    stroke: None,
+                    stroke_width: 0.0,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext {
+                font_size: 12.0,
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("/Helvetica 18 Tf\n"),
+            "150% font-size should resolve from the inherited SVG text size"
+        );
+    }
+
+    #[test]
+    fn text_font_size_unitless_number_treated_as_px() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: Some("12".to_string()),
+                fill_specified: true,
+                fill_raw: Some("currentColor".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    fill: Some((0.0, 0.0, 0.0)),
+                    stroke: None,
+                    stroke_width: 0.0,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext::default(),
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(
+            out.contains("/Helvetica 9 Tf\n"),
+            "unitless SVG font-size should resolve like px"
+        );
+    }
+
+    #[test]
+    fn text_fill_current_color_uses_context_color() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: true,
+                fill_raw: Some("currentColor".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    fill: None,
+                    stroke: None,
+                    stroke_width: 0.0,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((0.0, 0.5, 1.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("0 0.5 1 rg\n"));
+    }
+
+    #[test]
+    fn text_invalid_fill_defaults_to_black() {
+        let tree = SvgTree {
+            width: 100.0,
+            height: 100.0,
+            width_attr: None,
+            height_attr: None,
+            view_box: None,
+            children: vec![SvgNode::Text {
+                x: 10.0,
+                y: 20.0,
+                font_size: None,
+                font_size_attr: None,
+                fill_specified: true,
+                fill_raw: Some("bogus".to_string()),
+                font_family: None,
+                font_bold: None,
+                font_italic: None,
+                content: "Hello".to_string(),
+                style: SvgStyle {
+                    fill: None,
+                    stroke: None,
+                    stroke_width: 0.0,
+                    opacity: 1.0,
+                },
+            }],
+            text_ctx: SvgTextContext {
+                color: Some((1.0, 0.0, 0.0)),
+                ..SvgTextContext::default()
+            },
+        };
+        let mut out = String::new();
+        render_svg_tree(&tree, &mut out);
+        assert!(out.contains("0 0 0 rg\n"));
     }
 }

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -1,6 +1,6 @@
 //! SVG tree to PDF content stream renderer.
 
-use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTransform, SvgTree};
+use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTextContext, SvgTransform, SvgTree};
 
 /// Render an SVG tree to PDF content stream operators.
 ///
@@ -8,11 +8,11 @@ use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTransform, SvgTree};
 /// transform (position on page + y-axis flip).
 pub fn render_svg_tree(tree: &SvgTree, out: &mut String) {
     for node in &tree.children {
-        render_node(node, out);
+        render_node(node, &tree.text_ctx, out);
     }
 }
 
-fn render_node(node: &SvgNode, out: &mut String) {
+fn render_node(node: &SvgNode, text_ctx: &SvgTextContext, out: &mut String) {
     match node {
         SvgNode::Group {
             transform,
@@ -24,7 +24,7 @@ fn render_node(node: &SvgNode, out: &mut String) {
                 out.push_str(&format!("{a} {b} {c} {d} {e} {f} cm\n"));
             }
             for child in children {
-                render_node(child, out);
+                render_node(child, text_ctx, out);
             }
             out.push_str("Q\n");
         }
@@ -42,7 +42,6 @@ fn render_node(node: &SvgNode, out: &mut String) {
         }
         SvgNode::Circle { cx, cy, r, style } => {
             apply_style(style, out);
-            // Approximate circle with 4 cubic bezier curves
             emit_circle(*cx, *cy, *r, out);
             paint(style, out);
         }
@@ -70,7 +69,7 @@ fn render_node(node: &SvgNode, out: &mut String) {
         SvgNode::Polyline { points, style } => {
             apply_style(style, out);
             emit_polyline(points, false, out);
-            out.push_str("S\n"); // stroke only for polyline
+            out.push_str("S\n");
         }
         SvgNode::Polygon { points, style } => {
             apply_style(style, out);
@@ -81,6 +80,33 @@ fn render_node(node: &SvgNode, out: &mut String) {
             apply_style(style, out);
             emit_path(commands, out);
             paint(style, out);
+        }
+        SvgNode::Text {
+            x,
+            y,
+            font_size,
+            content,
+            style,
+        } => {
+            // Use SVG-explicit font_size if set, otherwise inherit from CSS context
+            let size = font_size.unwrap_or(text_ctx.font_size);
+            // Use SVG fill color if set, otherwise inherit CSS color
+            let fill = style.fill.or(text_ctx.color);
+            // Use inherited CSS font family (already resolved to PDF name)
+            let font = &text_ctx.font_family;
+
+            out.push_str("BT\n");
+            out.push_str(&format!("/{font} {size} Tf\n"));
+            if let Some((r, g, b)) = fill {
+                out.push_str(&format!("{r} {g} {b} rg\n"));
+            }
+            // The parent SVG content stream has a y-flip (scale 1,-1) to convert
+            // SVG coordinates to PDF coordinates. Text must counter this flip via
+            // the text matrix, otherwise glyphs render upside-down.
+            out.push_str(&format!("1 0 0 -1 {x} {y} Tm\n"));
+            let escaped = escape_pdf_text_simple(content);
+            out.push_str(&format!("({escaped}) Tj\n"));
+            out.push_str("ET\n");
         }
     }
 }
@@ -196,10 +222,27 @@ fn emit_path(commands: &[PathCommand], out: &mut String) {
     }
 }
 
+/// Escape a string for use inside a PDF text literal `(...)`.
+///
+/// Handles the three special characters that must be escaped in PDF
+/// parenthesised strings: backslash, open-paren, close-paren.
+fn escape_pdf_text_simple(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '\\' => result.push_str("\\\\"),
+            '(' => result.push_str("\\("),
+            ')' => result.push_str("\\)"),
+            _ => result.push(ch),
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTransform, SvgTree};
+    use crate::parser::svg::{PathCommand, SvgNode, SvgStyle, SvgTextContext, SvgTransform, SvgTree};
 
     fn style_fill(r: f32, g: f32, b: f32) -> SvgStyle {
         SvgStyle {
@@ -243,6 +286,7 @@ mod tests {
             height: 100.0,
             view_box: None,
             children,
+            text_ctx: SvgTextContext::default(),
         }
     }
 

--- a/tests/pdf_smoke_tests.rs
+++ b/tests/pdf_smoke_tests.rs
@@ -255,6 +255,34 @@ fn smoke_inline_svg() {
     assert!(pdf_is_valid(&pdf));
 }
 
+#[test]
+fn smoke_inline_svg_text_inherits_current_color() {
+    let html = r#"
+        <div style="color: blue">
+            <svg width="160" height="40" viewBox="0 0 160 40">
+                <text x="8" y="24" fill="currentColor">Hello SVG</text>
+            </svg>
+        </div>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Hello SVG"));
+    assert!(pdf_has_text(&pdf, "0 0 1 rg"));
+}
+
+#[test]
+fn smoke_inline_svg_text_tspan_uses_font_attributes() {
+    let html = r#"
+        <svg width="220" height="40" viewBox="0 0 220 40">
+            <text x="8" y="24" font-family="Courier" font-weight="700" font-style="oblique">Hello <tspan>world</tspan>!</text>
+        </svg>
+    "#;
+    let pdf = ironpress::html_to_pdf(html).unwrap();
+    assert!(pdf_is_valid(&pdf));
+    assert!(pdf_has_text(&pdf, "Hello world!"));
+    assert!(pdf_has_text(&pdf, "/Courier-BoldOblique"));
+}
+
 // === Complex document ===
 
 #[test]


### PR DESCRIPTION
## Summary

- SVG `<text>` element parsing and PDF rendering
- `SvgPaint` enum for proper fill/stroke/currentColor inheritance
- Inline `style` attribute parsing on SVG elements
- Nested SVG viewport handling with viewBox scaling
- Font attribute resolution (font-family, font-size, font-weight, font-style)
- SVG graphics example added to playground

Based on #29 by @Wicpar. Merged onto current main with conflict resolution and clippy fixes.

Security audit: SVG text content goes through `encode_pdf_text()` (no PDF injection). SVG sanitizer strips `<script>`, event handlers, `xlink:href`, and `javascript:` URLs.

## Test plan

- [x] ~33 new SVG unit tests (text, paint inheritance, viewports, fonts)
- [x] All 1664 tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Security audit passed

Closes #29

Co-authored-by: Frédéric Nieto <frederic.artus.nieto@gmail.com>