### PR TITLE
fix(pseudo): shift abs pseudo origin by first-child margin-top on collapse

### DIFF
--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -1279,10 +1279,26 @@ pub(crate) fn layout_block_element(
         };
         cb_info = make_containing_block(cb_height);
 
+        // When the first/last child's outer margins collapse through this
+        // container (no padding/border blocks them), the containing-block
+        // origin used for abs pseudos shifts down by the first child's
+        // margin-top so `top:0` aligns with the child's content top — matching
+        // Chrome's margin-collapse-through behavior.
+        let abs_origin_shift = if effective_height.is_none()
+            && style.padding.top == 0.0
+            && style.border.top.width == 0.0
+        {
+            child_elements
+                .first()
+                .map_or(0.0, crate::layout::helpers::outer_margin_top)
+        } else {
+            0.0
+        };
+
         // Add absolute-positioned ::before pseudo-element as a Container child.
         if let Some(ref ps) = before_style {
             if pseudo_is_block_like(ps) && ps.position == Position::Absolute {
-                child_elements.push(build_pseudo_block(
+                let mut pseudo = build_pseudo_block(
                     ps,
                     el,
                     inner_width,
@@ -1290,13 +1306,19 @@ pub(crate) fn layout_block_element(
                     cb_info,
                     positioned_depth,
                     env.counter_state,
-                ));
+                );
+                if abs_origin_shift > 0.0
+                    && let LayoutElement::TextBlock { offset_top, .. } = &mut pseudo
+                {
+                    *offset_top += abs_origin_shift;
+                }
+                child_elements.push(pseudo);
             }
         }
         // Add absolute-positioned ::after pseudo-element as a Container child.
         if let Some(ref ps) = after_style {
             if pseudo_is_block_like(ps) && ps.position == Position::Absolute {
-                child_elements.push(build_pseudo_block(
+                let mut pseudo = build_pseudo_block(
                     ps,
                     el,
                     inner_width,
@@ -1304,7 +1326,13 @@ pub(crate) fn layout_block_element(
                     cb_info,
                     positioned_depth,
                     env.counter_state,
-                ));
+                );
+                if abs_origin_shift > 0.0
+                    && let LayoutElement::TextBlock { offset_top, .. } = &mut pseudo
+                {
+                    *offset_top += abs_origin_shift;
+                }
+                child_elements.push(pseudo);
             }
         }
 

--- a/src/layout/helpers.rs
+++ b/src/layout/helpers.rs
@@ -72,7 +72,7 @@ pub(crate) fn collapse_outer_child_margins(
     (children_height - first_mt - last_mb).max(0.0)
 }
 
-fn outer_margin_top(el: &LayoutElement) -> f32 {
+pub(crate) fn outer_margin_top(el: &LayoutElement) -> f32 {
     match el {
         LayoutElement::TextBlock { margin_top, .. }
         | LayoutElement::Container { margin_top, .. }
@@ -86,7 +86,7 @@ fn outer_margin_top(el: &LayoutElement) -> f32 {
     }
 }
 
-fn outer_margin_bottom(el: &LayoutElement) -> f32 {
+pub(crate) fn outer_margin_bottom(el: &LayoutElement) -> f32 {
     match el {
         LayoutElement::TextBlock { margin_bottom, .. }
         | LayoutElement::Container { margin_bottom, .. }


### PR DESCRIPTION
When a container has no padding-top/border-top, its first block child's margin-top collapses through the parent (CSS 8.3.1). The containing-block origin for absolute-positioned children (e.g. a .block-pseudo::before `height:100%` left accent bar) should therefore sit at the child's content top, not above it.

Previously we collapsed the outer child margins out of the CB *height* (697e097) but left the CB origin at the container's pre-collapse top, so `top:0; height:100%` rendered *above* the paragraph, both starting and ending too early.

Adjust `offset_top` on any absolute pseudo by the first child's collapsed margin-top when the container has no top padding/border. The CB height remains the content-only height, so the bar now tightly hugs the paragraph content top to bottom — matching Chrome.