### PR TITLE
fix(parity): align render flags with Chrome --print-to-pdf defaults

### DIFF
--- a/scripts/generate-references.sh
+++ b/scripts/generate-references.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Generate Chromium reference PDFs and convert ALL pages to PNG for comparison.
-# Uses --print-to-pdf so Chrome applies the same A4 page constraints as ironpress.
+# Uses --print-to-pdf with Chrome's defaults (Letter, 0.4in margins). The parity
+# render script in scripts/render-fixtures.sh passes the matching flags so the
+# two rasters land on the same page geometry.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -33,7 +35,8 @@ for layer in features combined edge-cases; do
 
         echo "  $layer/$name..."
 
-        # Print to PDF with A4 page size (same as ironpress default)
+        # Print to PDF using Chrome's defaults (Letter, 0.4in margins).
+        # scripts/render-fixtures.sh aligns ironpress with --page-size letter --margin 28.8.
         "$CHROME" --headless=new --disable-gpu --no-sandbox --disable-software-rasterizer \
             --print-to-pdf="$ref_pdf" \
             --no-pdf-header-footer \

--- a/scripts/render-fixtures.sh
+++ b/scripts/render-fixtures.sh
@@ -25,8 +25,10 @@ for layer in features combined edge-cases; do
         name=$(basename "$html_file" .html)
         output="$OUTPUT_DIR/$layer/$name.pdf"
         echo "  $layer/$name..."
-        # Chromium --print-to-pdf defaults to 0.8in (57.6pt) on all sides.
-        "$CLI" --margin 57.6 "$html_file" "$output" 2>/dev/null || echo "    WARN: failed to render $layer/$name"
+        # Match Chromium --print-to-pdf defaults: Letter page, 0.4in (28.8pt) margins.
+        # Ironpress defaults to A4 + 72pt margins which produces a different raster
+        # size than the reference PDFs and creates spurious parity regressions.
+        "$CLI" --page-size letter --margin 28.8 "$html_file" "$output" 2>/dev/null || echo "    WARN: failed to render $layer/$name"
     done
 done
 


### PR DESCRIPTION
## Summary
- `render-fixtures.sh` now passes `--page-size letter --margin 28.8` so ironpress matches Chrome's `--print-to-pdf` defaults (Letter, 0.4in margins).
- Refresh the stale comment in `generate-references.sh` that claimed the reference pipeline was tuned to ironpress's A4 default — it was actually emitting Letter all along.

## Why
Ironpress was defaulting to A4 + 72pt margins while the reference pipeline used Chrome's defaults (Letter + 0.4in). The playground parity workflow compensated by ImageMagick-resizing the ironpress PNG to the reference dims, which stretched ~2.7% horizontally and squashed ~6% vertically. That's the "fond étiré" artefact in the parity dashboard and part of the "espacement différent sous le `<hr>`" feedback — the resize was warping measurements, not ironpress rendering incorrectly.

## Test plan
- [x] `ironpress --page-size letter --margin 28.8 <html> <pdf>` runs without error
- [ ] Parity CI: ironpress and reference PNGs now share dimensions (resize step becomes a no-op)
- [ ] `<hr>`/heading spacing visually closer between the two columns