### PR TITLE
fix(flex): wrap container border around all lines; align-items honors min-height

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -184,6 +184,16 @@ pub struct FlexCell {
     pub transform: Option<Transform>,
     /// Nested layout elements for complex flex items (tables, images, etc.)
     pub nested_elements: Vec<LayoutElement>,
+    /// Cross-axis offset of this cell within the FlexRow. For single-line
+    /// rows this is 0; for `flex-wrap: wrap` with multiple lines, items on
+    /// subsequent lines carry their cumulative cross_offset here so a single
+    /// FlexRow can visually span every wrapped line.
+    pub y_offset: f32,
+    /// Cross-axis size of the flex line this cell belongs to. Drives
+    /// per-line alignment math (stretch/center/flex-end) so that a single
+    /// FlexRow carrying cells from multiple wrapped lines still aligns each
+    /// item against its own line rather than the entire row.
+    pub line_cross_size: f32,
 }
 
 /// A styled text run (a piece of text with uniform style).
@@ -376,14 +386,6 @@ pub enum LayoutElement {
         background_repeat: BackgroundRepeat,
         background_origin: BackgroundOrigin,
         align_items: AlignItems,
-        /// For `flex-wrap: wrap` with multiple lines: the *first* emitted row
-        /// carries the full cross-axis content height of the container (sum of
-        /// all lines + inter-line gaps) so that the border/background drawing
-        /// extends around every wrapped line. `None` (the default) means the
-        /// row is alone and `row_height` already represents the whole content.
-        /// Used ONLY for background/border/box-shadow sizing — pagination and
-        /// flow still use `row_height`.
-        wrap_container_content_height: Option<f32>,
     },
     /// A progress bar or meter element.
     ProgressBar {

--- a/src/layout/flex.rs
+++ b/src/layout/flex.rs
@@ -643,6 +643,30 @@ pub(crate) fn layout_flex_container(
         Some(min_h) => container_h.max(min_h),
         None => container_h,
     };
+    // Cross-axis inner size once height/min-height have been honored. For
+    // row direction with a single line this is what each item should
+    // stretch to (align-items: stretch) and what flex-end/center measure
+    // against — otherwise a tall `min-height` container collapses visually
+    // to the natural item height.
+    let inner_cross_size =
+        (container_h - style.padding.top - style.padding.bottom).max(0.0);
+    if direction == FlexDirection::Row && lines.len() == 1 {
+        if let Some(line) = lines.first_mut() {
+            line.cross_size = line.cross_size.max(inner_cross_size);
+        }
+    }
+    // Recompute total_cross after possibly growing a single line.
+    let total_cross: f32 = match direction {
+        FlexDirection::Row => {
+            lines.iter().map(|l| l.cross_size).sum::<f32>()
+                + if lines.len() > 1 {
+                    (lines.len() - 1) as f32 * gap
+                } else {
+                    0.0
+                }
+        }
+        FlexDirection::Column => lines.iter().map(|l| l.cross_size).fold(0.0f32, f32::max),
+    };
     let bg = style
         .background_color
         .map(|color: crate::types::Color| color.to_f32_rgba());
@@ -779,6 +803,10 @@ pub(crate) fn layout_flex_container(
 
     // Position items within the flex container and emit them
     let mut cross_offset = 0.0;
+    // All flex cells across every line, merged into a single FlexRow for
+    // row direction. This keeps container borders/backgrounds around every
+    // wrapped line and keeps pagination flow correct.
+    let mut all_flex_cells: Vec<FlexCell> = Vec::new();
 
     for line in &lines {
         let line_items: Vec<usize> = line.item_indices.clone();
@@ -936,6 +964,8 @@ pub(crate) fn layout_flex_container(
                                 background_origin: BackgroundOrigin::Padding,
                                 transform: None,
                                 nested_elements: item.elements.clone(),
+                                y_offset: 0.0,
+                                line_cross_size: 0.0,
                             });
                             x += item.width + gap;
                             continue;
@@ -998,6 +1028,8 @@ pub(crate) fn layout_flex_container(
                             background_origin: BackgroundOrigin::Padding,
                             transform: None,
                             nested_elements: Vec::new(),
+                            y_offset: 0.0,
+                            line_cross_size: 0.0,
                         });
                         x += item.width + gap;
                         continue;
@@ -1051,6 +1083,8 @@ pub(crate) fn layout_flex_container(
                             transform: None,
                             nested_elements: Vec::new(),
                             natural_height: natural_h,
+                            y_offset: 0.0,
+                            line_cross_size: 0.0,
                         });
                     } else {
                         // Single non-TextBlock element (e.g. Container): store
@@ -1078,84 +1112,21 @@ pub(crate) fn layout_flex_container(
                             background_origin: BackgroundOrigin::Padding,
                             transform: None,
                             nested_elements: item.elements.clone(),
+                            y_offset: 0.0,
+                            line_cross_size: 0.0,
                         });
                     }
 
                     x += item.width + gap + extra_gap;
                 }
 
-                // For the first emitted row in a multi-line wrap, extend the
-                // background/border drawing to cover every wrapped line.
-                let wrap_container_content_height = if cross_offset == 0.0 && lines.len() > 1 {
-                    Some(total_cross)
-                } else {
-                    None
-                };
-                output.push(LayoutElement::FlexRow {
-                    cells: flex_cells,
-                    row_height: line.cross_size,
-                    margin_top: style.margin.top + cross_offset,
-                    margin_bottom: 0.0,
-                    background_color: if cross_offset == 0.0 { bg } else { None },
-                    container_width: block_w,
-                    padding_top: style.padding.top,
-                    padding_bottom: style.padding.bottom,
-                    padding_left: style.padding.left,
-                    padding_right: style.padding.right,
-                    border: if cross_offset == 0.0 {
-                        LayoutBorder::from_computed(&style.border)
-                    } else {
-                        LayoutBorder::default()
-                    },
-                    border_radius: style.border_radius,
-                    box_shadow: if cross_offset == 0.0 {
-                        style.box_shadow
-                    } else {
-                        None
-                    },
-                    background_gradient: if cross_offset == 0.0 {
-                        style.background_gradient.clone()
-                    } else {
-                        None
-                    },
-                    background_radial_gradient: if cross_offset == 0.0 {
-                        style.background_radial_gradient.clone()
-                    } else {
-                        None
-                    },
-                    background_svg: if cross_offset == 0.0 {
-                        background_svg_for_style(style)
-                    } else {
-                        None
-                    },
-                    background_blur_radius: if cross_offset == 0.0 {
-                        style.blur_radius
-                    } else {
-                        0.0
-                    },
-                    background_size: if cross_offset == 0.0 {
-                        style.background_size
-                    } else {
-                        BackgroundSize::Auto
-                    },
-                    background_position: if cross_offset == 0.0 {
-                        style.background_position
-                    } else {
-                        BackgroundPosition::default()
-                    },
-                    background_repeat: if cross_offset == 0.0 {
-                        style.background_repeat
-                    } else {
-                        BackgroundRepeat::Repeat
-                    },
-                    background_origin: if cross_offset == 0.0 {
-                        style.background_origin
-                    } else {
-                        BackgroundOrigin::Padding
-                    },
-                    align_items: align,
-                    wrap_container_content_height,
-                });
+                // Stamp each cell with its cross-axis position within the
+                // container so a single FlexRow can span every wrapped line.
+                for cell in flex_cells.iter_mut() {
+                    cell.y_offset = cross_offset;
+                    cell.line_cross_size = line.cross_size;
+                }
+                all_flex_cells.extend(flex_cells);
             }
             FlexDirection::Column => {
                 let _total_item_height: f32 = line_items.iter().map(|&i| items[i].height).sum();
@@ -1292,6 +1263,38 @@ pub(crate) fn layout_flex_container(
         }
 
         cross_offset += line.cross_size + gap;
+    }
+
+    // Emit a single FlexRow carrying every line's cells for row direction.
+    // The row's height is the container's inner cross size so pagination and
+    // the visual border both include every wrapped line. Each cell's own
+    // y_offset and line_cross_size handle per-line alignment internally.
+    if direction == FlexDirection::Row && !all_flex_cells.is_empty() {
+        let row_height = total_cross.max(inner_cross_size);
+        output.push(LayoutElement::FlexRow {
+            cells: all_flex_cells,
+            row_height,
+            margin_top: style.margin.top,
+            margin_bottom: 0.0,
+            background_color: bg,
+            container_width: block_w,
+            padding_top: style.padding.top,
+            padding_bottom: style.padding.bottom,
+            padding_left: style.padding.left,
+            padding_right: style.padding.right,
+            border: LayoutBorder::from_computed(&style.border),
+            border_radius: style.border_radius,
+            box_shadow: style.box_shadow,
+            background_gradient: style.background_gradient.clone(),
+            background_radial_gradient: style.background_radial_gradient.clone(),
+            background_svg: background_svg_for_style(style),
+            background_blur_radius: style.blur_radius,
+            background_size: style.background_size,
+            background_position: style.background_position,
+            background_repeat: style.background_repeat,
+            background_origin: style.background_origin,
+            align_items: align,
+        });
     }
 
     // Emit trailing margin (include bottom padding when bg spacer shifted y back)

--- a/src/layout/flex.rs
+++ b/src/layout/flex.rs
@@ -648,8 +648,7 @@ pub(crate) fn layout_flex_container(
     // stretch to (align-items: stretch) and what flex-end/center measure
     // against — otherwise a tall `min-height` container collapses visually
     // to the natural item height.
-    let inner_cross_size =
-        (container_h - style.padding.top - style.padding.bottom).max(0.0);
+    let inner_cross_size = (container_h - style.padding.top - style.padding.bottom).max(0.0);
     if direction == FlexDirection::Row && lines.len() == 1 {
         if let Some(line) = lines.first_mut() {
             line.cross_size = line.cross_size.max(inner_cross_size);

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -324,6 +324,8 @@ pub(crate) fn layout_inline_block_group(
             background_origin: item.background_origin,
             transform: item.transform,
             nested_elements: Vec::new(),
+            y_offset: 0.0,
+            line_cross_size: 0.0,
         });
         x += item.width + item.margin_right;
         row_height = row_height.max(item.height);
@@ -357,7 +359,6 @@ pub(crate) fn layout_inline_block_group(
             background_repeat: BackgroundRepeat::Repeat,
             background_origin: BackgroundOrigin::Padding,
             align_items: crate::style::computed::AlignItems::Stretch,
-            wrap_container_content_height: None,
         });
     }
 }

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1169,14 +1169,11 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     background_repeat: flex_bg_repeat,
                     background_origin: flex_bg_origin,
                     align_items,
-                    wrap_container_content_height,
                     ..
                 } => {
                     let row_y = page_size.height - margin.top - y_pos;
-                    let effective_content_height =
-                        wrap_container_content_height.unwrap_or(*row_height);
                     let full_height = padding_top
-                        + effective_content_height
+                        + row_height
                         + padding_bottom
                         + border.vertical_width();
 
@@ -1423,20 +1420,29 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     for cell in cells {
                         let cell_x = margin.left + padding_left + cell.x_offset;
                         let cell_inner_w = cell.width - cell.padding_left - cell.padding_right;
+                        // For single-line rows `line_cross_size == row_height`.
+                        // For multi-line wrap, each cell's line_cross_size is its
+                        // own flex line height, so alignment is per-line.
+                        let line_cross = if cell.line_cross_size > 0.0 {
+                            cell.line_cross_size
+                        } else {
+                            *row_height
+                        };
+                        let cell_y_origin = cell.y_offset;
 
                         // Compute per-cell height and vertical offset based on align-items.
-                        // For stretch: use full row_height (default CSS behavior).
+                        // For stretch: use the line's cross size (default CSS behavior).
                         // For flex-start/center/flex-end: use the cell's natural_height.
                         let (cell_render_h, cell_y_shift) = match align_items {
-                            AlignItems::Stretch => (*row_height, 0.0),
-                            AlignItems::FlexStart => (cell.natural_height, 0.0),
+                            AlignItems::Stretch => (line_cross, cell_y_origin),
+                            AlignItems::FlexStart => (cell.natural_height, cell_y_origin),
                             AlignItems::FlexEnd => {
                                 let h = cell.natural_height;
-                                (h, *row_height - h)
+                                (h, cell_y_origin + line_cross - h)
                             }
                             AlignItems::Center => {
                                 let h = cell.natural_height;
-                                (h, (*row_height - h) / 2.0)
+                                (h, cell_y_origin + (line_cross - h) / 2.0)
                             }
                         };
 
@@ -1444,7 +1450,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                         let cell_needs_transform = cell.transform.is_some();
                         if let Some(t) = &cell.transform {
                             let cx = cell_x + cell.width * 0.5;
-                            let cy = text_area_top - *row_height * 0.5;
+                            let cy = text_area_top - cell_y_origin - line_cross * 0.5;
                             content.push_str("q\n");
                             match t {
                                 crate::style::computed::Transform::Rotate(deg) => {

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1172,10 +1172,8 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     ..
                 } => {
                     let row_y = page_size.height - margin.top - y_pos;
-                    let full_height = padding_top
-                        + row_height
-                        + padding_bottom
-                        + border.vertical_width();
+                    let full_height =
+                        padding_top + row_height + padding_bottom + border.vertical_width();
 
                     // Draw box shadow with blur
                     if let Some(shadow) = box_shadow {

--- a/src/render/pdf_fonts.rs
+++ b/src/render/pdf_fonts.rs
@@ -457,6 +457,8 @@ mod tests {
             background_origin: BackgroundOrigin::Padding,
             transform: None,
             nested_elements: Vec::new(),
+            y_offset: 0.0,
+            line_cross_size: 0.0,
         }
     }
 
@@ -919,7 +921,6 @@ mod tests {
             background_repeat: BackgroundRepeat::Repeat,
             background_origin: BackgroundOrigin::Padding,
             align_items: crate::style::computed::AlignItems::Stretch,
-            wrap_container_content_height: None,
         };
         let fonts: HashMap<String, TtfFont> = HashMap::new();
         let mut usage: BTreeMap<String, FontUsage> = BTreeMap::new();


### PR DESCRIPTION
## Summary

Fixes two flexbox regressions visible on the parity dashboard after #125:

1. **flex-wrap wrapped-line border** — items on the second wrapped line rendered *outside* the container border. Previously each flex line emitted its own FlexRow; the first carried the border and an extended height, but pagination advanced past it so subsequent lines fell below the box. Now all lines merge into a single FlexRow; each cell tracks its own `y_offset` and `line_cross_size`, so one container border spans every line and flow uses a single consistent height.

2. **align-items ignoring min-height** — `min-height` on the container did not grow the flex line, so stretch/center/flex-end aligned against item height instead of the taller container. When a single-line row container has a taller `min-height`, the line's `cross_size` now grows to the container's inner cross size.

Removes the `wrap_container_content_height` shim added by #125 in favor of the single-row approach.

Before (main, deployed dashboard):
- align-items rows tight around items
- flex-wrap: Items 5-8 rendered completely outside the container border

After:
- align-items containers respect min-height, items align correctly
- flex-wrap: Items 1-8 all inside one container border on two lines

## Test plan
- [x] `cargo test --release` — all 15 integration tests pass
- [x] `cargo clippy --release` — clean
- [x] Local flexbox.html render matches Chromium screenshot (align-items min-height + flex-wrap border)
- [x] dashboard / invoice / box-model / resume fixtures: byte-identical PDF output vs main (no regressions in non-wrap flex uses)