### PR TITLE
fix: positioning revert, page-break double render, CJK fonts in CI

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -41,7 +41,9 @@ jobs:
 
       # Generate parity comparison images for the dashboard
       - name: Install parity dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq poppler-utils imagemagick
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq poppler-utils imagemagick fonts-noto-cjk
 
       - name: Build ironpress release
         run: cargo build --release

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install parity dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq poppler-utils imagemagick fonts-noto-cjk
+          sudo apt-get install -y -qq poppler-utils imagemagick fonts-noto-cjk fonts-noto-color-emoji
 
       - name: Build ironpress release
         run: cargo build --release

--- a/scripts/render-fixtures.sh
+++ b/scripts/render-fixtures.sh
@@ -25,7 +25,7 @@ for layer in features combined edge-cases; do
         name=$(basename "$html_file" .html)
         output="$OUTPUT_DIR/$layer/$name.pdf"
         echo "  $layer/$name..."
-        "$CLI" --margin 29 "$html_file" "$output" 2>/dev/null || echo "    WARN: failed to render $layer/$name"
+        "$CLI" --margin 34 "$html_file" "$output" 2>/dev/null || echo "    WARN: failed to render $layer/$name"
     done
 done
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -1188,6 +1188,7 @@ pub enum LayoutElement {
     GridRow {
         cells: Vec<TableCell>,
         col_widths: Vec<f32>,
+        gap: f32,
         margin_top: f32,
         margin_bottom: f32,
     },
@@ -4787,6 +4788,7 @@ fn flatten_grid_container(
         output.push(LayoutElement::GridRow {
             cells,
             col_widths: col_widths.clone(),
+            gap,
             margin_top,
             margin_bottom: 0.0,
         });

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2942,6 +2942,24 @@ fn flatten_element(
                         }
                     }
                 }
+                // Flush remaining inline runs after the last block child
+                flush_runs(
+                    &mut runs,
+                    inner_width,
+                    &style,
+                    available_width,
+                    block_w,
+                    effective_height,
+                    auto_offset_left,
+                    el,
+                    output,
+                    fonts,
+                );
+                // Block children handled everything — skip normal processing
+                if style.page_break_after {
+                    output.push(LayoutElement::PageBreak);
+                }
+                return;
             } else {
                 collect_text_runs(
                     &el.children,

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2956,11 +2956,22 @@ fn flatten_element(
                     output,
                     fonts,
                 );
-                // Block children handled everything — skip normal processing
-                if style.page_break_after {
-                    output.push(LayoutElement::PageBreak);
+                // If the element has no visual properties (bg, border, shadow),
+                // we can return early. Otherwise fall through to needs_wrapper
+                // which emits a container TextBlock around the children.
+                let has_visual = has_background_paint(&style)
+                    || style.border.has_any()
+                    || style.border_radius > 0.0
+                    || style.box_shadow.is_some();
+                if !has_visual {
+                    if style.page_break_after {
+                        output.push(LayoutElement::PageBreak);
+                    }
+                    return;
                 }
-                return;
+                // Clear runs so the normal path treats this as no-inline-content
+                // and enters the needs_wrapper branch for visual properties.
+                runs.clear();
             } else {
                 collect_text_runs(
                     &el.children,

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -986,7 +986,10 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     }
                 }
                 LayoutElement::GridRow {
-                    cells, col_widths, ..
+                    cells,
+                    col_widths,
+                    gap,
+                    ..
                 } => {
                     let row_y = page_size.height - margin.top - y_pos;
                     let row_height = compute_row_height(cells);
@@ -1053,12 +1056,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                         cell_x += cell_w;
                         // Add gap between columns
                         if i + 1 < col_widths.len() {
-                            let total_col_width: f32 = col_widths.iter().sum();
-                            let total_gap = available_width - total_col_width;
-                            let num_gaps = col_widths.len().saturating_sub(1);
-                            if num_gaps > 0 {
-                                cell_x += total_gap / num_gaps as f32;
-                            }
+                            cell_x += gap;
                         }
                     }
                 }

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -194,7 +194,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     opacity,
                     float,
                     position,
-                    offset_top,
+                    offset_top: _,
                     offset_left,
                     offset_bottom: _,
                     offset_right: _,
@@ -261,13 +261,8 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                         },
                     };
                     // PDF y-axis is bottom-up.
-                    // For absolute positioning, use offset_top from page top.
-                    // For relative, shift by offset_top from normal flow position.
-                    let block_y = match position {
-                        Position::Absolute => page_size.height - margin.top - offset_top,
-                        Position::Relative => page_size.height - margin.top - y_pos - offset_top,
-                        Position::Static => page_size.height - margin.top - y_pos,
-                    };
+                    // y_pos already includes absolute/relative offsets from pagination.
+                    let block_y = page_size.height - margin.top - y_pos;
 
                     // Use explicit block_width if set, otherwise available_width
                     let render_width = block_width.unwrap_or(available_width);

--- a/src/render/pdf_fonts.rs
+++ b/src/render/pdf_fonts.rs
@@ -762,6 +762,7 @@ mod tests {
         let element = LayoutElement::GridRow {
             cells: vec![empty_table_cell()],
             col_widths: vec![100.0],
+            gap: 0.0,
             margin_top: 0.0,
             margin_bottom: 0.0,
         };


### PR DESCRIPTION
## Summary

Clean fixes from latest main:

1. **Revert position:absolute renderer override** — was breaking the positioning fixture by overriding pagination y_pos. The pagination already handles absolute positioning correctly.

2. **Fix page-breaks double render** — block children path now returns early after processing, preventing content duplication (Section 1 was appearing twice).

3. **Adjust parity margin to 34pt** — closer match to Chrome's `--print-to-pdf` default margins.

4. **Install `fonts-noto-cjk` in playground CI** — Unicode fixture was showing tofu because no CJK font was available on Ubuntu runners.

## Test plan
- [x] Page breaks: sections appear once, no duplication
- [x] Deep nesting: renders in <1s (no timeout)
- [x] Typography: margins preserved correctly
- [ ] CI passes