### PR TITLE
feat: math rendering, parity benchmarks, 12 layout/rendering fixes

### DIFF
--- a/scripts/compare-parity.sh
+++ b/scripts/compare-parity.sh
@@ -73,17 +73,45 @@ for layer in features combined edge-cases; do
             continue
         fi
 
-        # Resize rendered PNG to match reference dimensions if needed
+        # Resize both images to exactly the same dimensions to prevent compare failure
         ref_dims=$(identify -format "%wx%h" "$ref_png" 2>/dev/null || echo "")
         if [ -n "$ref_dims" ]; then
-            convert "$render_png" -resize "$ref_dims!" "$render_png" 2>/dev/null
+            # Force-resize rendered image to exact reference size (! overrides aspect ratio)
+            convert "$render_png" -resize "${ref_dims}!" "$render_png" 2>/dev/null
+            # Also force-resize reference to ensure both end up at identical dimensions
+            # (needed when identify returns a size that convert rounds differently)
+            resized_ref="$TMPDIR_WORK/${layer}_${name}_ref.png"
+            convert "$ref_png" -resize "${ref_dims}!" "$resized_ref" 2>/dev/null
+        else
+            resized_ref="$ref_png"
+        fi
+
+        # Verify dimensions match before comparing
+        render_dims=$(identify -format "%wx%h" "$render_png" 2>/dev/null || echo "")
+        actual_ref_dims=$(identify -format "%wx%h" "$resized_ref" 2>/dev/null || echo "")
+        if [ "$render_dims" != "$actual_ref_dims" ]; then
+            # Dimensions still differ; force both to render_dims to guarantee a match
+            canonical_dims="$render_dims"
+            convert "$render_png"   -resize "${canonical_dims}!" "$render_png"   2>/dev/null
+            convert "$resized_ref"  -resize "${canonical_dims}!" "$resized_ref"  2>/dev/null
         fi
 
         # Compare with ImageMagick AE metric (absolute error = diff pixel count)
         diff_png="$TMPDIR_WORK/${layer}_${name}_diff.png"
-        diff_pixels=$(compare -metric AE "$ref_png" "$render_png" "$diff_png" 2>&1 || true)
+        compare_err="$TMPDIR_WORK/${layer}_${name}_compare.err"
+        diff_pixels=$(compare -metric AE "$resized_ref" "$render_png" "$diff_png" 2>"$compare_err" || true)
         # compare exits non-zero when images differ; capture output regardless
         diff_pixels=$(echo "$diff_pixels" | tr -d '[:space:]')
+
+        # If compare produced no numeric output or failed to create a diff image,
+        # fall back to a pixel-by-pixel difference composite instead of a grey placeholder
+        if ! [[ "$diff_pixels" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+            compare_err_msg=$(cat "$compare_err" 2>/dev/null | head -1)
+            echo "# compare error for $layer/$name: $compare_err_msg" >&2
+            # Use composite difference as fallback; count non-black pixels as diff
+            composite -compose difference "$resized_ref" "$render_png" "$diff_png" 2>/dev/null || true
+            diff_pixels=$(identify -format "%[fx:w*h]" "$resized_ref" 2>/dev/null || echo "0")
+        fi
 
         # Calculate total pixels from reference
         total_pixels=$(identify -format "%[fx:w*h]" "$ref_png" 2>/dev/null || echo "1")

--- a/scripts/compare-parity.sh
+++ b/scripts/compare-parity.sh
@@ -97,20 +97,21 @@ for layer in features combined edge-cases; do
         fi
 
         # Compare with ImageMagick AE metric (absolute error = diff pixel count)
+        # NOTE: compare outputs the metric value on STDERR, not stdout
         diff_png="$TMPDIR_WORK/${layer}_${name}_diff.png"
-        compare_err="$TMPDIR_WORK/${layer}_${name}_compare.err"
-        diff_pixels=$(compare -metric AE "$resized_ref" "$render_png" "$diff_png" 2>"$compare_err" || true)
-        # compare exits non-zero when images differ; capture output regardless
+        diff_pixels=$(compare -metric AE "$resized_ref" "$render_png" "$diff_png" 2>&1 || true)
         diff_pixels=$(echo "$diff_pixels" | tr -d '[:space:]')
 
-        # If compare produced no numeric output or failed to create a diff image,
-        # fall back to a pixel-by-pixel difference composite instead of a grey placeholder
+        # If compare produced no numeric output, try extracting from error message
         if ! [[ "$diff_pixels" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
-            compare_err_msg=$(cat "$compare_err" 2>/dev/null | head -1)
-            echo "# compare error for $layer/$name: $compare_err_msg" >&2
-            # Use composite difference as fallback; count non-black pixels as diff
-            composite -compose difference "$resized_ref" "$render_png" "$diff_png" 2>/dev/null || true
-            diff_pixels=$(identify -format "%[fx:w*h]" "$resized_ref" 2>/dev/null || echo "0")
+            # compare sometimes outputs "NNN image.png" — extract the number
+            numeric=$(echo "$diff_pixels" | grep -oE '^[0-9]+(\.[0-9]+)?' || echo "")
+            if [ -n "$numeric" ]; then
+                diff_pixels="$numeric"
+            else
+                echo "# compare failed for $layer/$name: $diff_pixels" >&2
+                diff_pixels=$(identify -format "%[fx:w*h]" "$resized_ref" 2>/dev/null || echo "0")
+            fi
         fi
 
         # Calculate total pixels from reference

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -517,4 +517,45 @@ mod tests {
             "Helvetica-BoldOblique"
         );
     }
+
+    /// BUG P2-3: the default `line-height: normal` factor must be 1.2 for
+    /// Helvetica/Arial, matching Chrome's measured value.  A smaller constant
+    /// (e.g. 1.0) would produce tighter text than browsers render.
+    #[test]
+    fn normal_line_height_factor_helvetica_is_1_2() {
+        let custom_fonts = HashMap::new();
+        let factor = normal_line_height_factor(&FontFamily::Helvetica, false, false, &custom_fonts);
+        assert!(
+            (factor - 1.2).abs() < 0.001,
+            "Helvetica normal line-height should be 1.2 (Chrome parity), got {factor}"
+        );
+    }
+
+    #[test]
+    fn normal_line_height_factor_helvetica_bold_is_1_2() {
+        let custom_fonts = HashMap::new();
+        let factor = normal_line_height_factor(&FontFamily::Helvetica, true, false, &custom_fonts);
+        assert!(
+            (factor - 1.2).abs() < 0.001,
+            "Helvetica-Bold normal line-height should be 1.2, got {factor}"
+        );
+    }
+
+    #[test]
+    fn normal_line_height_factor_standard_fonts_all_1_2() {
+        let custom_fonts = HashMap::new();
+        for family in &[
+            FontFamily::Helvetica,
+            FontFamily::TimesRoman,
+            FontFamily::Courier,
+        ] {
+            for bold in [false, true] {
+                let factor = normal_line_height_factor(family, bold, false, &custom_fonts);
+                assert!(
+                    (factor - 1.2).abs() < 0.001,
+                    "{family:?} bold={bold} normal line-height should be 1.2, got {factor}"
+                );
+            }
+        }
+    }
 }

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 pub struct LayoutBorderSide {
     pub width: f32,
     pub color: (f32, f32, f32),
+    pub style: crate::style::computed::BorderStyle,
 }
 
 /// Per-side border for layout rendering.
@@ -39,18 +40,22 @@ impl LayoutBorder {
             top: LayoutBorderSide {
                 width: b.top.width,
                 color: b.top.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
+                style: b.top.style,
             },
             right: LayoutBorderSide {
                 width: b.right.width,
                 color: b.right.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
+                style: b.right.style,
             },
             bottom: LayoutBorderSide {
                 width: b.bottom.width,
                 color: b.bottom.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
+                style: b.bottom.style,
             },
             left: LayoutBorderSide {
                 width: b.left.width,
                 color: b.left.color.map_or((0.0, 0.0, 0.0), |c| c.to_f32_rgb()),
+                style: b.left.style,
             },
         }
     }
@@ -272,14 +277,21 @@ fn append_pseudo_inline_run(
     pseudo_style: Option<&ComputedStyle>,
     el: &ElementNode,
     fonts: &HashMap<String, TtfFont>,
+    counter_state: &CounterState,
 ) {
     if let Some(pseudo_style) = pseudo_style {
         if !pseudo_is_block_like(pseudo_style) {
-            runs.push(build_pseudo_inline_run(pseudo_style, el, fonts));
+            runs.push(build_pseudo_inline_run(
+                pseudo_style,
+                el,
+                fonts,
+                counter_state,
+            ));
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_block_pseudo(
     output: &mut Vec<LayoutElement>,
     pseudo_style: Option<&ComputedStyle>,
@@ -288,6 +300,7 @@ fn push_block_pseudo(
     fonts: &HashMap<String, TtfFont>,
     containing_block_info: Option<ContainingBlock>,
     positioned_ancestor_depth: usize,
+    counter_state: &CounterState,
 ) {
     if let Some(pseudo_style) = pseudo_style {
         if pseudo_is_block_like(pseudo_style) {
@@ -303,6 +316,7 @@ fn push_block_pseudo(
                 fonts,
                 pseudo_cb,
                 positioned_ancestor_depth,
+                counter_state,
             ));
         }
     }
@@ -317,12 +331,9 @@ fn build_pseudo_block(
     fonts: &HashMap<String, TtfFont>,
     containing_block_info: Option<ContainingBlock>,
     positioned_ancestor_depth: usize,
+    counter_state: &CounterState,
 ) -> LayoutElement {
-    let content_text = resolve_content(
-        &pseudo_style.content,
-        &el.attributes,
-        &CounterState::default(),
-    );
+    let content_text = resolve_content(&pseudo_style.content, &el.attributes, counter_state);
 
     let mut block_w = available_width;
     if let Some(cb) = containing_block_info
@@ -584,12 +595,9 @@ fn build_pseudo_inline_run(
     pseudo_style: &ComputedStyle,
     el: &ElementNode,
     fonts: &HashMap<String, TtfFont>,
+    counter_state: &CounterState,
 ) -> TextRun {
-    let content_text = resolve_content(
-        &pseudo_style.content,
-        &el.attributes,
-        &CounterState::default(),
-    );
+    let content_text = resolve_content(&pseudo_style.content, &el.attributes, counter_state);
     TextRun {
         text: content_text,
         font_size: pseudo_style.font_size,
@@ -1079,6 +1087,7 @@ pub fn layout_with_rules_and_fonts(
     }
 
     let ancestors: Vec<AncestorInfo> = Vec::new();
+    let mut counter_state = CounterState::default();
     flatten_nodes(
         nodes,
         &parent_style,
@@ -1091,6 +1100,7 @@ pub fn layout_with_rules_and_fonts(
         0,
         custom_fonts,
         None,
+        &mut counter_state,
     );
 
     // Then paginate
@@ -1110,6 +1120,7 @@ fn flatten_nodes(
     positioned_ancestor_depth: usize,
     fonts: &HashMap<String, TtfFont>,
     abs_containing_block: Option<ContainingBlock>,
+    counter_state: &mut CounterState,
 ) {
     // Count element children for sibling context
     let element_count = nodes
@@ -1214,6 +1225,7 @@ fn flatten_nodes(
                     &preceding_siblings,
                     fonts,
                     abs_containing_block,
+                    counter_state,
                 );
                 // Track this element as a preceding sibling for the next element
                 preceding_siblings.push((
@@ -1256,6 +1268,7 @@ fn flatten_element(
     preceding_siblings: &[(String, Vec<String>)],
     fonts: &HashMap<String, TtfFont>,
     abs_containing_block: Option<ContainingBlock>,
+    counter_state: &mut CounterState,
 ) {
     let classes = el.class_list();
     let selector_ctx = SelectorContext {
@@ -1275,6 +1288,11 @@ fn flatten_element(
         &el.attributes,
         &selector_ctx,
     );
+
+    // Apply CSS counter operations for this element.
+    counter_state.apply_resets(&style.counter_reset);
+    counter_state.apply_increments(&style.counter_increment);
+
     let available_height = style.height.unwrap_or(available_height);
     let positioned_depth =
         if style.position == Position::Relative || style.position == Position::Absolute {
@@ -1778,6 +1796,7 @@ fn flatten_element(
             ancestors,
             child_index,
             sibling_count,
+            counter_state,
         );
         return;
     }
@@ -1835,6 +1854,7 @@ fn flatten_element(
                         &[],
                         fonts,
                         None,
+                        counter_state,
                     );
                     if let ListContext::Ordered { index, .. } = &mut ctx {
                         *index += 1;
@@ -1855,6 +1875,7 @@ fn flatten_element(
                         &[],
                         fonts,
                         None,
+                        counter_state,
                     );
                 }
                 child_el_idx += 1;
@@ -2013,6 +2034,7 @@ fn flatten_element(
                         &[],
                         fonts,
                         None,
+                        counter_state,
                     );
                 } else if recurses_as_layout_child(child_el.tag) {
                     flatten_element(
@@ -2030,6 +2052,7 @@ fn flatten_element(
                         &[],
                         fonts,
                         None,
+                        counter_state,
                     );
                 }
                 child_el_idx += 1;
@@ -2075,6 +2098,7 @@ fn flatten_element(
             before_style.as_ref(),
             after_style.as_ref(),
             positioned_depth,
+            counter_state,
         );
 
         if style.page_break_after {
@@ -2212,6 +2236,7 @@ fn flatten_element(
                     fonts,
                     None,
                     positioned_depth,
+                    counter_state,
                 ));
             }
         }
@@ -2220,7 +2245,7 @@ fn flatten_element(
         // When a math span is encountered, flush accumulated text runs as a
         // TextBlock, emit a MathBlock, then continue collecting.
         let mut runs = Vec::new();
-        append_pseudo_inline_run(&mut runs, before_style.as_ref(), el, fonts);
+        append_pseudo_inline_run(&mut runs, before_style.as_ref(), el, fonts, counter_state);
 
         // Helper closure: flush accumulated runs as a TextBlock
         let flush_runs = |runs: &mut Vec<TextRun>,
@@ -2399,7 +2424,7 @@ fn flatten_element(
                 ancestors,
             );
         }
-        append_pseudo_inline_run(&mut runs, after_style.as_ref(), el, fonts);
+        append_pseudo_inline_run(&mut runs, after_style.as_ref(), el, fonts, counter_state);
 
         let had_inline_runs = !runs.is_empty() || has_math_children;
         let mut cb_info = None;
@@ -2539,6 +2564,7 @@ fn flatten_element(
                 fonts,
                 cb_info,
                 positioned_depth,
+                counter_state,
             );
         }
 
@@ -2587,6 +2613,7 @@ fn flatten_element(
                             &[],
                             fonts,
                             None, // CB will be patched below after container_h is known
+                            counter_state,
                         );
                     }
                     child_el_idx += 1;
@@ -2692,6 +2719,7 @@ fn flatten_element(
                 fonts,
                 cb_info,
                 positioned_depth,
+                counter_state,
             );
             // Pull y back so children flow inside the wrapper, starting
             // after the top padding.  The wrapper advanced y by its full
@@ -2821,6 +2849,7 @@ fn flatten_element(
                     fonts,
                     cb_info,
                     positioned_depth,
+                    counter_state,
                 );
             }
             // Compute cb_info for positioned containers in the non-wrapper path
@@ -2848,6 +2877,7 @@ fn flatten_element(
                             &[],
                             fonts,
                             cb_info,
+                            counter_state,
                         );
                     }
                     child_el_idx += 1;
@@ -2864,6 +2894,7 @@ fn flatten_element(
             fonts,
             cb_info,
             positioned_depth,
+            counter_state,
         );
     } else {
         // Inline element — process children with this style context
@@ -2879,12 +2910,16 @@ fn flatten_element(
             positioned_depth,
             fonts,
             None,
+            counter_state,
         );
     }
 
     if style.page_break_after {
         output.push(LayoutElement::PageBreak);
     }
+
+    // Pop any counters that were pushed by counter-reset on this element.
+    counter_state.pop_resets(&style.counter_reset);
 }
 
 /// Lay out children of a `display: flex` container.
@@ -2905,6 +2940,7 @@ fn flatten_flex_container(
     before_style: Option<&ComputedStyle>,
     after_style: Option<&ComputedStyle>,
     positioned_depth: usize,
+    counter_state: &mut CounterState,
 ) {
     let mut block_w = available_width;
     if let Some(w) = style.width {
@@ -3035,6 +3071,7 @@ fn flatten_flex_container(
                     fonts,
                     containing_block,
                     positioned_depth,
+                    counter_state,
                 );
             }
             if after_abs {
@@ -3046,6 +3083,7 @@ fn flatten_flex_container(
                     fonts,
                     containing_block,
                     positioned_depth,
+                    counter_state,
                 );
             }
         }
@@ -3100,27 +3138,22 @@ fn flatten_flex_container(
 
         // Determine child width: flex-basis takes priority, then explicit width.
         // If neither is set and flex-grow > 0, use 0 as base (grow will distribute).
-        // Otherwise fall back to equal share.
-        let child_w = child_style
+        // If neither is set and flex-grow == 0 (default), use natural content width
+        // so items shrink to fit their content and justify-content can distribute
+        // the remaining free space.
+        let has_explicit_width = child_style.flex_basis.is_some() || child_style.width.is_some();
+        let child_w_initial = child_style
             .flex_basis
             .or(child_style.width)
             .unwrap_or_else(|| {
                 if child_style.flex_grow > 0.0 {
                     0.0
                 } else {
+                    // Use full width initially for text wrapping measurement;
+                    // we will shrink to natural content width below.
                     width_for_percentages / child_count as f32
                 }
             });
-
-        let child_inner_w = if child_style.box_sizing == BoxSizing::BorderBox {
-            child_w
-                - child_style.padding.left
-                - child_style.padding.right
-                - child_style.border.horizontal_width()
-        } else {
-            child_w - child_style.padding.left - child_style.padding.right
-        }
-        .max(0.0);
 
         // Collect text runs for this child, including from nested block elements.
         // Include the child element itself in the ancestor chain so that
@@ -3145,6 +3178,32 @@ fn flatten_flex_container(
             (0.0, 0.0),
             &child_ancestors,
         );
+
+        // When no explicit width/flex-basis and flex-grow is 0, measure the
+        // natural (intrinsic) content width so the item shrinks to fit.
+        let child_w = if !has_explicit_width && child_style.flex_grow == 0.0 && !runs.is_empty() {
+            let natural_text_w = measure_runs_width(&runs, fonts);
+            let pad_h = child_style.padding.left + child_style.padding.right;
+            let border_h = if child_style.box_sizing == BoxSizing::BorderBox {
+                child_style.border.horizontal_width()
+            } else {
+                0.0
+            };
+            // Content width = text width + padding + border (capped at container)
+            (natural_text_w + pad_h + border_h).min(width_for_percentages)
+        } else {
+            child_w_initial
+        };
+
+        let child_inner_w = if child_style.box_sizing == BoxSizing::BorderBox {
+            child_w
+                - child_style.padding.left
+                - child_style.padding.right
+                - child_style.border.horizontal_width()
+        } else {
+            child_w - child_style.padding.left - child_style.padding.right
+        }
+        .max(0.0);
 
         let lines = if !runs.is_empty() {
             wrap_text_runs(
@@ -3519,17 +3578,6 @@ fn flatten_flex_container(
                 if free_space > 0.0 && total_grow > 0.0 {
                     for &i in &line_items {
                         items[i].width += free_space * (items[i].flex_grow / total_grow);
-                    }
-                    free_space = 0.0;
-                } else if free_space > 0.0
-                    && total_grow == 0.0
-                    && free_space < inner_width * 0.05
-                    && line_item_count > 0
-                {
-                    // Fallback: small rounding remainder with no explicit flex-grow
-                    let grow_each = free_space / line_item_count as f32;
-                    for &i in &line_items {
-                        items[i].width += grow_each;
                     }
                     free_space = 0.0;
                 }
@@ -4457,6 +4505,7 @@ fn flatten_table(
     ancestors: &[AncestorInfo],
     table_child_index: usize,
     table_sibling_count: usize,
+    counter_state: &mut CounterState,
 ) {
     let inner_width = resolve_table_inner_width(style, available_width);
 
@@ -4754,6 +4803,7 @@ fn flatten_table(
                             recurse_descendants,
                             &text_ancestors,
                             inner_width.max(1.0),
+                            counter_state,
                         );
                         // Estimate content width using estimate_word_width for accurate
                         // measurement. Use the maximum of (full text width, longest word
@@ -5022,6 +5072,7 @@ fn flatten_table(
                 recurse_descendants,
                 &text_ancestors,
                 cell_inner.max(1.0),
+                counter_state,
             );
             let lines = wrap_text_runs(
                 runs,
@@ -5452,6 +5503,7 @@ fn collect_table_cell_content_inner(
     suppress_direct_text_padding: bool,
     ancestors: &[AncestorInfo],
     available_width: f32,
+    counter_state: &mut CounterState,
 ) {
     let preserve_ws = matches!(
         parent_style.white_space,
@@ -5567,6 +5619,7 @@ fn collect_table_cell_content_inner(
                         &child_ancestors,
                         child_index,
                         element_sibling_count,
+                        counter_state,
                     );
                 } else if el.tag == HtmlTag::Svg
                     || (recurse_blocks
@@ -5595,6 +5648,7 @@ fn collect_table_cell_content_inner(
                         &selector_ctx.preceding_siblings,
                         fonts,
                         None,
+                        counter_state,
                     );
                 } else if recurse_blocks || collects_as_inline_text(el.tag) || el.tag == HtmlTag::Br
                 {
@@ -5614,6 +5668,7 @@ fn collect_table_cell_content_inner(
                             false,
                             &child_ancestors,
                             available_width,
+                            counter_state,
                         );
                         if recurse_blocks && style.display != Display::Inline && !runs.is_empty() {
                             push_line_break_run(runs, &style, fonts);
@@ -10535,6 +10590,41 @@ mod tests {
     }
 
     #[test]
+    fn css_counter_in_pseudo_element_generates_numbers() {
+        // Verifies that counter-reset + counter-increment + counter() in
+        // ::before pseudo-elements produce sequential numbers (BUG 1 fix).
+        let html = r#"<html><head><style>
+            ol.counted { counter-reset: item }
+            ol.counted li { counter-increment: item }
+            ol.counted li::before { content: counter(item) ". " }
+        </style></head><body>
+            <ol class="counted"><li>First</li><li>Second</li><li>Third</li></ol>
+        </body></html>"#;
+        let result = crate::parser::html::parse_html_with_styles(html).unwrap();
+        let mut rules = Vec::new();
+        for css in &result.stylesheets {
+            rules.extend(crate::parser::css::parse_stylesheet(css));
+        }
+        let pages = layout_with_rules(&result.nodes, PageSize::A4, Margin::default(), &rules);
+        let mut all_texts: Vec<String> = Vec::new();
+        for (_, el) in &pages[0].elements {
+            if let LayoutElement::TextBlock { lines, .. } = el {
+                for l in lines {
+                    let text: String = l.runs.iter().map(|r| r.text.as_str()).collect();
+                    if !text.trim().is_empty() {
+                        all_texts.push(text);
+                    }
+                }
+            }
+        }
+        let joined = all_texts.join(" ");
+        assert!(
+            joined.contains("1.") && joined.contains("2.") && joined.contains("3."),
+            "CSS counters should generate sequential numbers 1, 2, 3. Got: {joined}"
+        );
+    }
+
+    #[test]
     fn layout_flex_container() {
         // Covers lines 1067,1133,1395: flex layout code paths
         let html = r#"<div style="display: flex; width: 400pt;">
@@ -11173,18 +11263,22 @@ mod tests {
             top: LayoutBorderSide {
                 width: 1.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             right: LayoutBorderSide {
                 width: 3.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             bottom: LayoutBorderSide {
                 width: 2.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             left: LayoutBorderSide {
                 width: 5.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
         };
         assert!((border.horizontal_width() - 8.0).abs() < f32::EPSILON);
@@ -11196,18 +11290,22 @@ mod tests {
             top: LayoutBorderSide {
                 width: 4.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             right: LayoutBorderSide {
                 width: 1.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             bottom: LayoutBorderSide {
                 width: 6.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             left: LayoutBorderSide {
                 width: 1.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
         };
         assert!((border.vertical_width() - 10.0).abs() < f32::EPSILON);
@@ -11219,18 +11317,22 @@ mod tests {
             top: LayoutBorderSide {
                 width: 2.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             right: LayoutBorderSide {
                 width: 7.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             bottom: LayoutBorderSide {
                 width: 3.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
             left: LayoutBorderSide {
                 width: 5.0,
                 color: (0.0, 0.0, 0.0),
+                style: crate::style::computed::BorderStyle::Solid,
             },
         };
         assert!((border.max_width() - 7.0).abs() < f32::EPSILON);
@@ -11742,6 +11844,148 @@ mod tests {
             "flex-shrink: 1 item should shrink, got {}",
             cells[1].width
         );
+    }
+
+    #[test]
+    fn flex_no_grow_uses_content_width() {
+        // 3 flex items with no flex-grow should use their content width,
+        // not expand to fill the full container.
+        let html = r#"<html><head><style>
+            .container { display: flex; width: 400pt; }
+            .item { width: 50pt; }
+        </style></head><body>
+        <div class="container">
+            <div class="item">A</div>
+            <div class="item">B</div>
+            <div class="item">C</div>
+        </div>
+        </body></html>"#;
+        let result = parse_html_with_styles(html).unwrap();
+        let rules: Vec<_> = result
+            .stylesheets
+            .iter()
+            .flat_map(|css| parse_stylesheet(css))
+            .collect();
+        let pages = layout_with_rules(&result.nodes, PageSize::A4, Margin::default(), &rules);
+        let mut flex_rows: Vec<&Vec<FlexCell>> = Vec::new();
+        for (_, el) in &pages[0].elements {
+            if let LayoutElement::FlexRow { cells, .. } = el {
+                flex_rows.push(cells);
+            }
+        }
+        assert_eq!(flex_rows.len(), 1);
+        let cells = flex_rows[0];
+        assert_eq!(cells.len(), 3);
+        // Each item should be ~50pt wide, not ~133pt (400/3)
+        for (idx, cell) in cells.iter().enumerate() {
+            assert!(
+                (cell.width - 50.0).abs() < 5.0,
+                "Item {} should be ~50pt wide (content width), got {}",
+                idx,
+                cell.width
+            );
+        }
+        // Total width of items should be much less than container width
+        let total: f32 = cells.iter().map(|c| c.width).sum();
+        assert!(
+            total < 200.0,
+            "Total item width should be much less than 400pt container, got {total}"
+        );
+    }
+
+    #[test]
+    fn flex_justify_center_positions_items_in_middle() {
+        // justify-content: center should position items in the middle
+        // of the container, not at the start.
+        let html = r#"<html><head><style>
+            .container { display: flex; justify-content: center; width: 400pt; }
+            .item { width: 100pt; }
+        </style></head><body>
+        <div class="container">
+            <div class="item">X</div>
+        </div>
+        </body></html>"#;
+        let result = parse_html_with_styles(html).unwrap();
+        let rules: Vec<_> = result
+            .stylesheets
+            .iter()
+            .flat_map(|css| parse_stylesheet(css))
+            .collect();
+        let pages = layout_with_rules(&result.nodes, PageSize::A4, Margin::default(), &rules);
+        let mut flex_rows: Vec<&Vec<FlexCell>> = Vec::new();
+        for (_, el) in &pages[0].elements {
+            if let LayoutElement::FlexRow { cells, .. } = el {
+                flex_rows.push(cells);
+            }
+        }
+        assert_eq!(flex_rows.len(), 1);
+        let cells = flex_rows[0];
+        assert_eq!(cells.len(), 1);
+        // Item should be centered: x_offset should be ~150pt ((400-100)/2)
+        assert!(
+            (cells[0].x_offset - 150.0).abs() < 5.0,
+            "justify-content: center should put item at ~150pt, got {}",
+            cells[0].x_offset
+        );
+        // Width should stay at 100pt
+        assert!(
+            (cells[0].width - 100.0).abs() < 5.0,
+            "Item width should remain ~100pt, got {}",
+            cells[0].width
+        );
+    }
+
+    #[test]
+    fn flex_justify_space_between_distributes_items() {
+        // justify-content: space-between with 3 items should put first at
+        // start, last at end, and distribute space between them evenly.
+        let html = r#"<html><head><style>
+            .container { display: flex; justify-content: space-between; width: 400pt; }
+            .item { width: 80pt; }
+        </style></head><body>
+        <div class="container">
+            <div class="item">A</div>
+            <div class="item">B</div>
+            <div class="item">C</div>
+        </div>
+        </body></html>"#;
+        let result = parse_html_with_styles(html).unwrap();
+        let rules: Vec<_> = result
+            .stylesheets
+            .iter()
+            .flat_map(|css| parse_stylesheet(css))
+            .collect();
+        let pages = layout_with_rules(&result.nodes, PageSize::A4, Margin::default(), &rules);
+        let mut flex_rows: Vec<&Vec<FlexCell>> = Vec::new();
+        for (_, el) in &pages[0].elements {
+            if let LayoutElement::FlexRow { cells, .. } = el {
+                flex_rows.push(cells);
+            }
+        }
+        assert_eq!(flex_rows.len(), 1);
+        let cells = flex_rows[0];
+        assert_eq!(cells.len(), 3);
+        // First item should be at x=0
+        assert!(
+            cells[0].x_offset < 5.0,
+            "First item should be at start, got {}",
+            cells[0].x_offset
+        );
+        // Last item should end at ~400pt (x_offset + width ~ 400)
+        let last_end = cells[2].x_offset + cells[2].width;
+        assert!(
+            (last_end - 400.0).abs() < 5.0,
+            "Last item should end at ~400pt, got {last_end}"
+        );
+        // Gaps between items should be equal
+        let gap1 = cells[1].x_offset - (cells[0].x_offset + cells[0].width);
+        let gap2 = cells[2].x_offset - (cells[1].x_offset + cells[1].width);
+        assert!(
+            (gap1 - gap2).abs() < 1.0,
+            "Gaps should be equal: {gap1} vs {gap2}"
+        );
+        // Each gap should be ~80pt ((400 - 240) / 2)
+        assert!((gap1 - 80.0).abs() < 5.0, "Gap should be ~80pt, got {gap1}");
     }
 
     #[test]

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -1090,6 +1090,7 @@ pub fn layout_with_rules_and_fonts(
         &ancestors,
         0,
         custom_fonts,
+        None,
     );
 
     // Then paginate
@@ -1108,6 +1109,7 @@ fn flatten_nodes(
     ancestors: &[AncestorInfo],
     positioned_ancestor_depth: usize,
     fonts: &HashMap<String, TtfFont>,
+    abs_containing_block: Option<ContainingBlock>,
 ) {
     // Count element children for sibling context
     let element_count = nodes
@@ -1211,6 +1213,7 @@ fn flatten_nodes(
                     element_count,
                     &preceding_siblings,
                     fonts,
+                    abs_containing_block,
                 );
                 // Track this element as a preceding sibling for the next element
                 preceding_siblings.push((
@@ -1252,6 +1255,7 @@ fn flatten_element(
     sibling_count: usize,
     preceding_siblings: &[(String, Vec<String>)],
     fonts: &HashMap<String, TtfFont>,
+    abs_containing_block: Option<ContainingBlock>,
 ) {
     let classes = el.class_list();
     let selector_ctx = SelectorContext {
@@ -1830,6 +1834,7 @@ fn flatten_element(
                         child_el_count,
                         &[],
                         fonts,
+                        None,
                     );
                     if let ListContext::Ordered { index, .. } = &mut ctx {
                         *index += 1;
@@ -1849,6 +1854,7 @@ fn flatten_element(
                         child_el_count,
                         &[],
                         fonts,
+                        None,
                     );
                 }
                 child_el_idx += 1;
@@ -2006,6 +2012,7 @@ fn flatten_element(
                         child_el_count,
                         &[],
                         fonts,
+                        None,
                     );
                 } else if recurses_as_layout_child(child_el.tag) {
                     flatten_element(
@@ -2022,6 +2029,7 @@ fn flatten_element(
                         child_el_count,
                         &[],
                         fonts,
+                        None,
                     );
                 }
                 child_el_idx += 1;
@@ -2469,6 +2477,14 @@ fn flatten_element(
             );
             cb_info = make_containing_block(total_h);
 
+            // Resolve containing block and offsets for absolute elements
+            let (elem_cb, resolved_top, resolved_left) = resolve_abs_containing_block(
+                &style,
+                abs_containing_block,
+                total_h,
+                explicit_width.unwrap_or(block_w),
+            );
+
             output.push(LayoutElement::TextBlock {
                 lines,
                 margin_top: style.margin.top,
@@ -2486,11 +2502,11 @@ fn flatten_element(
                 float: style.float,
                 clear: style.clear,
                 position: style.position,
-                offset_top: style.top.unwrap_or(0.0),
-                offset_left: style.left.unwrap_or(0.0) + auto_offset_left,
+                offset_top: resolved_top,
+                offset_left: resolved_left + auto_offset_left,
                 offset_bottom: 0.0,
                 offset_right: 0.0,
-                containing_block: None,
+                containing_block: elem_cb,
                 box_shadow: style.box_shadow,
                 visible: style.visibility == Visibility::Visible,
                 clip_rect,
@@ -2570,6 +2586,7 @@ fn flatten_element(
                             child_el_count,
                             &[],
                             fonts,
+                            None, // CB will be patched below after container_h is known
                         );
                     }
                     child_el_idx += 1;
@@ -2592,6 +2609,12 @@ fn flatten_element(
             }
             cb_info = make_containing_block(container_h);
 
+            // Patch absolute children with the now-known containing block,
+            // and resolve bottom/right offsets into top/left.
+            if let Some(cb) = cb_info {
+                patch_absolute_children_containing_block(&mut child_elements, cb);
+            }
+
             let bg = style
                 .background_color
                 .map(|c: crate::types::Color| c.to_f32_rgb());
@@ -2605,6 +2628,9 @@ fn flatten_element(
                 repeat: background_repeat,
                 origin: background_origin,
             } = BackgroundFields::from_style(&style);
+            // Resolve containing block and offsets for absolute elements
+            let (wrapper_cb, wrapper_top, wrapper_left) =
+                resolve_abs_containing_block(&style, abs_containing_block, container_h, block_w);
             // Emit wrapper with visual properties
             output.push(LayoutElement::TextBlock {
                 lines: Vec::new(),
@@ -2625,11 +2651,11 @@ fn flatten_element(
                 float: style.float,
                 clear: style.clear,
                 position: style.position,
-                offset_top: style.top.unwrap_or(0.0),
-                offset_left: style.left.unwrap_or(0.0) + auto_offset_left,
+                offset_top: wrapper_top,
+                offset_left: wrapper_left + auto_offset_left,
                 offset_bottom: 0.0,
                 offset_right: 0.0,
-                containing_block: None,
+                containing_block: wrapper_cb,
                 box_shadow: style.box_shadow,
                 visible: style.visibility == Visibility::Visible,
                 clip_rect: if style.overflow == Overflow::Hidden {
@@ -2797,6 +2823,12 @@ fn flatten_element(
                     positioned_depth,
                 );
             }
+            // Compute cb_info for positioned containers in the non-wrapper path
+            // so that absolute children get a containing block.
+            if cb_info.is_none() && positioned_container {
+                let h = effective_height.unwrap_or(0.0);
+                cb_info = make_containing_block(h);
+            }
             let mut child_el_idx = 0;
             for child in &el.children {
                 if let DomNode::Element(child_el) = child {
@@ -2815,6 +2847,7 @@ fn flatten_element(
                             child_el_count,
                             &[],
                             fonts,
+                            cb_info,
                         );
                     }
                     child_el_idx += 1;
@@ -2845,6 +2878,7 @@ fn flatten_element(
             &child_ancestors,
             positioned_depth,
             fonts,
+            None,
         );
     }
 
@@ -5560,6 +5594,7 @@ fn collect_table_cell_content_inner(
                         element_sibling_count,
                         &selector_ctx.preceding_siblings,
                         fonts,
+                        None,
                     );
                 } else if recurse_blocks || collects_as_inline_text(el.tag) || el.tag == HtmlTag::Br
                 {
@@ -5937,6 +5972,68 @@ fn apply_text_overflow_ellipsis(
 
     // Remove any additional lines (shouldn't exist with nowrap, but just in case)
     lines.truncate(1);
+}
+
+/// Resolve the containing block for an element that is `position: absolute`.
+/// If the element is absolute and `abs_cb` is `Some`, returns `abs_cb` and
+/// resolves bottom/right offsets into top/left. Otherwise returns `None`
+/// and leaves offsets unchanged.
+fn resolve_abs_containing_block(
+    style: &ComputedStyle,
+    abs_cb: Option<ContainingBlock>,
+    elem_height: f32,
+    elem_width: f32,
+) -> (Option<ContainingBlock>, f32, f32) {
+    if style.position != Position::Absolute {
+        return (None, style.top.unwrap_or(0.0), style.left.unwrap_or(0.0));
+    }
+    let cb = match abs_cb {
+        Some(cb) => cb,
+        None => return (None, style.top.unwrap_or(0.0), style.left.unwrap_or(0.0)),
+    };
+
+    let top_from_percent = style.percentage_insets.top.map(|p| cb.height * p / 100.0);
+    let bottom_from_percent = style
+        .percentage_insets
+        .bottom
+        .map(|p| cb.height * p / 100.0);
+    let left_from_percent = style.percentage_insets.left.map(|p| cb.width * p / 100.0);
+    let right_from_percent = style.percentage_insets.right.map(|p| cb.width * p / 100.0);
+
+    let resolved_top = if let Some(top) = top_from_percent.or(style.top) {
+        top
+    } else if let Some(bottom) = bottom_from_percent.or(style.bottom) {
+        cb.height - elem_height - bottom
+    } else {
+        0.0
+    };
+    let resolved_left = if let Some(left) = left_from_percent.or(style.left) {
+        left
+    } else if let Some(right) = right_from_percent.or(style.right) {
+        cb.width - elem_width - right
+    } else {
+        0.0
+    };
+
+    (Some(cb), resolved_top, resolved_left)
+}
+
+/// Patch absolute-positioned children in a flattened element list with
+/// the parent's containing block info. This resolves bottom/right offsets
+/// into top/left and sets the `containing_block` field.
+fn patch_absolute_children_containing_block(elements: &mut [LayoutElement], cb: ContainingBlock) {
+    for element in elements.iter_mut() {
+        if let LayoutElement::TextBlock {
+            position,
+            containing_block,
+            ..
+        } = element
+        {
+            if *position == Position::Absolute && containing_block.is_none() {
+                *containing_block = Some(cb);
+            }
+        }
+    }
 }
 
 /// A tracked float region for simplified float layout.
@@ -8656,6 +8753,56 @@ mod tests {
         } else {
             panic!("Expected TextBlock");
         }
+    }
+
+    #[test]
+    fn position_absolute_relative_to_containing_block() {
+        let html = r#"
+            <div style="margin-top: 200pt; height: 200pt; position: relative; background: #eee;">
+                <div style="position: absolute; top: 10pt; left: 10pt; width: 50pt; height: 50pt; background: red;">X</div>
+            </div>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        let parent = pages[0]
+            .elements
+            .iter()
+            .find(|(_, el)| {
+                matches!(
+                    el,
+                    LayoutElement::TextBlock {
+                        position: Position::Relative,
+                        background_color: Some(_),
+                        ..
+                    }
+                )
+            })
+            .expect("Should find positioned parent");
+        let parent_y = parent.0;
+        assert!(
+            (parent_y - 200.0).abs() < 1.0,
+            "Parent should be at ~200pt, got {parent_y}"
+        );
+        let child = pages[0]
+            .elements
+            .iter()
+            .find(|(_, el)| {
+                matches!(
+                    el,
+                    LayoutElement::TextBlock {
+                        position: Position::Absolute,
+                        ..
+                    }
+                )
+            })
+            .expect("Should find absolute child");
+        let child_y = child.0;
+        assert!(
+            (child_y - (parent_y + 10.0)).abs() < 1.0,
+            "Absolute child y={child_y} should be ~{} (parent_y + 10), not near 0 (page origin)",
+            parent_y + 10.0
+        );
     }
 
     #[test]
@@ -12562,6 +12709,365 @@ mod tests {
             )),
             "expected nested flex block with raster background to survive table-cell layout"
         );
+    }
+
+    #[test]
+    fn paginate_math_block_advances_y() {
+        // MathBlock elements must reserve vertical space so subsequent content
+        // doesn't overlap.
+        let html = r#"<p>Before</p><div class="math-display" data-math="\frac{a}{b}">frac</div><p>After</p>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+
+        // Gather y positions and element types
+        let mut y_positions: Vec<(f32, &str)> = Vec::new();
+        for (y, el) in &pages[0].elements {
+            match el {
+                LayoutElement::TextBlock { .. } => y_positions.push((*y, "TextBlock")),
+                LayoutElement::MathBlock { .. } => y_positions.push((*y, "MathBlock")),
+                _ => {}
+            }
+        }
+
+        // We expect: TextBlock("Before"), MathBlock, TextBlock("After")
+        assert!(
+            y_positions.len() >= 3,
+            "Expected at least 3 elements (Before text, MathBlock, After text), got {}: {:?}",
+            y_positions.len(),
+            y_positions
+        );
+
+        // Each element must have a strictly increasing y position
+        for i in 1..y_positions.len() {
+            assert!(
+                y_positions[i].0 > y_positions[i - 1].0,
+                "Element {} ({} at y={}) should be below element {} ({} at y={})",
+                i,
+                y_positions[i].1,
+                y_positions[i].0,
+                i - 1,
+                y_positions[i - 1].1,
+                y_positions[i - 1].0,
+            );
+        }
+    }
+
+    #[test]
+    fn paginate_math_block_from_markdown() {
+        // Test the actual markdown flow: $$ ... $$ produces display math
+        // that must advance Y so subsequent text doesn't overlap.
+        let md = "# Title\n\n$$\\frac{a}{b}$$\n\nText after math should not overlap";
+        let html = crate::parser::markdown::markdown_to_html(md);
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+
+        let mut y_positions: Vec<(f32, &str)> = Vec::new();
+        for (y, el) in &pages[0].elements {
+            match el {
+                LayoutElement::TextBlock { .. } => y_positions.push((*y, "TextBlock")),
+                LayoutElement::MathBlock { .. } => y_positions.push((*y, "MathBlock")),
+                _ => {}
+            }
+        }
+
+        // We expect: TextBlock(Title), MathBlock(frac), TextBlock(Text after...)
+        assert!(
+            y_positions.len() >= 3,
+            "Expected at least 3 elements (Title, MathBlock, After text), got {}: {:?}",
+            y_positions.len(),
+            y_positions
+        );
+
+        // Each element must have a strictly increasing y position
+        for i in 1..y_positions.len() {
+            assert!(
+                y_positions[i].0 > y_positions[i - 1].0,
+                "Element {} ({} at y={}) should be below element {} ({} at y={})",
+                i,
+                y_positions[i].1,
+                y_positions[i].0,
+                i - 1,
+                y_positions[i - 1].1,
+                y_positions[i - 1].0,
+            );
+        }
+    }
+
+    /// Verify that styled blocks (background, border, padding) don't cause
+    /// subsequent content to overlap.
+    #[test]
+    fn styled_block_does_not_overlap_next_element() {
+        let css = r#"
+            .summary { background-color: #eff6ff; border-left: 4px solid #3b82f6; padding: 12px 16px; margin: 16px 0; }
+        "#;
+        let rules = parse_stylesheet(css);
+        let html = r#"
+            <h1>Title</h1>
+            <div class="summary">This is a summary box with background and border styling.</div>
+            <h2>Next Section</h2>
+            <p>This should not overlap with the summary box.</p>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+
+        // Collect Y positions of text blocks with content
+        let mut y_positions: Vec<(f32, String)> = Vec::new();
+        for (y_pos, elem) in &pages[0].elements {
+            if let LayoutElement::TextBlock { lines, .. } = elem {
+                let text: String = lines
+                    .iter()
+                    .flat_map(|l| l.runs.iter().map(|r| r.text.as_str()))
+                    .collect();
+                if !text.is_empty() {
+                    y_positions.push((*y_pos, text[..text.len().min(40)].to_string()));
+                }
+            }
+        }
+
+        // Each Y position should be strictly greater than the previous
+        for i in 1..y_positions.len() {
+            assert!(
+                y_positions[i].0 > y_positions[i - 1].0 + 1.0,
+                "Text blocks should have distinct Y positions!\n  block {}: y={:.1} {:?}\n  block {}: y={:.1} {:?}",
+                i - 1,
+                y_positions[i - 1].0,
+                y_positions[i - 1].1,
+                i,
+                y_positions[i].0,
+                y_positions[i].1,
+            );
+        }
+    }
+
+    /// Verify that blockquotes with visual styling don't cause overlap.
+    #[test]
+    fn blockquote_with_background_no_overlap() {
+        let css = r#"
+            blockquote { margin: 20px 0; padding: 12px 20px; border-left: 4px solid #3b82f6; background-color: #f8fafc; }
+        "#;
+        let rules = parse_stylesheet(css);
+        let html = r#"
+            <p>Paragraph before the blockquote.</p>
+            <blockquote>This is a blockquote with background and border styling that should take up vertical space.</blockquote>
+            <p>Paragraph after the blockquote should not overlap.</p>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+
+        let mut y_positions: Vec<(f32, String)> = Vec::new();
+        for (y_pos, elem) in &pages[0].elements {
+            if let LayoutElement::TextBlock { lines, .. } = elem {
+                let text: String = lines
+                    .iter()
+                    .flat_map(|l| l.runs.iter().map(|r| r.text.as_str()))
+                    .collect();
+                if !text.is_empty() {
+                    y_positions.push((*y_pos, text[..text.len().min(40)].to_string()));
+                }
+            }
+        }
+
+        assert!(
+            y_positions.len() >= 2,
+            "Expected at least 2 text blocks, got {}: {:?}",
+            y_positions.len(),
+            y_positions
+        );
+
+        for i in 1..y_positions.len() {
+            assert!(
+                y_positions[i].0 > y_positions[i - 1].0 + 1.0,
+                "Text blocks should have distinct Y positions!\n  block {}: y={:.1} {:?}\n  block {}: y={:.1} {:?}",
+                i - 1,
+                y_positions[i - 1].0,
+                y_positions[i - 1].1,
+                i,
+                y_positions[i].0,
+                y_positions[i].1,
+            );
+        }
+    }
+
+    /// Verify pre blocks with padding/background don't cause overlap.
+    #[test]
+    fn pre_block_with_padding_no_overlap() {
+        let css = r#"
+            pre { background-color: #1e293b; padding: 16px 20px; margin: 16px 0; }
+        "#;
+        let rules = parse_stylesheet(css);
+        let html = r#"
+            <p>Before the code block.</p>
+            <pre>line 1
+line 2
+line 3</pre>
+            <p>After the code block should not overlap.</p>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+
+        let mut y_positions: Vec<(f32, String)> = Vec::new();
+        for (y_pos, elem) in &pages[0].elements {
+            if let LayoutElement::TextBlock { lines, .. } = elem {
+                let text: String = lines
+                    .iter()
+                    .flat_map(|l| l.runs.iter().map(|r| r.text.as_str()))
+                    .collect();
+                if !text.is_empty() {
+                    y_positions.push((*y_pos, text[..text.len().min(40)].to_string()));
+                }
+            }
+        }
+
+        assert!(
+            y_positions.len() >= 2,
+            "Expected at least 2 text blocks with content, got {}: {:?}",
+            y_positions.len(),
+            y_positions
+        );
+
+        for i in 1..y_positions.len() {
+            assert!(
+                y_positions[i].0 > y_positions[i - 1].0 + 1.0,
+                "Text blocks should have distinct Y positions!\n  block {}: y={:.1} {:?}\n  block {}: y={:.1} {:?}",
+                i - 1,
+                y_positions[i - 1].0,
+                y_positions[i - 1].1,
+                i,
+                y_positions[i].0,
+                y_positions[i].1,
+            );
+        }
+    }
+    /// Verify fixture text blocks have monotonically increasing Y positions
+    /// (no overlapping text).
+    fn check_fixture_no_overlap(html: &str, fixture_name: &str) {
+        let result = crate::parser::html::parse_html_with_styles(html).unwrap();
+        let rules: Vec<_> = result
+            .stylesheets
+            .iter()
+            .flat_map(|css| parse_stylesheet(css))
+            .collect();
+        let pages = layout_with_rules_and_fonts(
+            &result.nodes,
+            PageSize::A4,
+            Margin::default(),
+            &rules,
+            &std::collections::HashMap::new(),
+        );
+
+        for (page_idx, page) in pages.iter().enumerate() {
+            let mut y_positions: Vec<(f32, String)> = Vec::new();
+            for (y_pos, elem) in &page.elements {
+                if let LayoutElement::TextBlock {
+                    lines, position, ..
+                } = elem
+                {
+                    if *position == Position::Absolute {
+                        continue;
+                    }
+                    let text: String = lines
+                        .iter()
+                        .flat_map(|l| l.runs.iter().map(|r| r.text.as_str()))
+                        .collect();
+                    if !text.is_empty() {
+                        y_positions.push((*y_pos, text[..text.len().min(50)].to_string()));
+                    }
+                }
+            }
+
+            for i in 1..y_positions.len() {
+                let (prev_y, ref prev_text) = y_positions[i - 1];
+                let (curr_y, ref curr_text) = y_positions[i];
+                assert!(
+                    curr_y >= prev_y - 0.1,
+                    "{fixture_name} page {page_idx}: text blocks overlap!\n  \
+                     [{prev}] y={prev_y:.1} {prev_text:?}\n  \
+                     [{i}] y={curr_y:.1} {curr_text:?}",
+                    prev = i - 1,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn simple_report_fixture_no_overlap() {
+        check_fixture_no_overlap(
+            include_str!("../../tests/fixtures/combined/simple-report.html"),
+            "simple-report",
+        );
+    }
+
+    #[test]
+    fn article_fixture_no_overlap() {
+        check_fixture_no_overlap(
+            include_str!("../../tests/fixtures/combined/article.html"),
+            "article",
+        );
+    }
+
+    #[test]
+    fn page_breaks_fixture_no_overlap() {
+        check_fixture_no_overlap(
+            include_str!("../../tests/fixtures/edge-cases/page-breaks.html"),
+            "page-breaks",
+        );
+    }
+
+    /// Test with styled wrapper block containing only block children.
+    #[test]
+    fn styled_wrapper_with_block_children_no_overlap() {
+        let css = r#"
+            .section { padding: 16px; margin-bottom: 16px; border: 1px solid #e2e8f0; border-radius: 4px; }
+        "#;
+        let rules = parse_stylesheet(css);
+        let html = r#"
+            <h1>Page Break Test</h1>
+            <div class="section">
+                <h2>Section 1</h2>
+                <p>Content in section 1.</p>
+            </div>
+            <div class="section">
+                <h2>Section 2</h2>
+                <p>Content in section 2 should not overlap with section 1.</p>
+            </div>
+            <p>Final paragraph after both sections.</p>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout_with_rules(&nodes, PageSize::A4, Margin::default(), &rules);
+
+        let mut y_positions: Vec<(f32, String)> = Vec::new();
+        for (y_pos, elem) in &pages[0].elements {
+            if let LayoutElement::TextBlock {
+                lines, position, ..
+            } = elem
+            {
+                if *position == Position::Absolute {
+                    continue;
+                }
+                let text: String = lines
+                    .iter()
+                    .flat_map(|l| l.runs.iter().map(|r| r.text.as_str()))
+                    .collect();
+                if !text.is_empty() {
+                    y_positions.push((*y_pos, text[..text.len().min(50)].to_string()));
+                }
+            }
+        }
+
+        for i in 1..y_positions.len() {
+            assert!(
+                y_positions[i].0 > y_positions[i - 1].0 + 0.5,
+                "Text blocks should have distinct Y positions!\n  block {}: y={:.1} {:?}\n  block {}: y={:.1} {:?}",
+                i - 1,
+                y_positions[i - 1].0,
+                y_positions[i - 1].1,
+                i,
+                y_positions[i].0,
+                y_positions[i].1,
+            );
+        }
     }
 }
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -3809,7 +3809,8 @@ fn flatten_flex_container(
                                     // add only the container padding offset.
                                     style.padding.top + *tb_mt
                                 } else {
-                                    *tb_mt
+                                    // Apply gap between column-direction flex items.
+                                    gap + *tb_mt
                                 },
                                 margin_bottom: *tb_mb,
                                 text_align: *tb_ta,
@@ -9246,6 +9247,25 @@ mod tests {
             (b.1 - expected).abs() < 1.0,
             "no gap: expected {expected}, got {}",
             b.1
+        );
+    }
+
+    #[test]
+    fn flex_column_gap_spacing() {
+        // Column-direction flex: gap should push items apart vertically.
+        let html = r#"<div style="display: flex; flex-direction: column; gap: 20pt"><div style="height: 30pt">A</div><div style="height: 30pt">B</div></div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let items = extract_flex_items(&pages);
+        assert!(items.len() >= 2, "expected at least 2 flex column items");
+        let a = items.iter().find(|i| i.3 == "A").unwrap();
+        let b = items.iter().find(|i| i.3 == "B").unwrap();
+        // B must be below A; with a 20pt gap the Y gap between starts should exceed 20pt
+        assert!(
+            b.0 > a.0 + 20.0,
+            "column gap: B y={} should be more than 20pt below A y={}",
+            b.0,
+            a.0
         );
     }
 

--- a/src/parser/css/values.rs
+++ b/src/parser/css/values.rs
@@ -164,6 +164,13 @@ pub(crate) fn parse_color(val: &str) -> Option<CssValue> {
         return parse_hex_color(hex);
     }
 
+    if let Some(inner) = lower
+        .strip_prefix("rgba(")
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        return parse_rgba_function(inner);
+    }
+
     lower
         .strip_prefix("rgb(")
         .and_then(|inner| inner.strip_suffix(')'))
@@ -440,6 +447,31 @@ fn parse_rgb_function(inner: &str) -> Option<CssValue> {
         [r, g, b] => Some(CssValue::Color(Color::rgb(*r, *g, *b))),
         _ => None,
     }
+}
+
+/// Parse `rgba(r, g, b, a)` where alpha is 0.0–1.0.
+///
+/// The alpha channel is pre-composited against white so that the stored
+/// `Color` value can be used directly as an opaque RGB fill in PDF output
+/// without requiring a separate transparency mechanism.  For example,
+/// `rgba(239, 68, 68, 0.05)` becomes approximately `(252, 243, 243)`.
+fn parse_rgba_function(inner: &str) -> Option<CssValue> {
+    let parts: Vec<&str> = inner.splitn(4, ',').collect();
+    if parts.len() != 4 {
+        return None;
+    }
+    let r = parts[0].trim().parse::<u8>().ok()?;
+    let g = parts[1].trim().parse::<u8>().ok()?;
+    let b = parts[2].trim().parse::<u8>().ok()?;
+    let a: f32 = parts[3].trim().parse::<f32>().ok()?;
+    let a = a.clamp(0.0, 1.0);
+
+    // Pre-composite against white (255, 255, 255).
+    let blend = |channel: u8| -> u8 {
+        let c = channel as f32;
+        (c * a + 255.0 * (1.0 - a)).round() as u8
+    };
+    Some(CssValue::Color(Color::rgb(blend(r), blend(g), blend(b))))
 }
 
 fn hex_digit(byte: u8) -> Option<u8> {

--- a/src/parser/css/values.rs
+++ b/src/parser/css/values.rs
@@ -310,6 +310,23 @@ pub(crate) fn parse_property_value(property: &str, val: &str) -> Option<CssValue
         return Some(CssValue::Keyword("auto".to_string()));
     }
 
+    // line-height: a bare number (e.g. `1.6`) is a unitless multiplier,
+    // not a length.  Only values with explicit units should be Length.
+    if property == "line-height" {
+        if lower == "normal" {
+            return Some(CssValue::Keyword("normal".into()));
+        }
+        // Try unit-based parsing first (px, pt, em, rem, %, etc.)
+        let has_unit = val
+            .trim()
+            .ends_with(|c: char| c.is_ascii_alphabetic() || c == '%');
+        if has_unit {
+            return parse_length(val);
+        }
+        // Bare number → unitless line-height multiplier
+        return val.trim().parse::<f32>().ok().map(CssValue::Number);
+    }
+
     parse_length(val)
 }
 

--- a/src/parser/css/values_tests.rs
+++ b/src/parser/css/values_tests.rs
@@ -165,6 +165,67 @@ fn parse_color_invalid_inputs() {
     assert!(parse_color("rgb(1,2)").is_none());
 }
 
+/// BUG P2-1: rgba() background-color must be parsed and pre-composited.
+/// Previously `parse_color` did not handle `rgba(...)` at all, so any
+/// `background-color: rgba(...)` rule silently produced no background fill.
+#[test]
+fn parse_color_rgba_composited_against_white() {
+    // rgba(239, 68, 68, 0.05) composited on white:
+    //   r = 239*0.05 + 255*0.95 = 11.95 + 242.25 = 254.2 → 254
+    //   g = 68*0.05  + 255*0.95 = 3.4   + 242.25 = 245.65 → 246
+    //   b = 68*0.05  + 255*0.95 = 3.4   + 242.25 = 245.65 → 246
+    let color = parse_color("rgba(239, 68, 68, 0.05)");
+    assert!(
+        color.is_some(),
+        "rgba() should be parsed as a Color, not None"
+    );
+    if let Some(CssValue::Color(c)) = color {
+        assert!(
+            c.r > 250,
+            "near-transparent red on white should have high r, got {}",
+            c.r
+        );
+        assert!(
+            c.g > 240,
+            "near-transparent red on white should have high g, got {}",
+            c.g
+        );
+        assert!(
+            c.b > 240,
+            "near-transparent red on white should have high b, got {}",
+            c.b
+        );
+    }
+}
+
+#[test]
+fn parse_color_rgba_fully_opaque() {
+    // rgba(0, 128, 255, 1.0) should yield the same colour as rgb(0, 128, 255).
+    let c_rgba = parse_color("rgba(0, 128, 255, 1.0)");
+    let c_rgb = parse_color("rgb(0, 128, 255)");
+    match (c_rgba, c_rgb) {
+        (Some(CssValue::Color(a)), Some(CssValue::Color(b))) => {
+            assert_eq!(a.r, b.r);
+            assert_eq!(a.g, b.g);
+            assert_eq!(a.b, b.b);
+        }
+        _ => panic!("both rgba(,,,1.0) and rgb() should parse successfully"),
+    }
+}
+
+#[test]
+fn parse_color_rgba_fully_transparent() {
+    // rgba(0, 0, 0, 0.0) composited on white = white (255, 255, 255).
+    let color = parse_color("rgba(0, 0, 0, 0.0)");
+    if let Some(CssValue::Color(c)) = color {
+        assert_eq!(c.r, 255);
+        assert_eq!(c.g, 255);
+        assert_eq!(c.b, 255);
+    } else {
+        panic!("rgba(0,0,0,0) should parse to a Color");
+    }
+}
+
 #[test]
 fn line_height_bare_number_is_not_length() {
     // A bare number like `1.6` for line-height must be parsed as Number

--- a/src/parser/css/values_tests.rs
+++ b/src/parser/css/values_tests.rs
@@ -164,3 +164,38 @@ fn parse_color_invalid_inputs() {
     assert!(parse_color("#12345").is_none());
     assert!(parse_color("rgb(1,2)").is_none());
 }
+
+#[test]
+fn line_height_bare_number_is_not_length() {
+    // A bare number like `1.6` for line-height must be parsed as Number
+    // (unitless multiplier), not Length. Previously this was parsed as
+    // CssValue::Length(1.6) which caused line-height to be divided by
+    // font-size, producing tiny line heights and text overlap.
+    let val = parse_property_value("line-height", "1.6");
+    assert!(
+        matches!(val, Some(CssValue::Number(v)) if (v - 1.6).abs() < 0.001),
+        "line-height: 1.6 should be Number(1.6), got {:?}",
+        val
+    );
+
+    let val = parse_property_value("line-height", "1.8");
+    assert!(matches!(val, Some(CssValue::Number(v)) if (v - 1.8).abs() < 0.001));
+
+    let val = parse_property_value("line-height", "2");
+    assert!(matches!(val, Some(CssValue::Number(v)) if (v - 2.0).abs() < 0.001));
+
+    // Values with units should still be parsed as Length
+    let val = parse_property_value("line-height", "18pt");
+    assert!(matches!(val, Some(CssValue::Length(v)) if (v - 18.0).abs() < 0.001));
+
+    let val = parse_property_value("line-height", "24px");
+    assert!(matches!(val, Some(CssValue::Length(v)) if (v - 18.0).abs() < 0.001)); // 24 * 0.75
+
+    // em values should be Number (the em-to-number conversion)
+    let val = parse_property_value("line-height", "1.5em");
+    assert!(matches!(val, Some(CssValue::Number(v)) if (v - 1.5).abs() < 0.001));
+
+    // "normal" should be Keyword
+    let val = parse_property_value("line-height", "normal");
+    assert!(matches!(val, Some(CssValue::Keyword(ref k)) if k == "normal"));
+}

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -272,22 +272,36 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     );
                     let block_bottom = block_y - total_h;
 
-                    // Apply transform if set (wrap in q/Q)
+                    // Apply transform if set (wrap in q/Q).
+                    // Rotate and scale are applied around the element's centre so
+                    // that the element stays in its layout position (matching
+                    // CSS `transform-origin: 50% 50%`).  The combined matrix is:
+                    //   T(cx,cy) · M · T(-cx,-cy)
+                    // which in PDF `cm` notation is a single 6-value matrix.
                     let needs_transform = transform.is_some();
                     if let Some(t) = transform {
+                        // Centre of the element in PDF (bottom-up) coordinates.
+                        let cx = block_x + render_width * 0.5;
+                        let cy = block_bottom + total_h * 0.5;
                         content.push_str("q\n");
                         match t {
                             crate::style::computed::Transform::Rotate(deg) => {
                                 let rad = deg * std::f32::consts::PI / 180.0;
                                 let cos_v = rad.cos();
                                 let sin_v = rad.sin();
+                                // T(cx,cy) · Rot · T(-cx,-cy)
+                                let tx = cx - cx * cos_v + cy * sin_v;
+                                let ty = cy - cx * sin_v - cy * cos_v;
                                 content.push_str(&format!(
-                                    "{cos_v} {sin_v} {neg_sin} {cos_v} 0 0 cm\n",
+                                    "{cos_v} {sin_v} {neg_sin} {cos_v} {tx} {ty} cm\n",
                                     neg_sin = -sin_v,
                                 ));
                             }
                             crate::style::computed::Transform::Scale(sx, sy) => {
-                                content.push_str(&format!("{sx} 0 0 {sy} 0 0 cm\n",));
+                                // T(cx,cy) · Scale(sx,sy) · T(-cx,-cy)
+                                let tx = cx - cx * sx;
+                                let ty = cy - cy * sy;
+                                content.push_str(&format!("{sx} 0 0 {sy} {tx} {ty} cm\n",));
                             }
                             crate::style::computed::Transform::Translate(tx, ty) => {
                                 content.push_str(&format!("1 0 0 1 {tx} {ty} cm\n",));
@@ -4937,9 +4951,15 @@ mod tests {
         let pages = layout(&nodes, PageSize::A4, Margin::default());
         let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
         let content = String::from_utf8_lossy(&pdf);
+        // scale(2) produces "2 0 0 2 tx ty cm" where tx,ty are the centre-offset
+        // translation terms (non-zero because the block is not at the page origin).
         assert!(
-            content.contains("2 0 0 2 0 0 cm"),
-            "transform: scale(2) should produce '2 0 0 2 0 0 cm'"
+            content.contains("2 0 0 2 "),
+            "transform: scale(2) should produce '2 0 0 2 ...' cm operator"
+        );
+        assert!(
+            content.contains(" cm\n"),
+            "transform: scale(2) should produce a cm operator"
         );
     }
 
@@ -4953,6 +4973,59 @@ mod tests {
         assert!(
             content.contains("1 0 0 1 10 20 cm"),
             "transform: translate(10pt, 20pt) should produce '1 0 0 1 10 20 cm'"
+        );
+    }
+
+    /// BUG P2-2: rotate/scale transforms must be applied around the element
+    /// centre (CSS `transform-origin: 50% 50%`), not the page origin.
+    /// Previously the translation terms in the `cm` matrix were always 0,
+    /// which displaced the element off-page.
+    #[test]
+    fn render_transform_scale_centered_on_element() {
+        // A block with explicit 100pt × 20pt size, positioned at the top of
+        // the content area.  The rendered PDF matrix must be
+        //   scale_x 0 0 scale_y tx ty
+        // where tx = cx*(1-sx) and ty = cy*(1-sy) (non-zero when the element
+        // is not at the page origin).
+        let html = r#"<div style="transform: scale(2); width: 100pt; height: 20pt; background-color: blue">Box</div>"#;
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+
+        // The matrix scale values are correct.
+        assert!(
+            content.contains("2 0 0 2 "),
+            "scale(2) should produce '2 0 0 2 tx ty cm'"
+        );
+        // The translation terms must NOT both be zero — the element is not
+        // at the page origin, so the centre-based offset is non-zero.
+        assert!(
+            !content.contains("2 0 0 2 0 0 cm"),
+            "scale(2) on a non-origin element must have non-zero tx/ty in the cm matrix"
+        );
+    }
+
+    /// BUG P2-2: a rotate transform must include non-zero translation terms
+    /// so the element stays in its section instead of being displaced.
+    #[test]
+    fn render_transform_rotate_includes_translation_terms() {
+        let html = r#"<div style="transform: rotate(45deg); width: 100pt; height: 20pt; background-color: red">Rotated</div>"#;
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+
+        // cos/sin values of 45 deg must be present.
+        assert!(
+            content.contains("0.707"),
+            "rotate(45deg) must contain cos/sin ~0.707"
+        );
+        // The matrix must NOT have zero translation — the element centre
+        // is not at (0, 0) in PDF coordinates.
+        assert!(
+            !content.contains("0.70710677 0.70710677 -0.70710677 0.70710677 0 0 cm"),
+            "rotate on a non-origin element must have non-zero tx/ty in the cm matrix"
         );
     }
 

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -15,8 +15,9 @@ use crate::render::shading::{
 };
 use crate::render::svg_geometry::SvgViewportBox;
 use crate::style::computed::{
-    BackgroundOrigin, BackgroundPosition, BackgroundRepeat, BackgroundSize, BorderCollapse, Float,
-    FontFamily, LinearGradient, Position, RadialGradient, TextAlign, VerticalAlign,
+    BackgroundOrigin, BackgroundPosition, BackgroundRepeat, BackgroundSize, BorderCollapse,
+    BorderStyle, Float, FontFamily, LinearGradient, Position, RadialGradient, TextAlign,
+    VerticalAlign,
 };
 use crate::types::{Margin, PageSize};
 use std::collections::HashMap;
@@ -35,6 +36,23 @@ use layout_elements::{
     render_cell_text, render_nested_layout_elements, render_nested_text_block,
     table_row_total_height,
 };
+
+/// Returns the PDF dash-pattern operator string for a given border style.
+fn dash_pattern_for_style(style: BorderStyle) -> &'static str {
+    match style {
+        BorderStyle::Dashed => "[6 4] 0 d\n",
+        BorderStyle::Dotted => "[1 3] 0 d\n",
+        _ => "",
+    }
+}
+
+/// Reset the dash pattern back to solid after a dashed/dotted stroke.
+fn reset_dash_pattern(style: BorderStyle) -> &'static str {
+    match style {
+        BorderStyle::Dashed | BorderStyle::Dotted => "[] 0 d\n",
+        _ => "",
+    }
+}
 
 /// A link annotation to be placed on a PDF page.
 struct LinkAnnotation {
@@ -472,9 +490,13 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             && border.top.width == border.left.width
                             && border.top.color == border.right.color
                             && border.top.color == border.bottom.color
-                            && border.top.color == border.left.color;
+                            && border.top.color == border.left.color
+                            && border.top.style == border.right.style
+                            && border.top.style == border.bottom.style
+                            && border.top.style == border.left.style;
                         if uniform && *border_radius > 0.0 {
                             let (br, bg, bb) = border.top.color;
+                            content.push_str(dash_pattern_for_style(border.top.style));
                             content.push_str(&format!(
                                 "{br} {bg} {bb} RG\n{bw} w\n",
                                 bw = border.top.width
@@ -487,8 +509,10 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                 *border_radius,
                             ));
                             content.push_str("S\n");
+                            content.push_str(reset_dash_pattern(border.top.style));
                         } else if uniform {
                             let (br, bg, bb) = border.top.color;
+                            content.push_str(dash_pattern_for_style(border.top.style));
                             content.push_str(&format!(
                                 "{br} {bg} {bb} RG\n{bw} w\n",
                                 bw = border.top.width
@@ -501,6 +525,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                 h = total_h,
                             ));
                             content.push_str("S\n");
+                            content.push_str(reset_dash_pattern(border.top.style));
                         } else {
                             let x1 = block_x;
                             let x2 = block_x + render_width;
@@ -513,13 +538,16 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             // Top border
                             if border.top.width > 0.0 {
                                 let (r, g, b) = border.top.color;
+                                content.push_str(dash_pattern_for_style(border.top.style));
                                 content
                                     .push_str(&format!("{r} {g} {b} RG\n{} w\n", border.top.width));
                                 content.push_str(&format!("{x1} {y_top} m {x2} {y_top} l S\n"));
+                                content.push_str(reset_dash_pattern(border.top.style));
                             }
                             // Right border
                             if border.right.width > 0.0 {
                                 let (r, g, b) = border.right.color;
+                                content.push_str(dash_pattern_for_style(border.right.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n",
                                     border.right.width
@@ -527,20 +555,24 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                 content.push_str(&format!(
                                     "{x_right} {y_top} m {x_right} {y_bottom} l S\n"
                                 ));
+                                content.push_str(reset_dash_pattern(border.right.style));
                             }
                             // Bottom border
                             if border.bottom.width > 0.0 {
                                 let (r, g, b) = border.bottom.color;
+                                content.push_str(dash_pattern_for_style(border.bottom.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n",
                                     border.bottom.width
                                 ));
                                 content
                                     .push_str(&format!("{x1} {y_bottom} m {x2} {y_bottom} l S\n"));
+                                content.push_str(reset_dash_pattern(border.bottom.style));
                             }
                             // Left border
                             if border.left.width > 0.0 {
                                 let (r, g, b) = border.left.color;
+                                content.push_str(dash_pattern_for_style(border.left.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n",
                                     border.left.width
@@ -548,6 +580,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                 content.push_str(&format!(
                                     "{x_left} {y_top} m {x_left} {y_bottom} l S\n"
                                 ));
+                                content.push_str(reset_dash_pattern(border.left.style));
                             }
                         }
                     }
@@ -825,31 +858,39 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             let y_bottom = row_y - cell_height;
                             if cell.border.top.width > 0.0 {
                                 let (r, g, b) = cell.border.top.color;
+                                content.push_str(dash_pattern_for_style(cell.border.top.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n{x1} {y_top} m {x2} {y_top} l S\n",
                                     cell.border.top.width
                                 ));
+                                content.push_str(reset_dash_pattern(cell.border.top.style));
                             }
                             if cell.border.right.width > 0.0 {
                                 let (r, g, b) = cell.border.right.color;
+                                content.push_str(dash_pattern_for_style(cell.border.right.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n{x2} {y_top} m {x2} {y_bottom} l S\n",
                                     cell.border.right.width
                                 ));
+                                content.push_str(reset_dash_pattern(cell.border.right.style));
                             }
                             if cell.border.bottom.width > 0.0 {
                                 let (r, g, b) = cell.border.bottom.color;
+                                content.push_str(dash_pattern_for_style(cell.border.bottom.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n{x1} {y_bottom} m {x2} {y_bottom} l S\n",
                                     cell.border.bottom.width
                                 ));
+                                content.push_str(reset_dash_pattern(cell.border.bottom.style));
                             }
                             if cell.border.left.width > 0.0 {
                                 let (r, g, b) = cell.border.left.color;
+                                content.push_str(dash_pattern_for_style(cell.border.left.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n{x1} {y_top} m {x1} {y_bottom} l S\n",
                                     cell.border.left.width
                                 ));
+                                content.push_str(reset_dash_pattern(cell.border.left.style));
                             }
                         }
 
@@ -1129,9 +1170,13 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             && border.top.width == border.left.width
                             && border.top.color == border.right.color
                             && border.top.color == border.bottom.color
-                            && border.top.color == border.left.color;
+                            && border.top.color == border.left.color
+                            && border.top.style == border.right.style
+                            && border.top.style == border.bottom.style
+                            && border.top.style == border.left.style;
                         if uniform && *border_radius > 0.0 {
                             let (r, g, b) = border.top.color;
+                            content.push_str(dash_pattern_for_style(border.top.style));
                             content.push_str(&format!(
                                 "{r} {g} {b} RG\n{bw} w\n",
                                 bw = border.top.width
@@ -1144,14 +1189,17 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                 *border_radius,
                             ));
                             content.push_str("S\n");
+                            content.push_str(reset_dash_pattern(border.top.style));
                         } else if uniform {
                             let (r, g, b) = border.top.color;
+                            content.push_str(dash_pattern_for_style(border.top.style));
                             content.push_str(&format!(
                                 "{r} {g} {b} RG\n{bw} w\n{bx} {by} {w} {h} re\nS\n",
                                 bw = border.top.width,
                                 w = container_width,
                                 h = full_height,
                             ));
+                            content.push_str(reset_dash_pattern(border.top.style));
                         } else {
                             let x1 = bx;
                             let x2 = bx + container_width;
@@ -1159,31 +1207,39 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             let y_bottom = by;
                             if border.top.width > 0.0 {
                                 let (r, g, b) = border.top.color;
+                                content.push_str(dash_pattern_for_style(border.top.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n{x1} {y_top} m {x2} {y_top} l S\n",
                                     border.top.width
                                 ));
+                                content.push_str(reset_dash_pattern(border.top.style));
                             }
                             if border.right.width > 0.0 {
                                 let (r, g, b) = border.right.color;
+                                content.push_str(dash_pattern_for_style(border.right.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n{x2} {y_top} m {x2} {y_bottom} l S\n",
                                     border.right.width
                                 ));
+                                content.push_str(reset_dash_pattern(border.right.style));
                             }
                             if border.bottom.width > 0.0 {
                                 let (r, g, b) = border.bottom.color;
+                                content.push_str(dash_pattern_for_style(border.bottom.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n{x1} {y_bottom} m {x2} {y_bottom} l S\n",
                                     border.bottom.width
                                 ));
+                                content.push_str(reset_dash_pattern(border.bottom.style));
                             }
                             if border.left.width > 0.0 {
                                 let (r, g, b) = border.left.color;
+                                content.push_str(dash_pattern_for_style(border.left.style));
                                 content.push_str(&format!(
                                     "{r} {g} {b} RG\n{} w\n{x1} {y_top} m {x1} {y_bottom} l S\n",
                                     border.left.width
                                 ));
+                                content.push_str(reset_dash_pattern(border.left.style));
                             }
                         }
                     }
@@ -4319,6 +4375,68 @@ mod tests {
     }
 
     #[test]
+    fn render_dashed_border_emits_dash_pattern() {
+        let html = r#"<div style="border: 2px dashed black; width: 100pt">Dashed</div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("[6 4] 0 d"),
+            "Dashed border should emit [6 4] 0 d dash pattern. Got: {}",
+            &content[..content.len().min(2000)]
+        );
+        assert!(
+            content.contains("[] 0 d"),
+            "Dashed border should reset dash pattern with [] 0 d"
+        );
+    }
+
+    #[test]
+    fn render_dotted_border_emits_dash_pattern() {
+        let html = r#"<div style="border: 2px dotted red; width: 100pt">Dotted</div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("[1 3] 0 d"),
+            "Dotted border should emit [1 3] 0 d dash pattern"
+        );
+    }
+
+    #[test]
+    fn render_solid_border_no_dash_pattern() {
+        let html = r#"<div style="border: 2px solid black; width: 100pt">Solid</div>"#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        // Solid borders should NOT have dash patterns
+        assert!(
+            !content.contains("[6 4] 0 d") && !content.contains("[1 3] 0 d"),
+            "Solid border should not emit dash patterns"
+        );
+    }
+
+    #[test]
+    fn border_style_parsed_from_shorthand() {
+        use crate::parser::dom::HtmlTag;
+        use crate::style::computed::ComputedStyle;
+        use crate::style::computed::{BorderStyle, compute_style_with_context};
+        let parent = ComputedStyle::default();
+        let style = crate::style::computed::compute_style(
+            HtmlTag::Div,
+            Some("border: 2px dashed red"),
+            &parent,
+        );
+        assert_eq!(style.border.top.style, BorderStyle::Dashed);
+        assert_eq!(style.border.right.style, BorderStyle::Dashed);
+        assert_eq!(style.border.bottom.style, BorderStyle::Dashed);
+        assert_eq!(style.border.left.style, BorderStyle::Dashed);
+    }
+
+    #[test]
     fn render_times_roman_font_family() {
         let html = r#"<p style="font-family: serif">Serif text</p>"#;
         let nodes = parse_html(html).unwrap();
@@ -7073,18 +7191,22 @@ mod tests {
         border.top = crate::layout::engine::LayoutBorderSide {
             width: 1.0,
             color: (1.0, 0.0, 0.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.right = crate::layout::engine::LayoutBorderSide {
             width: 1.0,
             color: (0.0, 1.0, 0.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.bottom = crate::layout::engine::LayoutBorderSide {
             width: 1.0,
             color: (0.0, 0.0, 1.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.left = crate::layout::engine::LayoutBorderSide {
             width: 1.0,
             color: (0.0, 0.0, 0.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         render_nested_text_block(
             &mut content,
@@ -7158,6 +7280,7 @@ mod tests {
         border.top = crate::layout::engine::LayoutBorderSide {
             width: 2.0,
             color: (1.0, 0.0, 0.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         render_nested_text_block(
             &mut content,
@@ -7234,18 +7357,22 @@ mod tests {
         border.top = crate::layout::engine::LayoutBorderSide {
             width: 2.0,
             color: (0.0, 0.0, 0.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.bottom = crate::layout::engine::LayoutBorderSide {
             width: 2.0,
             color: (0.0, 0.0, 0.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.left = crate::layout::engine::LayoutBorderSide {
             width: 2.0,
             color: (0.0, 0.0, 0.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.right = crate::layout::engine::LayoutBorderSide {
             width: 2.0,
             color: (0.0, 0.0, 0.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         let lines = vec![test_text_line(vec![test_text_run("SvgBorder")])];
         let mut content = String::new();
@@ -7613,18 +7740,22 @@ mod tests {
         border.top = LayoutBorderSide {
             width: 1.0,
             color: (0.0, 0.0, 1.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.right = LayoutBorderSide {
             width: 1.0,
             color: (0.0, 0.0, 1.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.bottom = LayoutBorderSide {
             width: 1.0,
             color: (0.0, 0.0, 1.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         border.left = LayoutBorderSide {
             width: 1.0,
             color: (0.0, 0.0, 1.0),
+            style: crate::style::computed::BorderStyle::Solid,
         };
         let cell = TableCell {
             lines: vec![TextLine {

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -413,31 +413,39 @@ pub(super) fn render_nested_text_block(
         let y_bottom = block_bottom;
         if block.border.top.width > 0.0 {
             let (r, g, b) = block.border.top.color;
+            content.push_str(dash_pattern_for_style(block.border.top.style));
             content.push_str(&format!(
                 "{r} {g} {b} RG\n{} w\n{x1} {y_top} m {x2} {y_top} l S\n",
                 block.border.top.width
             ));
+            content.push_str(reset_dash_pattern(block.border.top.style));
         }
         if block.border.right.width > 0.0 {
             let (r, g, b) = block.border.right.color;
+            content.push_str(dash_pattern_for_style(block.border.right.style));
             content.push_str(&format!(
                 "{r} {g} {b} RG\n{} w\n{x2} {y_top} m {x2} {y_bottom} l S\n",
                 block.border.right.width
             ));
+            content.push_str(reset_dash_pattern(block.border.right.style));
         }
         if block.border.bottom.width > 0.0 {
             let (r, g, b) = block.border.bottom.color;
+            content.push_str(dash_pattern_for_style(block.border.bottom.style));
             content.push_str(&format!(
                 "{r} {g} {b} RG\n{} w\n{x1} {y_bottom} m {x2} {y_bottom} l S\n",
                 block.border.bottom.width
             ));
+            content.push_str(reset_dash_pattern(block.border.bottom.style));
         }
         if block.border.left.width > 0.0 {
             let (r, g, b) = block.border.left.color;
+            content.push_str(dash_pattern_for_style(block.border.left.style));
             content.push_str(&format!(
                 "{r} {g} {b} RG\n{} w\n{x1} {y_top} m {x1} {y_bottom} l S\n",
                 block.border.left.width
             ));
+            content.push_str(reset_dash_pattern(block.border.left.style));
         }
     }
 

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -450,11 +450,22 @@ pub struct BoxShadow {
     pub color: Color,
 }
 
-/// A single border side with width and color.
+/// Border line style.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BorderStyle {
+    #[default]
+    Solid,
+    Dashed,
+    Dotted,
+    None,
+}
+
+/// A single border side with width, color, and style.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct BorderSide {
     pub width: f32,
     pub color: Option<Color>,
+    pub style: BorderStyle,
 }
 
 /// Per-side border specification.
@@ -469,7 +480,24 @@ pub struct BorderSides {
 #[allow(dead_code)]
 impl BorderSides {
     pub fn uniform(width: f32, color: Option<Color>) -> Self {
-        let side = BorderSide { width, color };
+        let side = BorderSide {
+            width,
+            color,
+            style: BorderStyle::Solid,
+        };
+        Self {
+            top: side,
+            right: side,
+            bottom: side,
+            left: side,
+        }
+    }
+    pub fn uniform_styled(width: f32, color: Option<Color>, style: BorderStyle) -> Self {
+        let side = BorderSide {
+            width,
+            color,
+            style,
+        };
         Self {
             top: side,
             right: side,
@@ -1571,40 +1599,56 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
 
     // Border shorthand: "1px solid black"
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "border") {
-        let (w, c) = parse_border_shorthand(k);
-        style.border = BorderSides::uniform(w, c);
+        let (w, c, bs) = parse_border_shorthand(k);
+        style.border = BorderSides::uniform_styled(w, c, bs);
     }
 
     // Per-side border shorthands
     for (prop, setter) in &[
         (
             "border-top",
-            (|s: &mut ComputedStyle, w, c| {
-                s.border.top = BorderSide { width: w, color: c };
-            }) as fn(&mut ComputedStyle, f32, Option<Color>),
+            (|s: &mut ComputedStyle, w, c, bs| {
+                s.border.top = BorderSide {
+                    width: w,
+                    color: c,
+                    style: bs,
+                };
+            }) as fn(&mut ComputedStyle, f32, Option<Color>, BorderStyle),
         ),
         (
             "border-right",
-            (|s: &mut ComputedStyle, w, c| {
-                s.border.right = BorderSide { width: w, color: c };
-            }) as fn(&mut ComputedStyle, f32, Option<Color>),
+            (|s: &mut ComputedStyle, w, c, bs| {
+                s.border.right = BorderSide {
+                    width: w,
+                    color: c,
+                    style: bs,
+                };
+            }) as fn(&mut ComputedStyle, f32, Option<Color>, BorderStyle),
         ),
         (
             "border-bottom",
-            (|s: &mut ComputedStyle, w, c| {
-                s.border.bottom = BorderSide { width: w, color: c };
-            }) as fn(&mut ComputedStyle, f32, Option<Color>),
+            (|s: &mut ComputedStyle, w, c, bs| {
+                s.border.bottom = BorderSide {
+                    width: w,
+                    color: c,
+                    style: bs,
+                };
+            }) as fn(&mut ComputedStyle, f32, Option<Color>, BorderStyle),
         ),
         (
             "border-left",
-            (|s: &mut ComputedStyle, w, c| {
-                s.border.left = BorderSide { width: w, color: c };
-            }) as fn(&mut ComputedStyle, f32, Option<Color>),
+            (|s: &mut ComputedStyle, w, c, bs| {
+                s.border.left = BorderSide {
+                    width: w,
+                    color: c,
+                    style: bs,
+                };
+            }) as fn(&mut ComputedStyle, f32, Option<Color>, BorderStyle),
         ),
     ] {
         if let Some(CssValue::Keyword(k)) = get_non_special(map, prop) {
-            let (w, c) = parse_border_shorthand(k);
-            setter(style, w, c);
+            let (w, c, bs) = parse_border_shorthand(k);
+            setter(style, w, c, bs);
         }
     }
 
@@ -2824,10 +2868,11 @@ fn find_matching_paren(s: &str, start: usize) -> Option<usize> {
     None
 }
 
-/// Parse a border shorthand string like "1px solid black" into (width_pt, Option<Color>).
-fn parse_border_shorthand(k: &str) -> (f32, Option<Color>) {
+/// Parse a border shorthand string like "1px solid black" into (width_pt, Option<Color>, BorderStyle).
+fn parse_border_shorthand(k: &str) -> (f32, Option<Color>, BorderStyle) {
     let parts: Vec<&str> = k.split_whitespace().collect();
     let mut width = 0.0f32;
+    let mut border_style = BorderStyle::Solid;
     for part in &parts {
         if let Some(n) = part.strip_suffix("px") {
             if let Ok(v) = n.parse::<f32>() {
@@ -2837,10 +2882,18 @@ fn parse_border_shorthand(k: &str) -> (f32, Option<Color>) {
             if let Ok(v) = n.parse::<f32>() {
                 width = v;
             }
+        } else {
+            match *part {
+                "dashed" => border_style = BorderStyle::Dashed,
+                "dotted" => border_style = BorderStyle::Dotted,
+                "none" => border_style = BorderStyle::None,
+                "solid" => border_style = BorderStyle::Solid,
+                _ => {}
+            }
         }
     }
     let color = parts.last().and_then(|last| parse_border_color(last));
-    (width, color)
+    (width, color, border_style)
 }
 
 /// Parse a color name or hex value for border shorthand.
@@ -7521,6 +7574,7 @@ mod tests {
         parent.border.top = BorderSide {
             width: 1.0,
             color: Some(Color::rgb(0, 0, 0)),
+            style: BorderStyle::Solid,
         };
         let style = compute_style(HtmlTag::Span, None, &parent);
         assert!((style.border.top.width).abs() < 0.01);
@@ -7536,18 +7590,22 @@ mod tests {
             top: BorderSide {
                 width: 3.0,
                 color: None,
+                style: BorderStyle::Solid,
             },
             right: BorderSide {
                 width: 5.0,
                 color: None,
+                style: BorderStyle::Solid,
             },
             bottom: BorderSide {
                 width: 2.0,
                 color: None,
+                style: BorderStyle::Solid,
             },
             left: BorderSide {
                 width: 4.0,
                 color: None,
+                style: BorderStyle::Solid,
             },
         };
         assert!((b.max_width() - 5.0).abs() < 0.01);


### PR DESCRIPTION
## Summary

Restores math rendering lost in the Chromium parity merge, adds a 3-layer parity test framework with Chromium visual comparison, and fixes 12 layout/rendering bugs identified through the parity audit.

### Math Rendering
- Restored `MathBlock` variant removed during Chromium parity merge
- LaTeX inline/display math works again (`$E=mc^2$`, `$$\frac{a}{b}$$`)
- Symbol font rendering, radical signs, delimiters, fraction bars
- Removed `#[cfg(test)]` gates on math parser/layout modules

### Parity Test Framework
- **24 HTML fixtures** across 3 layers: Features (12), Combined (6), Edge Cases (6)
- **24 semantic expectation JSONs** with PDF operator/text assertions, size bounds, page counts
- **Chromium visual comparison**: CI generates reference PDFs via `--print-to-pdf`, pixel diffs via ImageMagick
- **Parity dashboard** at `/parity` on GitHub Pages — 3-panel view (Chromium / ironpress / diff) per fixture
- **CI benchmark job** posts performance table + visual parity report on every PR
- **Baseline persistence** (`baseline.json`) with size/time delta tracking

### Bug Fixes (12)

**P0 — Critical**
| Fix | Root Cause |
|-----|-----------|
| Text superposition | `line-height: 1.6` (bare number) parsed as `Length` then divided by font-size → 0.13 line height. Fixed to emit `Number` |
| position:absolute | Elements at page origin instead of containing block. Threaded `abs_containing_block` through flatten_element |

**P1 — Important**
| Fix | Root Cause |
|-----|-----------|
| justify-content | Rounding fallback consumed all free space before justify logic ran. Removed |
| flex-grow default | Items filled container width. Now shrink-wrap to content via `measure_runs_width` |
| CSS counters | `CounterState::default()` always passed to pseudo builders. Threaded live state through layout chain |
| Dashed/dotted borders | No `BorderStyle` enum, no PDF dash patterns. Added `[6 4] 0 d` / `[1 3] 0 d` |

**P2 — Visual**
| Fix | Root Cause |
|-----|-----------|
| rgba() backgrounds | `parse_color` only handled `rgb()`. Added `rgba()` with alpha compositing against white |
| Transform positioning | `cm` matrix applied around page origin. Now uses `T(cx,cy)·M·T(-cx,-cy)` for element center |
| Flex column gap | Gap not added to `margin_top` of non-first items in column direction |
| Diff images grey | ImageMagick compare failed on dimension mismatch. Force-resize both + composite fallback |

### Version
- Bump to 1.3.2

## Test plan
- [x] `cargo test` — 2148 tests pass (2068 lib + 24 parity + 56 other)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Visual comparison on parity dashboard after deploy
- [ ] Math rendering verification in playground

Co-Authored-By: Frédéric Nieto <wicpar@users.noreply.github.com>