### PR TITLE
fix(parity): match Chromium --print-to-pdf default margins (0.8in)

### DIFF
--- a/scripts/render-fixtures.sh
+++ b/scripts/render-fixtures.sh
@@ -25,8 +25,8 @@ for layer in features combined edge-cases; do
         name=$(basename "$html_file" .html)
         output="$OUTPUT_DIR/$layer/$name.pdf"
         echo "  $layer/$name..."
-        # Chromium --print-to-pdf defaults to 0.4in (28.8pt) on all sides.
-        "$CLI" --margin 28.8 "$html_file" "$output" 2>/dev/null || echo "    WARN: failed to render $layer/$name"
+        # Chromium --print-to-pdf defaults to 0.8in (57.6pt) on all sides.
+        "$CLI" --margin 57.6 "$html_file" "$output" 2>/dev/null || echo "    WARN: failed to render $layer/$name"
     done
 done
 


### PR DESCRIPTION
## Summary
- Chromium's `--print-to-pdf` defaults to **0.8in (57.6pt)** per side, not 0.4in as I assumed in #123.
- Measured from the Chrome reference render: content bbox at `x=120px` on both left and right of a 1275px-wide Letter page at 150 DPI = 57.6pt each side.
- Previous script used `--margin 28.8` → iron bbox sat at 29pt vs Chrome's 58pt, shifting the full page ~28pt left and giving iron ~56pt more usable width per line.

## Impact
- Typography (and all other fixtures): horizontal content alignment now matches Chromium's box.
- Vertical should also get closer since the same 57.6pt now applies to top/bottom.

## Test plan
- [x] Re-render `tests/fixtures/features/typography.html` and measure bbox: `left=57.60pt right=58.08pt` (Chrome: 57.6/57.6).
- [ ] CI parity dashboard rebuild on merge — verify typography and other fixtures visually