### PR TITLE
chore: update outdated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ unicode-bidi = "0.3.18"
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 proptest = "1"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 serde_json = "1"
 
 [[bench]]


### PR DESCRIPTION
Update criterion (0.5→0.8), getrandom (0.3→0.4). html5ever stays at 0.38 (blocked on markup5ever_rcdom).