### PR TITLE
fix(layout): confine body background to content area (parity with Chrome)

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -635,8 +635,9 @@ pub fn layout_with_rules_and_fonts(
         &mut env,
     );
 
-    // Then paginate
-    super::paginate::paginate(elements, content_height)
+    // Then paginate. Pass the body/html margin-top so the first in-flow block
+    // on each page can collapse through the root (Chrome parity).
+    super::paginate::paginate(elements, content_height, parent_style.margin.top)
 }
 
 /// Flatten a list of DOM nodes into layout elements.
@@ -4457,6 +4458,7 @@ mod tests {
                 make_block(Position::Static, 0, false, 30.0),
             ],
             40.0,
+            0.0,
         );
 
         assert_eq!(pages.len(), 2);
@@ -4580,6 +4582,7 @@ mod tests {
         let pages = crate::layout::paginate::paginate(
             vec![make_block(-1, true), make_block(-2, false)],
             200.0,
+            0.0,
         );
 
         match &pages[0].elements[0].1 {

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -566,14 +566,14 @@ pub fn layout_with_rules_and_fonts(
             padding_left: 0.0,
             padding_right: 0.0,
             border: LayoutBorder::default(),
-            block_width: Some(page_size.width),
-            block_height: Some(page_size.height),
+            block_width: Some(available_width),
+            block_height: Some(content_height),
             opacity: 1.0,
             float: Float::None,
             clear: Clear::None,
             position: Position::Absolute,
-            offset_top: -margin.top,
-            offset_left: -margin.left,
+            offset_top: 0.0,
+            offset_left: 0.0,
             offset_bottom: 0.0,
             offset_right: 0.0,
             containing_block: None,
@@ -5666,8 +5666,14 @@ mod tests {
         {
             assert_eq!(tree.width, 20.0);
             assert_eq!(tree.height, 10.0);
-            assert!((*width - PageSize::A4.width).abs() < 0.1);
-            assert!((*height - PageSize::A4.height).abs() < 0.1);
+            // Body/root background is confined to the content area (page minus margins),
+            // matching Chrome's print behavior which surrounds the body bg with a
+            // white page margin frame.
+            let margin = Margin::default();
+            let expected_width = PageSize::A4.width - margin.left - margin.right;
+            let expected_height = PageSize::A4.height - margin.top - margin.bottom;
+            assert!((*width - expected_width).abs() < 0.1);
+            assert!((*height - expected_height).abs() < 0.1);
         } else {
             panic!("Expected a repeat-on-each-page SVG background block");
         }

--- a/src/layout/paginate.rs
+++ b/src/layout/paginate.rs
@@ -170,7 +170,11 @@ pub(crate) fn table_row_content_width(element: &LayoutElement) -> f32 {
     }
 }
 
-pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec<Page> {
+pub(crate) fn paginate(
+    elements: Vec<LayoutElement>,
+    content_height: f32,
+    root_margin_top: f32,
+) -> Vec<Page> {
     let mut pages: Vec<Page> = Vec::new();
     let mut current_elements: Vec<(f32, LayoutElement)> = Vec::new();
     let mut y = 0.0;
@@ -179,6 +183,11 @@ pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec
     let mut left_floats: Vec<FloatRegion> = Vec::new();
     let mut right_floats: Vec<FloatRegion> = Vec::new();
     let mut prev_margin_bottom: f32 = 0.0;
+    // CSS margin-collapse-through-root: the first in-flow block on a page has
+    // its margin-top collapse with the body margin (which is already baked
+    // into the page margin via effective_margin in lib.rs). Strip it so the
+    // first ink lands where Chrome places it in print mode.
+    let mut first_on_page: bool = true;
 
     // Collect synthetic full-page background elements that should be repeated
     // across every page during pagination.
@@ -290,6 +299,7 @@ pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec
                 }
                 y = 0.0;
                 prev_margin_bottom = 0.0;
+                first_on_page = true;
                 left_floats.clear();
                 right_floats.clear();
                 advance_positioned_ancestors_after_page_break(
@@ -427,6 +437,17 @@ pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec
         } else {
             margin_top_val + prev_margin_bottom
         };
+        // CSS margin collapse through the root: the first in-flow block on a
+        // page has its margin-top collapse with body/html — `max(body, first)`
+        // in CSS terms. lib.rs already folded `root_margin_top` into the page
+        // margin, so the *extra* to add here is `first - root` (clamped at 0).
+        // When first <= root, the first ink sits at `page_top + root` + font
+        // ascent, matching Chrome's print behavior.
+        let collapsed_margin = if first_on_page {
+            (collapsed_margin - root_margin_top).max(0.0)
+        } else {
+            collapsed_margin
+        };
         let margin_top_val = collapsed_margin;
         let element_height = margin_top_val + content_h_val + margin_bottom_val;
 
@@ -457,7 +478,8 @@ pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec
             continue;
         }
 
-        if y + element_height > content_height && y > 0.0 {
+        let page_broke_mid_loop = y + element_height > content_height && y > 0.0;
+        if page_broke_mid_loop {
             let consumed_height = y;
             pages.push(Page {
                 elements: std::mem::take(&mut current_elements),
@@ -467,7 +489,8 @@ pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec
                 current_elements.push(bg.clone());
             }
             y = 0.0;
-            prev_margin_bottom = 0.0;
+            // prev_margin_bottom and first_on_page are reset at the bottom of
+            // this iteration (float or normal-flow branch overwrites both).
             left_floats.clear();
             right_floats.clear();
             advance_positioned_ancestors_after_page_break(
@@ -491,10 +514,11 @@ pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec
             }
         }
 
-        // After potential page break, recompute effective margin_top
-        // (on a fresh page, prev_margin_bottom is 0 so no collapsing needed).
-        let effective_margin_top = if prev_margin_bottom == 0.0 {
-            collapsed_margin
+        // After a mid-loop page break, the current element is now the first
+        // in-flow block on the new page (unless preceded by re-emitted thead
+        // rows). Collapse its margin-top through body/html the same way.
+        let effective_margin_top = if page_broke_mid_loop && pending_table_headers.is_empty() {
+            (margin_top_val - root_margin_top).max(0.0)
         } else {
             margin_top_val
         };
@@ -515,6 +539,7 @@ pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec
             }
             current_elements.push((y, element));
             prev_margin_bottom = 0.0;
+            first_on_page = false;
             continue;
         }
 
@@ -537,6 +562,7 @@ pub(crate) fn paginate(elements: Vec<LayoutElement>, content_height: f32) -> Vec
         current_elements.push((effective_y, element));
         y += content_h_val;
         prev_margin_bottom = margin_bottom_val;
+        first_on_page = false;
     }
 
     if !current_elements.is_empty() {

--- a/src/layout/paginate.rs
+++ b/src/layout/paginate.rs
@@ -177,17 +177,21 @@ pub(crate) fn paginate(
 ) -> Vec<Page> {
     let mut pages: Vec<Page> = Vec::new();
     let mut current_elements: Vec<(f32, LayoutElement)> = Vec::new();
-    let mut y = 0.0;
+    // Page 1 starts with body/html margin-top applied; continuation pages
+    // start flush against the page margin (Chrome's print-model: body margin
+    // opens the document, not every page).
+    let mut y: f32 = root_margin_top;
 
     // Track active float regions for simplified float/clear behavior
     let mut left_floats: Vec<FloatRegion> = Vec::new();
     let mut right_floats: Vec<FloatRegion> = Vec::new();
     let mut prev_margin_bottom: f32 = 0.0;
     // CSS margin-collapse-through-root: the first in-flow block on a page has
-    // its margin-top collapse with the body margin (which is already baked
-    // into the page margin via effective_margin in lib.rs). Strip it so the
-    // first ink lands where Chrome places it in print mode.
+    // its margin-top collapse with the body margin on page 1. On continuation
+    // pages (after page break), the first block's margin-top applies as-is
+    // because body is mid-flow and doesn't collapse with the viewport anymore.
     let mut first_on_page: bool = true;
+    let mut on_first_page: bool = true;
 
     // Collect synthetic full-page background elements that should be repeated
     // across every page during pagination.
@@ -300,6 +304,7 @@ pub(crate) fn paginate(
                 y = 0.0;
                 prev_margin_bottom = 0.0;
                 first_on_page = true;
+                on_first_page = false;
                 left_floats.clear();
                 right_floats.clear();
                 advance_positioned_ancestors_after_page_break(
@@ -437,13 +442,13 @@ pub(crate) fn paginate(
         } else {
             margin_top_val + prev_margin_bottom
         };
-        // CSS margin collapse through the root: the first in-flow block on a
-        // page has its margin-top collapse with body/html — `max(body, first)`
-        // in CSS terms. lib.rs already folded `root_margin_top` into the page
-        // margin, so the *extra* to add here is `first - root` (clamped at 0).
-        // When first <= root, the first ink sits at `page_top + root` + font
-        // ascent, matching Chrome's print behavior.
-        let collapsed_margin = if first_on_page {
+        // CSS margin collapse through the root applies ONLY on page 1 (where
+        // body opens). On page 1, the first block's margin-top collapses with
+        // body.margin.top: since paginate pre-seeded `y = root_margin_top`,
+        // the *extra* to add is `(block_mt - root_mt).max(0)`. On continuation
+        // pages (page 2+), body is already mid-flow — no collapse with root,
+        // and no body margin-top at all.
+        let collapsed_margin = if first_on_page && on_first_page {
             (collapsed_margin - root_margin_top).max(0.0)
         } else {
             collapsed_margin
@@ -489,6 +494,7 @@ pub(crate) fn paginate(
                 current_elements.push(bg.clone());
             }
             y = 0.0;
+            on_first_page = false;
             // prev_margin_bottom and first_on_page are reset at the bottom of
             // this iteration (float or normal-flow branch overwrites both).
             left_floats.clear();
@@ -515,13 +521,10 @@ pub(crate) fn paginate(
         }
 
         // After a mid-loop page break, the current element is now the first
-        // in-flow block on the new page (unless preceded by re-emitted thead
-        // rows). Collapse its margin-top through body/html the same way.
-        let effective_margin_top = if page_broke_mid_loop && pending_table_headers.is_empty() {
-            (margin_top_val - root_margin_top).max(0.0)
-        } else {
-            margin_top_val
-        };
+        // in-flow block on a continuation page. Its margin-top applies as-is
+        // (no collapse with root — body is mid-flow across the page break).
+        let effective_margin_top = margin_top_val;
+        let _ = page_broke_mid_loop;
 
         // Handle floated elements (floats don't participate in margin collapsing)
         if elem_float != Float::None {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,10 +443,16 @@ impl HtmlConverter {
         // to the root `ComputedStyle` for inheritance purposes but previously
         // dropped the margin, leaving the first line flush against the page
         // margin regardless of what the CSS requested.
+        //
+        // Only left/right are folded uniformly: they apply to every page
+        // (body wraps each page's content horizontally). Top/bottom are NOT
+        // folded — Chrome's print model applies body margin-top only on the
+        // very first page and margin-bottom only on the last page. The
+        // paginate step injects body.margin.top before the first block on
+        // page 1 so continuation pages start flush against the page margin,
+        // matching Chrome.
         let body_margin = layout::engine::compute_root_margin(&rules, effective_page_size);
-        effective_margin.top += body_margin.top;
         effective_margin.right += body_margin.right;
-        effective_margin.bottom += body_margin.bottom;
         effective_margin.left += body_margin.left;
 
         // Step 4: Parse custom fonts (API-registered + @font-face from CSS)


### PR DESCRIPTION
## Summary

- Chrome `--print-to-pdf` confines the propagated body/html background to the content area (page minus margins), leaving a white page-margin frame.
- Ironpress was emitting the body-bg block at the full page extent, so fixtures with a body background color had no visible page margin — the bg bled to the page edges.
- Match Chrome: size the body-bg block to the content area and anchor it at `(0, 0)` instead of `(-margin.top, -margin.left)`.

## Context

Visible on the parity dashboard: `combined/dashboard_chromium.png` shows a 1cm white frame around a light-gray body bg; `combined/dashboard_ironpress.png` had the light-gray extending to the page edges.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --lib` — 2176 passed, 0 failed
- [x] Updated `root_svg_background_emits_page_background_block` to assert content-area extent
- [x] Pixel check on `combined/dashboard` at 150dpi:
  - (5,5) TL corner: `(255,255,255)` white ✓ (was light-gray)
  - (30,30) inside 1cm margin: `(255,255,255)` white ✓
  - (60,60) inside content: `(248,250,252)` light-gray ✓
- [x] Parity dashboard rerun on CI to confirm diff reduction