### PR TITLE
security: add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches: [main]
 
+# Restrict default permissions to read-only for all jobs.
+# Jobs that need more (benchmarks, publish) override below.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -97,6 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, clippy, fmt]
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -183,6 +190,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Set top-level `permissions: contents: read` (least privilege default) and add explicit permissions to `publish-crate` and `coverage` jobs.

Resolves all 7 CodeQL `actions/missing-workflow-permissions` warnings from the [code scanning dashboard](https://github.com/gastongouron/ironpress/security/code-scanning).

## Test plan
- [x] No functional change to CI behavior
- [x] Jobs that need elevated permissions (benchmarks: pull-requests: write, publish-npm: contents: read) already had them