### PR TITLE
fix(parity): flex content-box width, SVG opacity, inline-block box-shadow

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -182,6 +182,8 @@ pub struct FlexCell {
     pub background_repeat: BackgroundRepeat,
     pub background_origin: BackgroundOrigin,
     pub transform: Option<Transform>,
+    /// Box shadow to render behind this cell (CSS `box-shadow`).
+    pub box_shadow: Option<BoxShadow>,
     /// Nested layout elements for complex flex items (tables, images, etc.)
     pub nested_elements: Vec<LayoutElement>,
     /// Cross-axis offset of this cell within the FlexRow. For single-line

--- a/src/layout/flex.rs
+++ b/src/layout/flex.rs
@@ -246,17 +246,31 @@ pub(crate) fn layout_flex_container(
         //   proportionally by grow factors
         // - flex-grow == 0 without basis/width: use equal share, then shrink to
         //   natural content width (for justify-content)
+        //
+        // For `box-sizing: content-box` (the CSS default), the specified width
+        // is the *content* width, so the outer box used for flex main-axis
+        // layout is `width + padding + border`. For `border-box`, the
+        // specified width is already the outer box.
         let has_explicit_width = child_style.flex_basis.is_some() || child_style.width.is_some();
-        let child_w_initial = child_style
-            .flex_basis
-            .or(child_style.width)
-            .unwrap_or_else(|| {
+        let inflate_outer = |w: f32| -> f32 {
+            if child_style.box_sizing == BoxSizing::ContentBox {
+                w + child_style.padding.left
+                    + child_style.padding.right
+                    + child_style.border.horizontal_width()
+            } else {
+                w
+            }
+        };
+        let child_w_initial = match child_style.flex_basis.or(child_style.width) {
+            Some(w) => inflate_outer(w),
+            None => {
                 if child_style.flex_grow > 0.0 {
                     0.0
                 } else {
                     width_for_percentages / child_count as f32
                 }
-            });
+            }
+        };
         // For text wrapping, use equal share as measurement width even when
         // flex base is 0 — text needs a nonzero width to wrap into lines.
         // The actual item width will be set after grow distribution.
@@ -276,13 +290,14 @@ pub(crate) fn layout_flex_container(
             preceding_siblings: Vec::new(),
         });
 
-        // Two widths: child_w_for_flex is the CSS flex-basis for wrapping
-        // decisions, child_w_for_layout is the width used to lay out children
-        // (inflated for flex-grow items so percentage children resolve correctly).
-        let child_w_for_flex = child_style
-            .flex_basis
-            .or(child_style.width)
-            .unwrap_or(width_for_percentages / child_count as f32);
+        // Two widths: child_w_for_flex is the outer main-axis size used for
+        // wrapping decisions (content-box + padding + border for content-box),
+        // child_w_for_layout is the content width used to lay out children so
+        // percentage resolution against the parent content area is correct.
+        let child_w_for_flex = match child_style.flex_basis.or(child_style.width) {
+            Some(w) => inflate_outer(w),
+            None => width_for_percentages / child_count as f32,
+        };
         let child_w_for_layout = if child_style.flex_grow > 0.0
             && child_style.flex_basis == Some(0.0)
             && child_style.width.is_none()
@@ -291,7 +306,12 @@ pub(crate) fn layout_flex_container(
             // but flex wrapping uses the actual basis (child_w_for_flex).
             width_for_percentages
         } else {
-            child_w_for_flex
+            // Content area for child layout = outer minus padding + border.
+            (child_w_for_flex
+                - child_style.padding.left
+                - child_style.padding.right
+                - child_style.border.horizontal_width())
+            .max(0.0)
         };
 
         // Check if this flex item has block-level children that need full layout
@@ -391,12 +411,8 @@ pub(crate) fn layout_flex_container(
         let child_w = if !has_explicit_width && child_style.flex_grow == 0.0 && !runs.is_empty() {
             let natural_text_w = measure_runs_width(&runs, env.fonts);
             let pad_h = child_style.padding.left + child_style.padding.right;
-            let border_h = if child_style.box_sizing == BoxSizing::BorderBox {
-                child_style.border.horizontal_width()
-            } else {
-                0.0
-            };
-            // Content width = text width + padding + border (capped at container)
+            let border_h = child_style.border.horizontal_width();
+            // Outer width = text + padding + border (capped at container)
             (natural_text_w + pad_h + border_h).min(width_for_percentages)
         } else {
             child_w_initial
@@ -408,14 +424,12 @@ pub(crate) fn layout_flex_container(
         } else {
             child_w
         };
-        let child_inner_w = if child_style.box_sizing == BoxSizing::BorderBox {
-            wrap_w
-                - child_style.padding.left
-                - child_style.padding.right
-                - child_style.border.horizontal_width()
-        } else {
-            wrap_w - child_style.padding.left - child_style.padding.right
-        }
+        // wrap_w is always the outer box width (after content-box inflation),
+        // so the inner content area is outer - padding - border.
+        let child_inner_w = (wrap_w
+            - child_style.padding.left
+            - child_style.padding.right
+            - child_style.border.horizontal_width())
         .max(0.0);
 
         let lines = if !runs.is_empty() {
@@ -962,6 +976,7 @@ pub(crate) fn layout_flex_container(
                                 background_repeat: BackgroundRepeat::Repeat,
                                 background_origin: BackgroundOrigin::Padding,
                                 transform: None,
+                                box_shadow: None,
                                 nested_elements: item.elements.clone(),
                                 y_offset: 0.0,
                                 line_cross_size: 0.0,
@@ -1026,6 +1041,7 @@ pub(crate) fn layout_flex_container(
                             background_repeat: BackgroundRepeat::Repeat,
                             background_origin: BackgroundOrigin::Padding,
                             transform: None,
+                            box_shadow: None,
                             nested_elements: Vec::new(),
                             y_offset: 0.0,
                             line_cross_size: 0.0,
@@ -1052,6 +1068,7 @@ pub(crate) fn layout_flex_container(
                         background_position: tb_bg_pos,
                         background_repeat: tb_bg_repeat,
                         background_origin: tb_bg_origin,
+                        box_shadow: tb_bs,
                         border,
                         ..
                     }) = item.elements.first()
@@ -1080,6 +1097,7 @@ pub(crate) fn layout_flex_container(
                             background_repeat: *tb_bg_repeat,
                             background_origin: *tb_bg_origin,
                             transform: None,
+                            box_shadow: *tb_bs,
                             nested_elements: Vec::new(),
                             natural_height: natural_h,
                             y_offset: 0.0,
@@ -1110,6 +1128,7 @@ pub(crate) fn layout_flex_container(
                             background_repeat: BackgroundRepeat::Repeat,
                             background_origin: BackgroundOrigin::Padding,
                             transform: None,
+                            box_shadow: None,
                             nested_elements: item.elements.clone(),
                             y_offset: 0.0,
                             line_cross_size: 0.0,

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -125,6 +125,7 @@ pub(crate) fn layout_inline_block_group(
         text_align: TextAlign,
         margin_left: f32,
         margin_right: f32,
+        box_shadow: Option<crate::style::computed::BoxShadow>,
     }
 
     let mut items: Vec<InlineBlockItem> = Vec::new();
@@ -277,6 +278,7 @@ pub(crate) fn layout_inline_block_group(
             text_align: child_style.text_align,
             margin_left: child_style.margin.left,
             margin_right: child_style.margin.right,
+            box_shadow: child_style.box_shadow,
         });
     }
 
@@ -323,6 +325,7 @@ pub(crate) fn layout_inline_block_group(
             background_repeat: item.background_repeat,
             background_origin: item.background_origin,
             transform: item.transform,
+            box_shadow: item.box_shadow,
             nested_elements: Vec::new(),
             y_offset: 0.0,
             line_cross_size: 0.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2058,6 +2058,41 @@ body { background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy
     }
 
     #[test]
+    fn pdf_inline_block_box_shadow_renders() {
+        // Regression: box-shadow on `display: inline-block` items (rendered via
+        // FlexCells) was dropped because FlexCell didn't carry the shadow. The
+        // blurred shadow path emits per-layer ExtGState entries with low alpha.
+        let html = "<div><div style=\"display:inline-block;width:80pt;height:40pt;\
+            background:white;box-shadow:4pt 4pt 8pt rgba(0,0,0,0.3)\">A</div></div>";
+        let pdf = html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        // The shadow renderer registers its alpha layers under `GSbs<n>`.
+        assert!(
+            content.contains("GSbs"),
+            "expected inline-block box-shadow to emit blurred shadow ExtGState (GSbs...)"
+        );
+    }
+
+    #[test]
+    fn pdf_svg_path_opacity_emits_gstate() {
+        // Regression: <path opacity="0.6"> inside inline SVG must register
+        // an ExtGState with /ca 0.6 so the shape is rendered translucent.
+        let html = "<svg width=\"120\" height=\"120\" viewBox=\"0 0 120 120\">\
+            <path d=\"M10,110 L60,20 L110,110 Z\" fill=\"#f97316\" opacity=\"0.6\" />\
+        </svg>";
+        let pdf = html_to_pdf(html).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("/ca 0.6"),
+            "expected SVG opacity to emit an ExtGState dict with /ca 0.6"
+        );
+        assert!(
+            content.contains("GSsvg"),
+            "expected the SVG ExtGState to be referenced via /GSsvgN gs"
+        );
+    }
+
+    #[test]
     fn pdf_box_shadow_renders_rect() {
         // Covers pdf.rs lines 184-213: box-shadow rendering
         let html =

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1486,6 +1486,25 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             }
                         }
 
+                        // Draw per-cell box-shadow (e.g. inline-block items
+                        // with `box-shadow`). We draw it before the background
+                        // so the shadow sits behind the cell.
+                        if let Some(shadow) = &cell.box_shadow {
+                            let cell_bg_x = margin.left + padding_left + cell.x_offset;
+                            let cell_bg_y = text_area_top - cell_y_shift - cell_render_h;
+                            render_box_shadow(
+                                &mut content,
+                                shadow,
+                                cell_bg_x,
+                                cell_bg_y,
+                                cell.width,
+                                cell_render_h,
+                                cell.border_radius,
+                                &mut page_ext_gstates,
+                                &mut bg_alpha_counter,
+                            );
+                        }
+
                         // Draw cell background
                         if let Some((r, g, b, a)) = cell.background_color {
                             let bg_x = margin.left + padding_left + cell.x_offset;
@@ -2018,6 +2037,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                                 crate::render::svg_to_pdf::SvgPdfResources {
                                                     shadings: &mut page_shadings,
                                                     shading_counter: &mut shading_counter,
+                                                    ext_gstates: Some(&mut page_ext_gstates),
                                                     image_sink: Some(&mut image_sink),
                                                 };
                                             crate::render::svg_to_pdf::render_svg_tree_with_resources(
@@ -2470,6 +2490,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             let mut resources = crate::render::svg_to_pdf::SvgPdfResources {
                                 shadings: &mut page_shadings,
                                 shading_counter: &mut shading_counter,
+                                ext_gstates: Some(&mut page_ext_gstates),
                                 image_sink: Some(&mut image_sink),
                             };
                             crate::render::svg_to_pdf::render_svg_tree_with_resources(
@@ -3237,6 +3258,7 @@ fn render_container_children(
                         let mut res = crate::render::svg_to_pdf::SvgPdfResources {
                             shadings: &mut Vec::new(),
                             shading_counter: &mut 0,
+                            ext_gstates: Some(page_ext_gstates),
                             image_sink: None,
                         };
                         crate::render::svg_to_pdf::render_svg_tree_with_resources(
@@ -3248,6 +3270,7 @@ fn render_container_children(
                     let mut res = crate::render::svg_to_pdf::SvgPdfResources {
                         shadings: &mut Vec::new(),
                         shading_counter: &mut 0,
+                        ext_gstates: Some(page_ext_gstates),
                         image_sink: None,
                     };
                     crate::render::svg_to_pdf::render_svg_tree_with_resources(
@@ -4365,6 +4388,7 @@ fn render_svg_background(
                     let mut resources = crate::render::svg_to_pdf::SvgPdfResources {
                         shadings,
                         shading_counter,
+                        ext_gstates: None,
                         image_sink: Some(&mut image_sink),
                     };
                     crate::render::svg_to_pdf::render_svg_tree_with_resources(

--- a/src/render/pdf_fonts.rs
+++ b/src/render/pdf_fonts.rs
@@ -456,6 +456,7 @@ mod tests {
             background_repeat: BackgroundRepeat::Repeat,
             background_origin: BackgroundOrigin::Padding,
             transform: None,
+            box_shadow: None,
             nested_elements: Vec::new(),
             y_offset: 0.0,
             line_cross_size: 0.0,

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -19,6 +19,7 @@ pub(crate) trait SvgImageObjectSink {
 pub(crate) struct SvgPdfResources<'a> {
     pub shadings: &'a mut Vec<ShadingEntry>,
     pub shading_counter: &'a mut usize,
+    pub ext_gstates: Option<&'a mut Vec<(String, f32)>>,
     pub image_sink: Option<&'a mut dyn SvgImageObjectSink>,
 }
 
@@ -27,6 +28,7 @@ impl<'a> SvgPdfResources<'a> {
         Self {
             shadings,
             shading_counter,
+            ext_gstates: None,
             image_sink: None,
         }
     }
@@ -37,6 +39,19 @@ impl<'a> SvgPdfResources<'a> {
 
     fn register_raster(&mut self, raw_image: &[u8]) -> Option<String> {
         self.image_sink.as_deref_mut()?.register_raster(raw_image)
+    }
+
+    /// Register an opacity ExtGState and return the generated name, or None
+    /// if ExtGState tracking isn't wired up (e.g. in tests).
+    ///
+    /// The name embeds the page-level ExtGState vector index, so it stays unique
+    /// even when multiple SVGs and HTML elements share the same page.
+    fn register_opacity(&mut self, opacity: f32) -> Option<String> {
+        let entries = self.ext_gstates.as_deref_mut()?;
+        let idx = entries.len();
+        let name = format!("GSsvg{idx}");
+        entries.push((name.clone(), opacity));
+        Some(name)
     }
 }
 
@@ -78,6 +93,7 @@ pub(crate) fn render_svg_tree_with_resources(
         font_family: None,
         font_bold: None,
         font_italic: None,
+        opacity: 1.0,
     };
     for node in &tree.children {
         render_node(
@@ -102,6 +118,8 @@ struct ResolvedStyle {
     font_family: Option<String>,
     font_bold: Option<bool>,
     font_italic: Option<bool>,
+    /// Accumulated (multiplicative) opacity from ancestor groups and self.
+    opacity: f32,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -197,6 +215,10 @@ fn resolve_style(parent: ResolvedStyle, local: &SvgStyle) -> ResolvedStyle {
         other => other.clone(),
     };
     let stroke_width = local.stroke_width.unwrap_or(parent.stroke_width);
+    // SVG `opacity` on a group applies to the composited result; the most
+    // faithful rendering without offscreen buffers is to multiply the parent's
+    // opacity by the local one and apply the combined alpha at each leaf.
+    let opacity = (parent.opacity * local.opacity).clamp(0.0, 1.0);
     ResolvedStyle {
         color,
         fill,
@@ -206,6 +228,7 @@ fn resolve_style(parent: ResolvedStyle, local: &SvgStyle) -> ResolvedStyle {
         font_family: local.font_family.clone().or(parent.font_family),
         font_bold: local.font_bold.or(parent.font_bold),
         font_italic: local.font_italic.or(parent.font_italic),
+        opacity,
     }
 }
 
@@ -319,6 +342,13 @@ fn render_node(
                 );
             }
 
+            // Isolate opacity state in its own q/Q so it doesn't leak to siblings.
+            let opacity_wrapped = style.opacity < 1.0;
+            if opacity_wrapped {
+                out.push_str("q\n");
+                push_opacity_gstate(&style, resources, out);
+            }
+
             match &style.fill {
                 SvgPaint::Url(id) => {
                     out.push_str(&path);
@@ -359,6 +389,10 @@ fn render_node(
                 }
             }
 
+            if opacity_wrapped {
+                out.push_str("Q\n");
+            }
+
             // Close clip-path save state
             if style.clip_path.is_some() {
                 out.push_str("Q\n");
@@ -379,9 +413,17 @@ fn render_node(
                 return;
             }
 
+            let opacity_wrapped = style.opacity < 1.0;
+            if opacity_wrapped {
+                out.push_str("q\n");
+                push_opacity_gstate(&style, resources, out);
+            }
             apply_stroke_style(&style, out);
             out.push_str(&path);
             paint_stroke_only(&style, out);
+            if opacity_wrapped {
+                out.push_str("Q\n");
+            }
         }
         SvgNode::Image {
             x,
@@ -447,6 +489,12 @@ fn render_node(
                 );
             }
 
+            let opacity_wrapped = style.opacity < 1.0;
+            if opacity_wrapped {
+                out.push_str("q\n");
+                push_opacity_gstate(&style, resources, out);
+            }
+
             // Use SVG-explicit font_size if set, otherwise inherit from CSS context
             let fill = paint_to_rgb(&style.fill, style.color);
             let stroke = paint_to_rgb(&style.stroke, style.color);
@@ -487,6 +535,9 @@ fn render_node(
             let encoded = encode_pdf_text(content);
             out.push_str(&format!("({encoded}) Tj\n"));
             out.push_str("ET\n");
+            if opacity_wrapped {
+                out.push_str("Q\n");
+            }
             if clip_path.is_some() {
                 out.push_str("Q\n");
             }
@@ -604,6 +655,7 @@ fn render_clip_path(
         font_family: None,
         font_bold: None,
         font_italic: None,
+        opacity: 1.0,
     };
 
     for transform in &transforms {
@@ -1062,6 +1114,21 @@ fn apply_style(style: &ResolvedStyle, out: &mut String) {
         out.push_str(&format!("{r} {g} {b} rg\n"));
     }
     apply_stroke_style(style, out);
+}
+
+/// Emit `/GSxx gs` for the node's effective opacity when it's < 1.0.
+/// Returns `true` when a gs operator was emitted, so the caller can balance
+/// a surrounding `q ... Q` pair that isolates the opacity state.
+fn push_opacity_gstate(style: &ResolvedStyle, resources: &mut SvgPdfResources, out: &mut String) -> bool {
+    if style.opacity >= 1.0 {
+        return false;
+    }
+    if let Some(name) = resources.register_opacity(style.opacity) {
+        out.push_str(&format!("/{name} gs\n"));
+        true
+    } else {
+        false
+    }
 }
 
 fn apply_stroke_style(style: &ResolvedStyle, out: &mut String) {
@@ -2689,6 +2756,7 @@ mod tests {
         let mut resources = SvgPdfResources {
             shadings: &mut shadings,
             shading_counter: &mut shading_counter,
+            ext_gstates: None,
             image_sink: Some(&mut image_sink),
         };
 

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -1119,7 +1119,11 @@ fn apply_style(style: &ResolvedStyle, out: &mut String) {
 /// Emit `/GSxx gs` for the node's effective opacity when it's < 1.0.
 /// Returns `true` when a gs operator was emitted, so the caller can balance
 /// a surrounding `q ... Q` pair that isolates the opacity state.
-fn push_opacity_gstate(style: &ResolvedStyle, resources: &mut SvgPdfResources, out: &mut String) -> bool {
+fn push_opacity_gstate(
+    style: &ResolvedStyle,
+    resources: &mut SvgPdfResources,
+    out: &mut String,
+) -> bool {
     if style.opacity >= 1.0 {
         return false;
     }


### PR DESCRIPTION
## Summary
Three pre-release parity fixes aimed at the dashboard diffs visible before tagging **v1.4.2**:

- **Flex item widths under `box-sizing: content-box`** — `width: 120px; padding: 16px` now occupies 152px of main-axis space, matching CSS spec and Chromium. Restores flex-wrap parity.
- **SVG `opacity` attribute** — propagated through `ResolvedStyle`, emitted as `/GSsvgN gs` + `ExtGState { /ca /CA }` before each paint. The orange triangle in `images-svg.html` is now 60% translucent instead of fully opaque.
- **`box-shadow` on `display: inline-block` items** — `FlexCell` now carries `box_shadow`, populated from the source TextBlock/inline style and rendered via `render_box_shadow` before the cell background. All six `.shadow-box` items in `transforms.html` now show their shadow.

Two regression tests added (`pdf_svg_path_opacity_emits_gstate`, `pdf_inline_block_box_shadow_renders`). Full suite: **2173 passed / 0 failed**.

Does **not** close parity bugs #10 (overflow + invisible text in nested overflow) or #12 (pseudo `::before` blue bars extending past `<p>` — tracked separately, needs margin-collapse fix).

## Test plan
- [x] `cargo test --lib` — 2173 passed, 0 failed, 3 ignored
- [x] `tests/fixtures/features/images-svg.html` → PDF contains `/ca 0.6`
- [x] `tests/fixtures/features/transforms.html` → PDF contains `GSbs*` blur layers for each `.shadow-box`
- [ ] Parity dashboard diffs on images-svg, transforms, flexbox shrink below previous thresholds