### PR TITLE
chore: bump to 1.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter with layout engine, LaTeX math, tables, images, custom fonts, and streaming output. No browser, no system dependencies."


### PR DESCRIPTION
## Summary

Bump Cargo.toml version to 1.4.2 for release.

## Release notes (since v1.4.1)

- fix(flex): wrap container border around all lines; align-items honors min-height (#127)
- perf(fonts): cache fontdb system font discovery across conversions (#126)
- fix(playground): dashboard render time and diff % calculation (#125)
- ci(playground): install fonts-noto-cjk for CJK parity (#125)
- fix(layout): flex min-height, flex-wrap border, table border-spacing (#125)

## After merging

Tag `v1.4.2` on main to trigger Python/Ruby release workflows.