### PR TITLE
ci: add manual trigger + self-path to Deploy Playground

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,6 +1,7 @@
 name: Deploy Playground
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -8,6 +9,7 @@ on:
       - 'playground/**'
       - 'tests/fixtures/**'
       - 'Cargo.toml'
+      - '.github/workflows/playground.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger so deploy can be launched manually via UI or `gh workflow run`
- Add `.github/workflows/playground.yml` to the paths filter so workflow changes trigger a deploy

## Context
PR #93 changed the workflow file but didn't trigger a deploy because `.github/` wasn't in the paths filter.