### PR TITLE
chore: bump python/ruby bindings to 1.4.2

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ironpress"
-version = "1.4.1"
+version = "1.4.2"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter. No browser, no system dependencies."
 readme = "README.md"
 license = "MIT"

--- a/bindings/ruby/ironpress.gemspec
+++ b/bindings/ruby/ironpress.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "ironpress"
-  spec.version       = "1.4.1"
+  spec.version       = "1.4.2"
   spec.authors       = ["Paul Gaston Gouron"]
   spec.summary       = "Pure Rust HTML/CSS/Markdown to PDF converter"
   spec.description   = "Convert HTML, CSS, and Markdown to PDF with no browser or system dependencies. Native Rust extension for maximum performance."


### PR DESCRIPTION
## Summary
- Bump `bindings/python/pyproject.toml` to 1.4.2
- Bump `bindings/ruby/ironpress.gemspec` to 1.4.2

The previous bump PR (#128) only touched root `Cargo.toml`. When the `v1.4.2` tag fired the publish workflows, maturin built `ironpress-1.4.1-*.whl` and skipped uploading (`--skip-existing`), and `gem push` failed with "Repushing of gem versions is not allowed" but was swallowed by `|| true`. Both workflows reported success despite not publishing.

## Next steps (after merge)
Re-push the `v1.4.2` tag onto the new merge commit to retrigger the Python/Ruby publish workflows. Cargo/npm will no-op (registries reject duplicate versions, workflow flags keep them green).

## Test plan
- [ ] CI green
- [ ] After merge + tag re-push: PyPI shows `ironpress==1.4.2`
- [ ] After merge + tag re-push: RubyGems shows `ironpress 1.4.2`