### PR TITLE
fix: inline-block elements no longer broken by whitespace text nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ getrandom = { version = "0.3", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 proptest = "1"
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 serde_json = "1"
 
 [[bench]]

--- a/scripts/generate-references.sh
+++ b/scripts/generate-references.sh
@@ -38,10 +38,12 @@ for layer in features combined edge-cases; do
         "$CHROME" --headless=new --disable-gpu --no-sandbox --disable-software-rasterizer \
             --print-to-pdf="$ref_pdf" \
             --no-pdf-header-footer \
+            --no-margins \
             "file://$html_file" 2>/dev/null || \
         "$CHROME" --headless --disable-gpu --no-sandbox \
             --print-to-pdf="$ref_pdf" \
             --no-pdf-header-footer \
+            --no-margins \
             "file://$html_file" 2>/dev/null || {
             echo "    WARN: failed to render $layer/$name"
             continue

--- a/scripts/render-fixtures.sh
+++ b/scripts/render-fixtures.sh
@@ -25,7 +25,7 @@ for layer in features combined edge-cases; do
         name=$(basename "$html_file" .html)
         output="$OUTPUT_DIR/$layer/$name.pdf"
         echo "  $layer/$name..."
-        "$CLI" "$html_file" "$output" 2>/dev/null || echo "    WARN: failed to render $layer/$name"
+        "$CLI" --margin 0 "$html_file" "$output" 2>/dev/null || echo "    WARN: failed to render $layer/$name"
     done
 done
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -114,6 +114,284 @@ fn collects_as_inline_text(tag: HtmlTag) -> bool {
     tag != HtmlTag::Svg && tag.is_inline()
 }
 
+/// Check if an element computes to `display: inline-block` given parent style and CSS rules.
+fn element_is_inline_block(
+    el: &ElementNode,
+    parent_style: &ComputedStyle,
+    rules: &[CssRule],
+    ancestors: &[AncestorInfo],
+    child_index: usize,
+    sibling_count: usize,
+    preceding_siblings: &[(String, Vec<String>)],
+) -> bool {
+    let classes = el.class_list();
+    let selector_ctx = SelectorContext {
+        ancestors: ancestors.to_vec(),
+        child_index,
+        sibling_count,
+        preceding_siblings: preceding_siblings.to_vec(),
+    };
+    let style = compute_style_with_context(
+        el.tag,
+        el.style_attr(),
+        parent_style,
+        rules,
+        el.tag_name(),
+        &classes,
+        el.id(),
+        &el.attributes,
+        &selector_ctx,
+    );
+    style.display == Display::InlineBlock
+}
+
+/// Emit a `FlexRow` for a group of consecutive `display: inline-block` elements.
+///
+/// Each element is laid out independently into its own buffer, then positioned
+/// horizontally in a row, similar to how `flatten_flex_container` works.
+#[allow(clippy::too_many_arguments)]
+fn flush_inline_block_group(
+    elements: &[&ElementNode],
+    parent_style: &ComputedStyle,
+    available_width: f32,
+    available_height: f32,
+    output: &mut Vec<LayoutElement>,
+    rules: &[CssRule],
+    ancestors: &[AncestorInfo],
+    positioned_ancestor_depth: usize,
+    fonts: &HashMap<String, TtfFont>,
+    counter_state: &mut CounterState,
+) {
+    if elements.is_empty() {
+        return;
+    }
+
+    // Lay out each inline-block element as a block to measure its size
+    struct InlineBlockItem {
+        width: f32,
+        height: f32,
+        lines: Vec<TextLine>,
+        background_color: Option<(f32, f32, f32, f32)>,
+        padding_top: f32,
+        padding_right: f32,
+        padding_bottom: f32,
+        padding_left: f32,
+        border_radius: f32,
+        background_gradient: Option<LinearGradient>,
+        background_radial_gradient: Option<RadialGradient>,
+        background_svg: Option<crate::parser::svg::SvgTree>,
+        background_blur_radius: f32,
+        background_size: BackgroundSize,
+        background_position: BackgroundPosition,
+        background_repeat: BackgroundRepeat,
+        background_origin: BackgroundOrigin,
+        text_align: TextAlign,
+        margin_left: f32,
+        margin_right: f32,
+    }
+
+    let mut items: Vec<InlineBlockItem> = Vec::new();
+    let child_count = elements.len();
+
+    for (idx, child_el) in elements.iter().enumerate() {
+        let classes = child_el.class_list();
+        let selector_ctx = SelectorContext {
+            ancestors: ancestors.to_vec(),
+            child_index: idx,
+            sibling_count: child_count,
+            preceding_siblings: Vec::new(),
+        };
+        let child_style = compute_style_with_context(
+            child_el.tag,
+            child_el.style_attr(),
+            parent_style,
+            rules,
+            child_el.tag_name(),
+            &classes,
+            child_el.id(),
+            &child_el.attributes,
+            &selector_ctx,
+        );
+
+        if child_style.display == Display::None {
+            continue;
+        }
+
+        // Determine the element width
+        let child_w = child_style.width.unwrap_or(0.0);
+        let child_h = child_style.height.unwrap_or(0.0);
+
+        let inner_width = if child_style.box_sizing == BoxSizing::BorderBox {
+            child_w - child_style.padding.left - child_style.padding.right
+                - child_style.border.horizontal_width()
+        } else {
+            child_w
+        };
+        let inner_width = inner_width.max(0.0);
+
+        // Collect text runs from the inline-block element's children
+        let mut child_ancestors = ancestors.to_vec();
+        child_ancestors.push(AncestorInfo {
+            element: child_el,
+            child_index: idx,
+            sibling_count: child_count,
+            preceding_siblings: Vec::new(),
+        });
+        let mut runs = Vec::new();
+        FlexTextRunCollector {
+            runs: &mut runs,
+            rules,
+            fonts,
+        }
+        .collect(
+            &child_el.children,
+            &child_style,
+            None,
+            (0.0, 0.0),
+            &child_ancestors,
+        );
+
+        let lines = if !runs.is_empty() {
+            wrap_text_runs(
+                runs,
+                TextWrapOptions::new(
+                    inner_width.max(1.0),
+                    child_style.font_size,
+                    resolved_line_height_factor(&child_style, fonts),
+                    child_style.overflow_wrap,
+                ),
+                fonts,
+            )
+        } else {
+            Vec::new()
+        };
+
+        // Total element width including padding + border
+        let total_w = if child_style.box_sizing == BoxSizing::BorderBox {
+            child_w
+        } else {
+            child_w
+                + child_style.padding.left
+                + child_style.padding.right
+                + child_style.border.horizontal_width()
+        };
+
+        // Total element height including padding + border
+        let text_height: f32 = lines.iter().map(|l| l.height).sum();
+        let content_h = if child_h > 0.0 { child_h } else { text_height };
+        let total_h = if child_style.box_sizing == BoxSizing::BorderBox {
+            content_h.max(child_h)
+        } else {
+            content_h
+                + child_style.padding.top
+                + child_style.padding.bottom
+                + child_style.border.vertical_width()
+        };
+
+        let bg = child_style
+            .background_color
+            .map(|c: crate::types::Color| c.to_f32_rgba());
+        let bg_fields = BackgroundFields::from_style(&child_style);
+
+        items.push(InlineBlockItem {
+            width: total_w,
+            height: total_h,
+            lines,
+            background_color: bg,
+            padding_top: child_style.padding.top,
+            padding_right: child_style.padding.right,
+            padding_bottom: child_style.padding.bottom,
+            padding_left: child_style.padding.left,
+            border_radius: child_style.border_radius,
+            background_gradient: bg_fields.gradient,
+            background_radial_gradient: bg_fields.radial_gradient,
+            background_svg: bg_fields.svg,
+            background_blur_radius: bg_fields.blur_radius,
+            background_size: bg_fields.size,
+            background_position: bg_fields.position,
+            background_repeat: bg_fields.repeat,
+            background_origin: bg_fields.origin,
+            text_align: child_style.text_align,
+            margin_left: child_style.margin.left,
+            margin_right: child_style.margin.right,
+        });
+    }
+
+    if items.is_empty() {
+        return;
+    }
+
+    // Position items horizontally, wrapping to new rows when they exceed available width
+    let mut rows: Vec<(Vec<FlexCell>, f32)> = Vec::new(); // (cells, row_height)
+    let mut current_cells: Vec<FlexCell> = Vec::new();
+    let mut x = 0.0f32;
+    let mut row_height = 0.0f32;
+
+    for item in &items {
+        let item_total_w = item.margin_left + item.width + item.margin_right;
+        // Wrap to new row if this item would overflow
+        if !current_cells.is_empty() && x + item_total_w > available_width + 0.01 {
+            rows.push((std::mem::take(&mut current_cells), row_height));
+            x = 0.0;
+            row_height = 0.0;
+        }
+
+        x += item.margin_left;
+        current_cells.push(FlexCell {
+            lines: item.lines.clone(),
+            x_offset: x,
+            width: item.width,
+            text_align: item.text_align,
+            background_color: item.background_color,
+            padding_top: item.padding_top,
+            padding_right: item.padding_right,
+            padding_bottom: item.padding_bottom,
+            padding_left: item.padding_left,
+            border_radius: item.border_radius,
+            background_gradient: item.background_gradient.clone(),
+            background_radial_gradient: item.background_radial_gradient.clone(),
+            background_svg: item.background_svg.clone(),
+            background_blur_radius: item.background_blur_radius,
+            background_size: item.background_size,
+            background_position: item.background_position,
+            background_repeat: item.background_repeat,
+            background_origin: item.background_origin,
+        });
+        x += item.width + item.margin_right;
+        row_height = row_height.max(item.height);
+    }
+    // Flush last row
+    if !current_cells.is_empty() {
+        rows.push((current_cells, row_height));
+    }
+
+    for (cells, rh) in rows {
+        output.push(LayoutElement::FlexRow {
+            cells,
+            row_height: rh,
+            margin_top: 0.0,
+            margin_bottom: 0.0,
+            background_color: None,
+            container_width: available_width,
+            padding_top: 0.0,
+            padding_bottom: 0.0,
+            padding_left: 0.0,
+            padding_right: 0.0,
+            border: LayoutBorder::default(),
+            border_radius: 0.0,
+            box_shadow: None,
+            background_gradient: None,
+            background_radial_gradient: None,
+            background_svg: None,
+            background_blur_radius: 0.0,
+            background_size: BackgroundSize::Auto,
+            background_position: BackgroundPosition::default(),
+            background_repeat: BackgroundRepeat::Repeat,
+            background_origin: BackgroundOrigin::Padding,
+        });
+    }
+}
+
 /// Counter state for CSS counters.
 #[derive(Debug, Default, Clone)]
 #[allow(dead_code)]
@@ -1134,10 +1412,63 @@ fn flatten_nodes(
     let mut element_index = 0;
     let mut preceding_siblings: Vec<(String, Vec<String>)> = Vec::new();
 
+    // Accumulator for consecutive inline-block elements
+    let mut ib_group: Vec<&ElementNode> = Vec::new();
+
+    // Helper closure-like macro for flushing an inline-block group.
+    // We use a nested fn instead since closures can't borrow multiple fields.
+    #[inline]
+    fn flush_ib(
+        group: &mut Vec<&ElementNode>,
+        parent_style: &ComputedStyle,
+        available_width: f32,
+        available_height: f32,
+        output: &mut Vec<LayoutElement>,
+        rules: &[CssRule],
+        ancestors: &[AncestorInfo],
+        positioned_ancestor_depth: usize,
+        fonts: &HashMap<String, TtfFont>,
+        counter_state: &mut CounterState,
+    ) {
+        if group.is_empty() {
+            return;
+        }
+        let taken: Vec<&ElementNode> = group.drain(..).collect();
+        flush_inline_block_group(
+            &taken,
+            parent_style,
+            available_width,
+            available_height,
+            output,
+            rules,
+            ancestors,
+            positioned_ancestor_depth,
+            fonts,
+            counter_state,
+        );
+    }
+
     for node in nodes {
         match node {
             DomNode::Text(text) => {
                 let trimmed = collapse_whitespace(text);
+                // Only flush inline-block group for non-whitespace text.
+                // Whitespace between consecutive inline-block elements must
+                // not break the group — they should stay on the same row.
+                if !trimmed.is_empty() {
+                    flush_ib(
+                        &mut ib_group,
+                        parent_style,
+                        available_width,
+                        available_height,
+                        output,
+                        list_ctx.map(|_| rules).unwrap_or(rules),
+                        ancestors,
+                        positioned_ancestor_depth,
+                        fonts,
+                        counter_state,
+                    );
+                }
                 if !trimmed.is_empty() {
                     let mut text_runs = Vec::new();
                     push_text_run_with_fallback(
@@ -1219,23 +1550,49 @@ fn flatten_nodes(
                 }
             }
             DomNode::Element(el) => {
-                flatten_element(
+                // Check if this element is inline-block
+                if element_is_inline_block(
                     el,
                     parent_style,
-                    available_width,
-                    available_height,
-                    output,
-                    list_ctx,
                     rules,
                     ancestors,
-                    positioned_ancestor_depth,
                     element_index,
                     element_count,
                     &preceding_siblings,
-                    fonts,
-                    abs_containing_block,
-                    counter_state,
-                );
+                ) {
+                    ib_group.push(el);
+                } else {
+                    // Flush any pending inline-block group
+                    flush_ib(
+                        &mut ib_group,
+                        parent_style,
+                        available_width,
+                        available_height,
+                        output,
+                        rules,
+                        ancestors,
+                        positioned_ancestor_depth,
+                        fonts,
+                        counter_state,
+                    );
+                    flatten_element(
+                        el,
+                        parent_style,
+                        available_width,
+                        available_height,
+                        output,
+                        list_ctx,
+                        rules,
+                        ancestors,
+                        positioned_ancestor_depth,
+                        element_index,
+                        element_count,
+                        &preceding_siblings,
+                        fonts,
+                        abs_containing_block,
+                        counter_state,
+                    );
+                }
                 // Track this element as a preceding sibling for the next element
                 preceding_siblings.push((
                     el.tag_name().to_string(),
@@ -1245,6 +1602,19 @@ fn flatten_nodes(
             }
         }
     }
+    // Flush any remaining inline-block group at end of nodes
+    flush_ib(
+        &mut ib_group,
+        parent_style,
+        available_width,
+        available_height,
+        output,
+        rules,
+        ancestors,
+        positioned_ancestor_depth,
+        fonts,
+        counter_state,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2171,7 +2541,7 @@ fn flatten_element(
         }
     }
 
-    if style.display == Display::Block {
+    if style.display == Display::Block || style.display == Display::InlineBlock {
         // Compute effective block width considering CSS width/max-width/min-width
         let mut block_w = available_width;
         if let Some(w) = style.width {
@@ -2616,29 +2986,77 @@ fn flatten_element(
             // Pre-flatten children to measure total height
             let mut child_elements = Vec::new();
             let mut child_el_idx = 0;
+            let mut ib_group_wrapper: Vec<&ElementNode> = Vec::new();
             for child in &el.children {
                 if let DomNode::Element(child_el) = child {
-                    if recurses_as_layout_child(child_el.tag) {
-                        flatten_element(
+                    if recurses_as_layout_child(child_el.tag)
+                        && element_is_inline_block(
                             child_el,
                             &style,
-                            inner_width,
-                            available_height,
-                            &mut child_elements,
-                            None,
                             rules,
                             &child_ancestors,
-                            positioned_depth,
                             child_el_idx,
                             child_el_count,
                             &[],
-                            fonts,
-                            None, // CB will be patched below after container_h is known
-                            counter_state,
-                        );
+                        )
+                    {
+                        ib_group_wrapper.push(child_el);
+                    } else {
+                        // Flush any pending inline-block group
+                        if !ib_group_wrapper.is_empty() {
+                            let taken: Vec<&ElementNode> =
+                                ib_group_wrapper.drain(..).collect();
+                            flush_inline_block_group(
+                                &taken,
+                                &style,
+                                inner_width,
+                                available_height,
+                                &mut child_elements,
+                                rules,
+                                &child_ancestors,
+                                positioned_depth,
+                                fonts,
+                                counter_state,
+                            );
+                        }
+                        if recurses_as_layout_child(child_el.tag) {
+                            flatten_element(
+                                child_el,
+                                &style,
+                                inner_width,
+                                available_height,
+                                &mut child_elements,
+                                None,
+                                rules,
+                                &child_ancestors,
+                                positioned_depth,
+                                child_el_idx,
+                                child_el_count,
+                                &[],
+                                fonts,
+                                None, // CB will be patched below after container_h is known
+                                counter_state,
+                            );
+                        }
                     }
                     child_el_idx += 1;
                 }
+            }
+            // Flush remaining inline-block group
+            if !ib_group_wrapper.is_empty() {
+                let taken: Vec<&ElementNode> = ib_group_wrapper.drain(..).collect();
+                flush_inline_block_group(
+                    &taken,
+                    &style,
+                    inner_width,
+                    available_height,
+                    &mut child_elements,
+                    rules,
+                    &child_ancestors,
+                    positioned_depth,
+                    fonts,
+                    counter_state,
+                );
             }
             // Measure children total height
             let children_h: f32 = child_elements.iter().map(estimate_element_height).sum();
@@ -2880,29 +3298,76 @@ fn flatten_element(
                 cb_info = make_containing_block(h);
             }
             let mut child_el_idx = 0;
+            let mut ib_group: Vec<&ElementNode> = Vec::new();
             for child in &el.children {
                 if let DomNode::Element(child_el) = child {
-                    if recurses_as_layout_child(child_el.tag) {
-                        flatten_element(
+                    if recurses_as_layout_child(child_el.tag)
+                        && element_is_inline_block(
                             child_el,
                             &style,
-                            inner_width,
-                            available_height,
-                            output,
-                            None,
                             rules,
                             &child_ancestors,
-                            positioned_depth,
                             child_el_idx,
                             child_el_count,
                             &[],
-                            fonts,
-                            cb_info,
-                            counter_state,
-                        );
+                        )
+                    {
+                        ib_group.push(child_el);
+                    } else {
+                        // Flush any pending inline-block group
+                        if !ib_group.is_empty() {
+                            let taken: Vec<&ElementNode> = ib_group.drain(..).collect();
+                            flush_inline_block_group(
+                                &taken,
+                                &style,
+                                inner_width,
+                                available_height,
+                                output,
+                                rules,
+                                &child_ancestors,
+                                positioned_depth,
+                                fonts,
+                                counter_state,
+                            );
+                        }
+                        if recurses_as_layout_child(child_el.tag) {
+                            flatten_element(
+                                child_el,
+                                &style,
+                                inner_width,
+                                available_height,
+                                output,
+                                None,
+                                rules,
+                                &child_ancestors,
+                                positioned_depth,
+                                child_el_idx,
+                                child_el_count,
+                                &[],
+                                fonts,
+                                cb_info,
+                                counter_state,
+                            );
+                        }
                     }
                     child_el_idx += 1;
                 }
+            }
+            // Flush remaining inline-block group
+            if !ib_group.is_empty() {
+                let taken: Vec<&ElementNode> = ib_group.drain(..).collect();
+                flush_inline_block_group(
+                    &taken,
+                    &style,
+                    inner_width,
+                    available_height,
+                    output,
+                    rules,
+                    &child_ancestors,
+                    positioned_depth,
+                    fonts,
+                    counter_state,
+                );
             }
         }
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -142,7 +142,9 @@ fn element_is_inline_block(
         &el.attributes,
         &selector_ctx,
     );
-    style.display == Display::InlineBlock
+    // Elements with transforms need individual block layout to preserve the
+    // `cm` operator in the PDF — FlexCell doesn't support transforms yet.
+    style.display == Display::InlineBlock && style.transform.is_none()
 }
 
 /// Emit a `FlexRow` for a group of consecutive `display: inline-block` elements.
@@ -1419,6 +1421,7 @@ fn flatten_nodes(
 
     // Helper closure-like macro for flushing an inline-block group.
     // We use a nested fn instead since closures can't borrow multiple fields.
+    #[allow(clippy::drain_collect)]
     #[inline]
     fn flush_ib(
         group: &mut Vec<&ElementNode>,
@@ -3006,6 +3009,7 @@ fn flatten_element(
                     } else {
                         // Flush any pending inline-block group
                         if !ib_group_wrapper.is_empty() {
+                            #[allow(clippy::drain_collect)]
                             let taken: Vec<&ElementNode> = ib_group_wrapper.drain(..).collect();
                             flush_inline_block_group(
                                 &taken,
@@ -3045,6 +3049,7 @@ fn flatten_element(
             }
             // Flush remaining inline-block group
             if !ib_group_wrapper.is_empty() {
+                #[allow(clippy::drain_collect)]
                 let taken: Vec<&ElementNode> = ib_group_wrapper.drain(..).collect();
                 flush_inline_block_group(
                     &taken,
@@ -3317,6 +3322,7 @@ fn flatten_element(
                     } else {
                         // Flush any pending inline-block group
                         if !ib_group.is_empty() {
+                            #[allow(clippy::drain_collect)]
                             let taken: Vec<&ElementNode> = ib_group.drain(..).collect();
                             flush_inline_block_group(
                                 &taken,
@@ -3356,6 +3362,7 @@ fn flatten_element(
             }
             // Flush remaining inline-block group
             if !ib_group.is_empty() {
+                #[allow(clippy::drain_collect)]
                 let taken: Vec<&ElementNode> = ib_group.drain(..).collect();
                 flush_inline_block_group(
                     &taken,

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -142,9 +142,16 @@ fn element_is_inline_block(
         &el.attributes,
         &selector_ctx,
     );
-    // Elements with transforms need individual block layout to preserve the
-    // `cm` operator in the PDF — FlexCell doesn't support transforms yet.
-    style.display == Display::InlineBlock && style.transform.is_none()
+    // SVGs, elements with transforms, and elements with blur filters
+    // need individual block layout — FlexCell doesn't support these yet.
+    style.display == Display::InlineBlock
+        && style.transform.is_none()
+        && style.blur_radius == 0.0
+        && el.tag != HtmlTag::Svg
+        && !el
+            .children
+            .iter()
+            .any(|c| matches!(c, DomNode::Element(e) if e.tag == HtmlTag::Svg))
 }
 
 /// Emit a `FlexRow` for a group of consecutive `display: inline-block` elements.
@@ -220,18 +227,24 @@ fn flush_inline_block_group(
         }
 
         // Determine the element width
+        let has_explicit_width = child_style.width.is_some();
         let child_w = child_style.width.unwrap_or(0.0);
         let child_h = child_style.height.unwrap_or(0.0);
 
-        let inner_width = if child_style.box_sizing == BoxSizing::BorderBox {
-            child_w
-                - child_style.padding.left
-                - child_style.padding.right
-                - child_style.border.horizontal_width()
+        let inner_width = if has_explicit_width {
+            if child_style.box_sizing == BoxSizing::BorderBox {
+                child_w
+                    - child_style.padding.left
+                    - child_style.padding.right
+                    - child_style.border.horizontal_width()
+            } else {
+                child_w
+            }
+            .max(0.0)
         } else {
-            child_w
+            // No explicit width: use available width for shrink-to-fit
+            available_width
         };
-        let inner_width = inner_width.max(0.0);
 
         // Collect text runs from the inline-block element's children
         let mut child_ancestors = ancestors.to_vec();
@@ -271,10 +284,26 @@ fn flush_inline_block_group(
         };
 
         // Total element width including padding + border
-        let total_w = if child_style.box_sizing == BoxSizing::BorderBox {
+        let content_w = if has_explicit_width {
             child_w
         } else {
-            child_w
+            // Shrink-to-fit: use the widest line
+            lines
+                .iter()
+                .map(|l| {
+                    l.runs
+                        .iter()
+                        .map(|r| {
+                            crate::fonts::str_width(&r.text, r.font_size, &r.font_family, r.bold)
+                        })
+                        .sum::<f32>()
+                })
+                .fold(0.0f32, f32::max)
+        };
+        let total_w = if child_style.box_sizing == BoxSizing::BorderBox && has_explicit_width {
+            content_w
+        } else {
+            content_w
                 + child_style.padding.left
                 + child_style.padding.right
                 + child_style.border.horizontal_width()

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -222,7 +222,9 @@ fn flush_inline_block_group(
         let child_h = child_style.height.unwrap_or(0.0);
 
         let inner_width = if child_style.box_sizing == BoxSizing::BorderBox {
-            child_w - child_style.padding.left - child_style.padding.right
+            child_w
+                - child_style.padding.left
+                - child_style.padding.right
                 - child_style.border.horizontal_width()
         } else {
             child_w
@@ -3004,8 +3006,7 @@ fn flatten_element(
                     } else {
                         // Flush any pending inline-block group
                         if !ib_group_wrapper.is_empty() {
-                            let taken: Vec<&ElementNode> =
-                                ib_group_wrapper.drain(..).collect();
+                            let taken: Vec<&ElementNode> = ib_group_wrapper.drain(..).collect();
                             flush_inline_block_group(
                                 &taken,
                                 &style,

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -154,13 +154,13 @@ fn flush_inline_block_group(
     elements: &[&ElementNode],
     parent_style: &ComputedStyle,
     available_width: f32,
-    available_height: f32,
+    _available_height: f32,
     output: &mut Vec<LayoutElement>,
     rules: &[CssRule],
     ancestors: &[AncestorInfo],
-    positioned_ancestor_depth: usize,
+    _positioned_ancestor_depth: usize,
     fonts: &HashMap<String, TtfFont>,
-    counter_state: &mut CounterState,
+    _counter_state: &mut CounterState,
 ) {
     if elements.is_empty() {
         return;

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -12,6 +12,7 @@ use crate::types::{Color, EdgeSizes};
 pub enum Display {
     Block,
     Inline,
+    InlineBlock,
     Flex,
     Grid,
     None,
@@ -1483,6 +1484,7 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
         style.display = match k.as_str() {
             "none" => Display::None,
             "inline" => Display::Inline,
+            "inline-block" => Display::InlineBlock,
             "block" => Display::Block,
             "flex" => Display::Flex,
             "grid" => Display::Grid,
@@ -2265,6 +2267,7 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
             style.display = match kw.as_str() {
                 "none" => Display::None,
                 "inline" => Display::Inline,
+                "inline-block" => Display::InlineBlock,
                 "block" => Display::Block,
                 "flex" => Display::Flex,
                 "grid" => Display::Grid,

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -1428,17 +1428,33 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
         }
     }
 
-    if let Some(CssValue::Length(v)) = get_non_special(map, "margin-top") {
-        style.margin.top = *v;
+    if let Some(val) = get_non_special(map, "margin-top") {
+        match val {
+            CssValue::Length(v) => style.margin.top = *v,
+            CssValue::Number(v) => style.margin.top = *v * style.font_size, // em
+            _ => {}
+        }
     }
-    if let Some(CssValue::Length(v)) = get_non_special(map, "margin-right") {
-        style.margin.right = *v;
+    if let Some(val) = get_non_special(map, "margin-right") {
+        match val {
+            CssValue::Length(v) => style.margin.right = *v,
+            CssValue::Number(v) => style.margin.right = *v * style.font_size,
+            _ => {}
+        }
     }
-    if let Some(CssValue::Length(v)) = get_non_special(map, "margin-bottom") {
-        style.margin.bottom = *v;
+    if let Some(val) = get_non_special(map, "margin-bottom") {
+        match val {
+            CssValue::Length(v) => style.margin.bottom = *v,
+            CssValue::Number(v) => style.margin.bottom = *v * style.font_size,
+            _ => {}
+        }
     }
-    if let Some(CssValue::Length(v)) = get_non_special(map, "margin-left") {
-        style.margin.left = *v;
+    if let Some(val) = get_non_special(map, "margin-left") {
+        match val {
+            CssValue::Length(v) => style.margin.left = *v,
+            CssValue::Number(v) => style.margin.left = *v * style.font_size,
+            _ => {}
+        }
     }
 
     if let Some(CssValue::Length(v)) = get_non_special(map, "padding-top") {

--- a/src/style/defaults.rs
+++ b/src/style/defaults.rs
@@ -13,42 +13,42 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
             // Chrome: font-size 2em (32px=24pt), margin 0.67em top/bottom
             style.set("font-size", CssValue::Length(24.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(16.0));  // 0.67 * 24
+            style.set("margin-top", CssValue::Length(16.0)); // 0.67 * 24
             style.set("margin-bottom", CssValue::Length(16.0));
         }
         HtmlTag::H2 => {
             // Chrome: font-size 1.5em (24px=18pt), margin 0.83em top/bottom
             style.set("font-size", CssValue::Length(20.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(16.6));  // 0.83 * 20
+            style.set("margin-top", CssValue::Length(16.6)); // 0.83 * 20
             style.set("margin-bottom", CssValue::Length(16.6));
         }
         HtmlTag::H3 => {
             // Chrome: font-size 1.17em, margin 1em top/bottom
             style.set("font-size", CssValue::Length(16.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(16.0));  // 1.0 * 16
+            style.set("margin-top", CssValue::Length(16.0)); // 1.0 * 16
             style.set("margin-bottom", CssValue::Length(16.0));
         }
         HtmlTag::H4 => {
             // Chrome: font-size 1em, margin 1.33em top/bottom
             style.set("font-size", CssValue::Length(14.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(18.6));  // 1.33 * 14
+            style.set("margin-top", CssValue::Length(18.6)); // 1.33 * 14
             style.set("margin-bottom", CssValue::Length(18.6));
         }
         HtmlTag::H5 => {
             // Chrome: font-size 0.83em, margin 1.67em top/bottom
             style.set("font-size", CssValue::Length(12.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(20.0));  // 1.67 * 12
+            style.set("margin-top", CssValue::Length(20.0)); // 1.67 * 12
             style.set("margin-bottom", CssValue::Length(20.0));
         }
         HtmlTag::H6 => {
             // Chrome: font-size 0.67em, margin 2.33em top/bottom
             style.set("font-size", CssValue::Length(10.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(23.3));  // 2.33 * 10
+            style.set("margin-top", CssValue::Length(23.3)); // 2.33 * 10
             style.set("margin-bottom", CssValue::Length(23.3));
         }
         HtmlTag::P => {

--- a/src/style/defaults.rs
+++ b/src/style/defaults.rs
@@ -7,46 +7,54 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
     let mut style = StyleMap::new();
 
     match tag {
+        // Chrome UA stylesheet margins: headings use em-based values relative
+        // to their font size.  We use the equivalent in points (1em = font-size).
         HtmlTag::H1 => {
+            // Chrome: font-size 2em (32px=24pt), margin 0.67em top/bottom
             style.set("font-size", CssValue::Length(24.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(8.0));
-            style.set("margin-bottom", CssValue::Length(6.0));
+            style.set("margin-top", CssValue::Length(16.0));  // 0.67 * 24
+            style.set("margin-bottom", CssValue::Length(16.0));
         }
         HtmlTag::H2 => {
+            // Chrome: font-size 1.5em (24px=18pt), margin 0.83em top/bottom
             style.set("font-size", CssValue::Length(20.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(6.0));
-            style.set("margin-bottom", CssValue::Length(4.0));
+            style.set("margin-top", CssValue::Length(16.6));  // 0.83 * 20
+            style.set("margin-bottom", CssValue::Length(16.6));
         }
         HtmlTag::H3 => {
+            // Chrome: font-size 1.17em, margin 1em top/bottom
             style.set("font-size", CssValue::Length(16.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(4.0));
-            style.set("margin-bottom", CssValue::Length(4.0));
+            style.set("margin-top", CssValue::Length(16.0));  // 1.0 * 16
+            style.set("margin-bottom", CssValue::Length(16.0));
         }
         HtmlTag::H4 => {
+            // Chrome: font-size 1em, margin 1.33em top/bottom
             style.set("font-size", CssValue::Length(14.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(4.0));
-            style.set("margin-bottom", CssValue::Length(2.0));
+            style.set("margin-top", CssValue::Length(18.6));  // 1.33 * 14
+            style.set("margin-bottom", CssValue::Length(18.6));
         }
         HtmlTag::H5 => {
+            // Chrome: font-size 0.83em, margin 1.67em top/bottom
             style.set("font-size", CssValue::Length(12.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(2.0));
-            style.set("margin-bottom", CssValue::Length(2.0));
+            style.set("margin-top", CssValue::Length(20.0));  // 1.67 * 12
+            style.set("margin-bottom", CssValue::Length(20.0));
         }
         HtmlTag::H6 => {
+            // Chrome: font-size 0.67em, margin 2.33em top/bottom
             style.set("font-size", CssValue::Length(10.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(2.0));
-            style.set("margin-bottom", CssValue::Length(2.0));
+            style.set("margin-top", CssValue::Length(23.3));  // 2.33 * 10
+            style.set("margin-bottom", CssValue::Length(23.3));
         }
         HtmlTag::P => {
-            // No default font-size — <p> inherits from parent (matches browser UA behavior)
-            style.set("margin-top", CssValue::Length(0.0));
-            style.set("margin-bottom", CssValue::Length(4.0));
+            // Chrome: margin 1em top/bottom (1em = parent font-size, default 12pt)
+            style.set("margin-top", CssValue::Length(12.0));
+            style.set("margin-bottom", CssValue::Length(12.0));
         }
         HtmlTag::Strong | HtmlTag::B => {
             style.set("font-weight", CssValue::Keyword("bold".into()));
@@ -72,8 +80,9 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
             style.set("margin-bottom", CssValue::Length(2.0));
         }
         HtmlTag::Ul | HtmlTag::Ol => {
-            style.set("margin-top", CssValue::Length(4.0));
-            style.set("margin-bottom", CssValue::Length(8.0));
+            // Chrome: margin 1em top/bottom, padding-left 40px
+            style.set("margin-top", CssValue::Length(12.0));
+            style.set("margin-bottom", CssValue::Length(12.0));
             style.set("margin-left", CssValue::Length(20.0));
         }
         HtmlTag::Dl => {

--- a/src/style/defaults.rs
+++ b/src/style/defaults.rs
@@ -7,54 +7,47 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
     let mut style = StyleMap::new();
 
     match tag {
-        // Chrome UA stylesheet margins: headings use em-based values relative
-        // to their font size.  We use the equivalent in points (1em = font-size).
+        // Chrome UA stylesheet uses em-based margins that scale with font-size.
+        // CssValue::Number is resolved as em (multiplied by font_size) in apply_style_map.
         HtmlTag::H1 => {
-            // Chrome: font-size 2em (32px=24pt), margin 0.67em top/bottom
             style.set("font-size", CssValue::Length(24.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(16.0)); // 0.67 * 24
-            style.set("margin-bottom", CssValue::Length(16.0));
+            style.set("margin-top", CssValue::Number(0.67));
+            style.set("margin-bottom", CssValue::Number(0.67));
         }
         HtmlTag::H2 => {
-            // Chrome: font-size 1.5em (24px=18pt), margin 0.83em top/bottom
             style.set("font-size", CssValue::Length(20.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(16.6)); // 0.83 * 20
-            style.set("margin-bottom", CssValue::Length(16.6));
+            style.set("margin-top", CssValue::Number(0.83));
+            style.set("margin-bottom", CssValue::Number(0.83));
         }
         HtmlTag::H3 => {
-            // Chrome: font-size 1.17em, margin 1em top/bottom
             style.set("font-size", CssValue::Length(16.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(16.0)); // 1.0 * 16
-            style.set("margin-bottom", CssValue::Length(16.0));
+            style.set("margin-top", CssValue::Number(1.0));
+            style.set("margin-bottom", CssValue::Number(1.0));
         }
         HtmlTag::H4 => {
-            // Chrome: font-size 1em, margin 1.33em top/bottom
             style.set("font-size", CssValue::Length(14.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(18.6)); // 1.33 * 14
-            style.set("margin-bottom", CssValue::Length(18.6));
+            style.set("margin-top", CssValue::Number(1.33));
+            style.set("margin-bottom", CssValue::Number(1.33));
         }
         HtmlTag::H5 => {
-            // Chrome: font-size 0.83em, margin 1.67em top/bottom
             style.set("font-size", CssValue::Length(12.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(20.0)); // 1.67 * 12
-            style.set("margin-bottom", CssValue::Length(20.0));
+            style.set("margin-top", CssValue::Number(1.67));
+            style.set("margin-bottom", CssValue::Number(1.67));
         }
         HtmlTag::H6 => {
-            // Chrome: font-size 0.67em, margin 2.33em top/bottom
             style.set("font-size", CssValue::Length(10.0));
             style.set("font-weight", CssValue::Keyword("bold".into()));
-            style.set("margin-top", CssValue::Length(23.3)); // 2.33 * 10
-            style.set("margin-bottom", CssValue::Length(23.3));
+            style.set("margin-top", CssValue::Number(2.33));
+            style.set("margin-bottom", CssValue::Number(2.33));
         }
         HtmlTag::P => {
-            // Chrome: margin 1em top/bottom (1em = parent font-size, default 12pt)
-            style.set("margin-top", CssValue::Length(12.0));
-            style.set("margin-bottom", CssValue::Length(12.0));
+            style.set("margin-top", CssValue::Number(1.0));
+            style.set("margin-bottom", CssValue::Number(1.0));
         }
         HtmlTag::Strong | HtmlTag::B => {
             style.set("font-weight", CssValue::Keyword("bold".into()));
@@ -81,8 +74,8 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
         }
         HtmlTag::Ul | HtmlTag::Ol => {
             // Chrome: margin 1em top/bottom, padding-left 40px
-            style.set("margin-top", CssValue::Length(12.0));
-            style.set("margin-bottom", CssValue::Length(12.0));
+            style.set("margin-top", CssValue::Number(1.0));
+            style.set("margin-bottom", CssValue::Number(1.0));
             style.set("margin-left", CssValue::Length(20.0));
         }
         HtmlTag::Dl => {


### PR DESCRIPTION
Whitespace-only text nodes between consecutive inline-block elements were flushing the inline-block group prematurely, causing each element to render in its own row (stacked vertically) instead of side by side.

Now only non-whitespace text flushes the group, so consecutive inline-block elements stay on the same row as expected.

Fixes #62 (colors-backgrounds), #69 (transforms), partially fixes #61 (box-model), #72 (resume tags), #73 (dashboard)