### PR TITLE
fix(parity): honor body/html/:root margin

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -466,6 +466,37 @@ pub fn layout(nodes: &[DomNode], page_size: PageSize, margin: Margin) -> Vec<Pag
     layout_with_rules(nodes, page_size, margin, &[])
 }
 
+/// Resolve the margin declared on `body`, `html`, or `:root` selectors against
+/// the given page size. The result is additive to the caller-supplied page
+/// margin — Chrome treats the body margin as shrinking the printable area
+/// inside the page margin, so both offsets stack.
+///
+/// Returns zeros when no matching rule declares a margin.
+pub fn compute_root_margin(rules: &[CssRule], page_size: PageSize) -> Margin {
+    let mut style = ComputedStyle::default();
+    let parent = ComputedStyle {
+        viewport_width: page_size.width,
+        viewport_height: page_size.height,
+        root_font_size: style.font_size,
+        width: Some(page_size.width),
+        ..ComputedStyle::default()
+    };
+
+    for rule in rules {
+        let sel = rule.selector.trim();
+        if sel == "body" || sel == "html" || sel == ":root" {
+            crate::style::computed::apply_style_map(&mut style, &rule.declarations, &parent);
+        }
+    }
+
+    Margin {
+        top: style.margin.top,
+        right: style.margin.right,
+        bottom: style.margin.bottom,
+        left: style.margin.left,
+    }
+}
+
 /// Lay out the DOM nodes into pages with stylesheet rules.
 #[allow(dead_code)]
 pub fn layout_with_rules(
@@ -9320,6 +9351,35 @@ line 3</pre>
 
         style.background_image = Some(TEST_JPEG_DATA_URI.to_string());
         let _ = background_svg_for_style(&style);
+    }
+
+    #[test]
+    fn compute_root_margin_resolves_body_margin() {
+        // body { margin: 40px } → 40 CSS px = 30pt on each side.
+        let rules = parse_stylesheet("body { margin: 40px; }");
+        let m = compute_root_margin(&rules, PageSize::LETTER);
+        assert!((m.top - 30.0).abs() < 0.01, "top = {}", m.top);
+        assert!((m.right - 30.0).abs() < 0.01, "right = {}", m.right);
+        assert!((m.bottom - 30.0).abs() < 0.01, "bottom = {}", m.bottom);
+        assert!((m.left - 30.0).abs() < 0.01, "left = {}", m.left);
+    }
+
+    #[test]
+    fn compute_root_margin_zero_when_no_body_rule() {
+        let rules = parse_stylesheet("p { margin: 40px; }");
+        let m = compute_root_margin(&rules, PageSize::A4);
+        assert_eq!(m.top, 0.0);
+        assert_eq!(m.right, 0.0);
+        assert_eq!(m.bottom, 0.0);
+        assert_eq!(m.left, 0.0);
+    }
+
+    #[test]
+    fn compute_root_margin_accepts_html_and_root_selectors() {
+        let rules = parse_stylesheet(":root { margin-top: 20pt; } html { margin-left: 10pt; }");
+        let m = compute_root_margin(&rules, PageSize::A4);
+        assert!((m.top - 20.0).abs() < 0.01);
+        assert!((m.left - 10.0).abs() < 0.01);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,18 @@ impl HtmlConverter {
             ));
         }
 
+        // Step 3d: Fold body/html/:root margin into the effective page margin.
+        // Chrome's default UA sheet sets `body { margin: 8px }`, and author
+        // stylesheets frequently override it. Ironpress applies body styles
+        // to the root `ComputedStyle` for inheritance purposes but previously
+        // dropped the margin, leaving the first line flush against the page
+        // margin regardless of what the CSS requested.
+        let body_margin = layout::engine::compute_root_margin(&rules, effective_page_size);
+        effective_margin.top += body_margin.top;
+        effective_margin.right += body_margin.right;
+        effective_margin.bottom += body_margin.bottom;
+        effective_margin.left += body_margin.left;
+
         // Step 4: Parse custom fonts (API-registered + @font-face from CSS)
         let mut parsed_fonts = self.parse_custom_fonts();
 


### PR DESCRIPTION
## Summary
- Add `layout::engine::compute_root_margin()` which resolves the margin declared on `body`/`html`/`:root` selectors against the page viewport.
- In `HtmlConverter::convert_to_writer`, fold that margin into `effective_margin` so it stacks with the page margin (matching Chrome).
- Cover the helper with three unit tests (px resolution, no-op when no rule matches, html/:root selectors).

## Why
Ironpress already applied body/html/:root rules to the root `ComputedStyle` (so root inherited properties like `color` and `background` worked), but `parent_style.margin` was never consumed — it was silently dropped. So `body { margin: 40px }` rendered with the first line flush against the page margin, while Chrome inset it by an additional 30pt (40 CSS px). That's the "première ligne trop haute" parity complaint.

Before:
```
First line at (28.8, 28.8)   ← page margin only
```

After:
```
First line at (58.8, 58.8)   ← page margin 28.8 + body margin 30pt
```

## Test plan
- [x] `cargo test --release --lib` — 2176 passed (3 new).
- [x] Reproducer HTML: `body { margin: 40px }` + `<p>First line</p>` now lands at the expected offset.
- [ ] Parity dashboard shows reduced diff on fixtures that declare `body { margin: ... }`.