### PR TITLE
fix: reported bugs #139 (RTL), #140 (loose lists), #141 (code font)

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -210,6 +210,14 @@ std::fs::write("output.pdf", pdf).unwrap();
 2. Phase 2: CSS support
 3. Phase 3: Advanced features
 
+## Loose List
+
+- First item with some content
+  spanning two lines.
+
+- Second item after a blank line.
+  Markers sit on the first baseline.
+
 > ironpress: Pure Rust HTML to PDF. No browser needed.
 
 ---
@@ -314,6 +322,13 @@ unicode: `<html>
     <p>Arabic: \u0645\u0631\u062D\u0628\u0627 \u0628\u0627\u0644\u0639\u0627\u0644\u0645</p>
     <p>Hebrew: \u05E9\u05DC\u05D5\u05DD \u05E2\u05D5\u05DC\u05DD</p>
     <p>Mixed: Hello \u0645\u0631\u062D\u0628\u0627 World</p>
+  </div>
+
+  <h2>RTL Paragraphs (bidi)</h2>
+  <div class="sample" style="font-size: 18px;">
+    <div dir="rtl">\u05E9\u05DC\u05D5\u05DD \u05E2\u05D5\u05DC\u05DD Hello World</div>
+    <div style="direction: rtl;">\u05D1\u05D3\u05D9\u05E7\u05D4 \u05D1\u05E2\u05D1\u05E8\u05D9\u05EA RTL \u05D1\u05D3\u05D9\u05E7\u05D4 123</div>
+    <p>English only paragraph stays LTR.</p>
   </div>
 
   <h2>Mathematical Symbols</h2>

--- a/src/bidi.rs
+++ b/src/bidi.rs
@@ -42,11 +42,8 @@ pub(crate) fn reorder_runs_bidi(runs: &[TextRun], paragraph_rtl: bool) -> Vec<Te
 
     // Check if purely LTR — return unchanged
     if vis_ranges.len() == 1
-        && vis_ranges[0]
-            .start
-            .lt(&vis_levels.len())
-            .then(|| vis_levels[vis_ranges[0].start].is_ltr())
-            .unwrap_or(false)
+        && vis_ranges[0].start < vis_levels.len()
+        && vis_levels[vis_ranges[0].start].is_ltr()
     {
         return runs.to_vec();
     }
@@ -66,11 +63,8 @@ pub(crate) fn reorder_runs_bidi(runs: &[TextRun], paragraph_rtl: bool) -> Vec<Te
     for byte_range in vis_ranges.iter() {
         // Each visual run's characters remain in *logical* order inside the
         // run — the shaper (rustybuzz) will flip RTL glyphs itself. Only the
-        // *order of runs* is visual (left-to-right on the page).
-        let _level = vis_levels
-            .get(byte_range.start)
-            .copied()
-            .unwrap_or_else(|| if paragraph_rtl { Level::rtl() } else { Level::ltr() });
+        // *order of runs* is visual (left-to-right on the page), so we emit
+        // runs in the order `visual_runs` gives them.
         // Find chars in this byte range (already in logical order).
         let segment_chars: Vec<(char, usize)> = char_info
             .iter()

--- a/src/bidi.rs
+++ b/src/bidi.rs
@@ -5,8 +5,12 @@ use unicode_bidi::{BidiInfo, Level};
 
 /// Reorder text runs according to the Unicode Bidirectional Algorithm.
 ///
-/// Takes a list of text runs in logical order and returns them in visual
-/// order. RTL segments are reversed for correct display in a LTR PDF context.
+/// Takes a list of text runs in logical order and returns them split into
+/// one run per level-run, arranged in visual left-to-right order. Each
+/// resulting run's text is kept in LOGICAL order (not pre-reversed) so that
+/// the downstream text shaper (rustybuzz, via `guess_segment_properties`)
+/// can apply the correct RTL shaping itself. Pre-reversing here would cause
+/// rustybuzz to reverse a second time, undoing the bidi reorder.
 pub(crate) fn reorder_runs_bidi(runs: &[TextRun], paragraph_rtl: bool) -> Vec<TextRun> {
     if runs.is_empty() {
         return Vec::new();
@@ -31,12 +35,19 @@ pub(crate) fn reorder_runs_bidi(runs: &[TextRun], paragraph_rtl: bool) -> Vec<Te
     let para = &bidi_info.paragraphs[0];
     let line = para.range.clone();
 
-    // Get visual runs: each is a (byte_range, level) indicating a segment
-    // that should be displayed contiguously, with RTL segments reversed.
+    // Get visual runs: `vis_levels` is per-byte resolved levels; `vis_ranges`
+    // are byte ranges already in visual (left-to-right) order. We look up a
+    // run's level via its starting byte.
     let (vis_levels, vis_ranges) = bidi_info.visual_runs(para, line);
 
     // Check if purely LTR — return unchanged
-    if vis_ranges.len() == 1 && vis_levels[0].is_ltr() {
+    if vis_ranges.len() == 1
+        && vis_ranges[0]
+            .start
+            .lt(&vis_levels.len())
+            .then(|| vis_levels[vis_ranges[0].start].is_ltr())
+            .unwrap_or(false)
+    {
         return runs.to_vec();
     }
 
@@ -52,20 +63,20 @@ pub(crate) fn reorder_runs_bidi(runs: &[TextRun], paragraph_rtl: bool) -> Vec<Te
 
     let mut result: Vec<TextRun> = Vec::new();
 
-    for (idx, byte_range) in vis_ranges.iter().enumerate() {
-        let level = &vis_levels[idx];
-        // Find chars in this byte range
-        let mut segment_chars: Vec<(char, usize)> = char_info
+    for byte_range in vis_ranges.iter() {
+        // Each visual run's characters remain in *logical* order inside the
+        // run — the shaper (rustybuzz) will flip RTL glyphs itself. Only the
+        // *order of runs* is visual (left-to-right on the page).
+        let _level = vis_levels
+            .get(byte_range.start)
+            .copied()
+            .unwrap_or_else(|| if paragraph_rtl { Level::rtl() } else { Level::ltr() });
+        // Find chars in this byte range (already in logical order).
+        let segment_chars: Vec<(char, usize)> = char_info
             .iter()
             .filter(|(_, bo, _)| byte_range.contains(bo))
             .map(|(ch, _, ri)| (*ch, *ri))
             .collect();
-
-        // RTL segments: characters are already in logical order,
-        // reverse them for visual display
-        if level.is_rtl() {
-            segment_chars.reverse();
-        }
 
         // Group consecutive chars by run index and emit
         let mut current_text = String::new();

--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -224,7 +224,8 @@ pub(crate) fn layout_block_element(
                 style.font_size,
                 resolved_line_height_factor(style, fonts),
                 style.overflow_wrap,
-            ),
+            )
+            .with_rtl(style.direction_rtl),
             fonts,
         );
         if lines.is_empty() {
@@ -942,7 +943,8 @@ pub(crate) fn layout_block_element(
                 style.font_size,
                 resolved_line_height_factor(style, env.fonts),
                 style.overflow_wrap,
-            ),
+            )
+            .with_rtl(style.direction_rtl),
             env.fonts,
         );
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -1630,62 +1630,14 @@ pub(crate) fn flatten_element(
         // but its first block child is a <p>, inline that <p>'s runs so the
         // marker sits on the same baseline as the first line of text (matching
         // Chrome), and apply the <p>'s vertical margins on the combined block
-        // so consecutive loose items are separated as paragraphs.
-        let mut consumed_p_idx: Option<usize> = None;
-        let mut extra_margin_top: f32 = 0.0;
-        let mut extra_margin_bottom: f32 = 0.0;
-        let li_child_el_count = el
-            .children
-            .iter()
-            .filter(|c| matches!(c, DomNode::Element(_)))
-            .count();
-        if runs.len() == runs_before_inline {
-            // No direct inline content — look for first block <p> child
-            let mut child_el_ordinal = 0usize;
-            for (raw_idx, child) in el.children.iter().enumerate() {
-                if let DomNode::Element(child_el) = child {
-                    if child_el.tag == HtmlTag::P {
-                        // Inline this <p>'s runs
-                        let p_cls: Vec<&str> = child_el.class_list();
-                        let p_selector_ctx = SelectorContext {
-                            ancestors: child_ancestors.to_vec(),
-                            child_index: child_el_ordinal,
-                            sibling_count: li_child_el_count,
-                            preceding_siblings: Vec::new(),
-                        };
-                        let p_style = compute_style_with_context(
-                            child_el.tag,
-                            child_el.style_attr(),
-                            &style,
-                            env.rules,
-                            child_el.tag_name(),
-                            &p_cls,
-                            child_el.id(),
-                            &child_el.attributes,
-                            &p_selector_ctx,
-                        );
-                        collect_text_runs(
-                            &child_el.children,
-                            &p_style,
-                            &mut runs,
-                            None,
-                            env.rules,
-                            env.fonts,
-                            &child_ancestors,
-                        );
-                        extra_margin_top = p_style.margin.top;
-                        extra_margin_bottom = p_style.margin.bottom;
-                        consumed_p_idx = Some(raw_idx);
-                        break;
-                    }
-                    child_el_ordinal += 1;
-                    // Stop looking after first block-level non-<p> sibling
-                    if recurses_as_layout_child(child_el.tag) {
-                        break;
-                    }
-                }
-            }
-        }
+        // so consecutive loose items are separated as paragraphs. Gated on
+        // <li> to keep the hot path (nested blocks) free of extra stack.
+        let (consumed_p_idx, extra_margin_top, extra_margin_bottom) =
+            if el.tag == HtmlTag::Li && runs.len() == runs_before_inline {
+                inline_loose_list_p(el, &style, &child_ancestors, env, &mut runs)
+            } else {
+                (None, 0.0, 0.0)
+            };
 
         let block_heading_level = heading_level(el.tag);
 
@@ -1851,6 +1803,69 @@ pub(crate) fn flatten_element(
         after_style,
         env,
     );
+}
+
+/// Extracted helper for the loose-list fix (#140): when an `<li>` has no
+/// direct inline content and its first block child is a `<p>`, inline that
+/// `<p>`'s runs into the li's TextBlock and return the `<p>`'s margins +
+/// raw child index so the caller can skip re-emitting it as a block.
+///
+/// Isolated into its own function so the extra locals (SelectorContext,
+/// ComputedStyle, class list, etc.) are only paid for on the `<li>` path,
+/// not on every recursive `flatten_element` frame — deep nested blocks are
+/// otherwise stack-sensitive.
+fn inline_loose_list_p(
+    el: &ElementNode,
+    parent_style: &ComputedStyle,
+    child_ancestors: &[AncestorInfo],
+    env: &mut LayoutEnv,
+    runs: &mut Vec<TextRun>,
+) -> (Option<usize>, f32, f32) {
+    let li_child_el_count = el
+        .children
+        .iter()
+        .filter(|c| matches!(c, DomNode::Element(_)))
+        .count();
+    let mut child_el_ordinal = 0usize;
+    for (raw_idx, child) in el.children.iter().enumerate() {
+        if let DomNode::Element(child_el) = child {
+            if child_el.tag == HtmlTag::P {
+                let p_cls: Vec<&str> = child_el.class_list();
+                let p_selector_ctx = SelectorContext {
+                    ancestors: child_ancestors.to_vec(),
+                    child_index: child_el_ordinal,
+                    sibling_count: li_child_el_count,
+                    preceding_siblings: Vec::new(),
+                };
+                let p_style = compute_style_with_context(
+                    child_el.tag,
+                    child_el.style_attr(),
+                    parent_style,
+                    env.rules,
+                    child_el.tag_name(),
+                    &p_cls,
+                    child_el.id(),
+                    &child_el.attributes,
+                    &p_selector_ctx,
+                );
+                collect_text_runs(
+                    &child_el.children,
+                    &p_style,
+                    runs,
+                    None,
+                    env.rules,
+                    env.fonts,
+                    child_ancestors,
+                );
+                return (Some(raw_idx), p_style.margin.top, p_style.margin.bottom);
+            }
+            child_el_ordinal += 1;
+            if recurses_as_layout_child(child_el.tag) {
+                break;
+            }
+        }
+    }
+    (None, 0.0, 0.0)
 }
 
 /// Dispatch an element to the appropriate layout function based on its

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -735,7 +735,8 @@ fn flatten_nodes(
                             parent_style.font_size,
                             resolved_line_height_factor(parent_style, env.fonts),
                             parent_style.overflow_wrap,
-                        ),
+                        )
+                        .with_rtl(parent_style.direction_rtl),
                         env.fonts,
                     );
                     if !lines.is_empty() {
@@ -1137,7 +1138,8 @@ pub(crate) fn flatten_element(
                     style.font_size,
                     resolved_line_height_factor(&style, env.fonts),
                     style.overflow_wrap,
-                ),
+                )
+                .with_rtl(style.direction_rtl),
                 env.fonts,
             );
         }
@@ -1291,7 +1293,8 @@ pub(crate) fn flatten_element(
                 style.font_size,
                 resolved_line_height_factor(&style, env.fonts),
                 style.overflow_wrap,
-            ),
+            )
+            .with_rtl(style.direction_rtl),
             env.fonts,
         );
 
@@ -1611,6 +1614,7 @@ pub(crate) fn flatten_element(
             );
         }
 
+        let runs_before_inline = runs.len();
         collect_text_runs(
             &el.children,
             &style,
@@ -1620,6 +1624,68 @@ pub(crate) fn flatten_element(
             env.fonts,
             ancestors,
         );
+
+        // "Loose" list items (Markdown with blank lines between items) wrap each
+        // item's content in a <p>. When the <li> has no direct inline content
+        // but its first block child is a <p>, inline that <p>'s runs so the
+        // marker sits on the same baseline as the first line of text (matching
+        // Chrome), and apply the <p>'s vertical margins on the combined block
+        // so consecutive loose items are separated as paragraphs.
+        let mut consumed_p_idx: Option<usize> = None;
+        let mut extra_margin_top: f32 = 0.0;
+        let mut extra_margin_bottom: f32 = 0.0;
+        let li_child_el_count = el
+            .children
+            .iter()
+            .filter(|c| matches!(c, DomNode::Element(_)))
+            .count();
+        if runs.len() == runs_before_inline {
+            // No direct inline content — look for first block <p> child
+            let mut child_el_ordinal = 0usize;
+            for (raw_idx, child) in el.children.iter().enumerate() {
+                if let DomNode::Element(child_el) = child {
+                    if child_el.tag == HtmlTag::P {
+                        // Inline this <p>'s runs
+                        let p_cls: Vec<&str> = child_el.class_list();
+                        let p_selector_ctx = SelectorContext {
+                            ancestors: child_ancestors.to_vec(),
+                            child_index: child_el_ordinal,
+                            sibling_count: li_child_el_count,
+                            preceding_siblings: Vec::new(),
+                        };
+                        let p_style = compute_style_with_context(
+                            child_el.tag,
+                            child_el.style_attr(),
+                            &style,
+                            env.rules,
+                            child_el.tag_name(),
+                            &p_cls,
+                            child_el.id(),
+                            &child_el.attributes,
+                            &p_selector_ctx,
+                        );
+                        collect_text_runs(
+                            &child_el.children,
+                            &p_style,
+                            &mut runs,
+                            None,
+                            env.rules,
+                            env.fonts,
+                            &child_ancestors,
+                        );
+                        extra_margin_top = p_style.margin.top;
+                        extra_margin_bottom = p_style.margin.bottom;
+                        consumed_p_idx = Some(raw_idx);
+                        break;
+                    }
+                    child_el_ordinal += 1;
+                    // Stop looking after first block-level non-<p> sibling
+                    if recurses_as_layout_child(child_el.tag) {
+                        break;
+                    }
+                }
+            }
+        }
 
         let block_heading_level = heading_level(el.tag);
 
@@ -1631,7 +1697,8 @@ pub(crate) fn flatten_element(
                     style.font_size,
                     resolved_line_height_factor(&style, env.fonts),
                     style.overflow_wrap,
-                ),
+                )
+                .with_rtl(style.direction_rtl),
                 env.fonts,
             );
             let BackgroundFields {
@@ -1646,8 +1713,8 @@ pub(crate) fn flatten_element(
             } = BackgroundFields::from_style(&style);
             output.push(LayoutElement::TextBlock {
                 lines,
-                margin_top: style.margin.top,
-                margin_bottom: style.margin.bottom,
+                margin_top: style.margin.top + extra_margin_top,
+                margin_bottom: style.margin.bottom + extra_margin_bottom,
                 text_align: style.text_align,
                 background_color: None,
                 padding_top: style.padding.top,
@@ -1700,7 +1767,12 @@ pub(crate) fn flatten_element(
             .filter(|c| matches!(c, DomNode::Element(_)))
             .count();
         let mut child_el_idx = 0;
-        for child in &el.children {
+        for (raw_idx, child) in el.children.iter().enumerate() {
+            if Some(raw_idx) == consumed_p_idx {
+                // This <p> was inlined into the li's TextBlock above — skip.
+                child_el_idx += 1;
+                continue;
+            }
             if let DomNode::Element(child_el) = child {
                 if child_el.tag == HtmlTag::Ul || child_el.tag == HtmlTag::Ol {
                     let child_ctx = layout_ctx

--- a/src/layout/flex.rs
+++ b/src/layout/flex.rs
@@ -440,7 +440,8 @@ pub(crate) fn layout_flex_container(
                     child_style.font_size,
                     resolved_line_height_factor(&child_style, env.fonts),
                     child_style.overflow_wrap,
-                ),
+                )
+                .with_rtl(child_style.direction_rtl),
                 env.fonts,
             )
         } else {

--- a/src/layout/grid.rs
+++ b/src/layout/grid.rs
@@ -165,7 +165,8 @@ pub(crate) fn layout_grid_container(
                     child_style.font_size,
                     resolved_line_height_factor(&child_style, env.fonts),
                     child_style.overflow_wrap,
-                ),
+                )
+                .with_rtl(child_style.direction_rtl),
                 env.fonts,
             );
 

--- a/src/layout/helpers.rs
+++ b/src/layout/helpers.rs
@@ -347,7 +347,8 @@ pub(crate) fn build_pseudo_block(
                 pseudo_style.font_size,
                 resolved_line_height_factor(pseudo_style, fonts),
                 pseudo_style.overflow_wrap,
-            ),
+            )
+            .with_rtl(pseudo_style.direction_rtl),
             fonts,
         );
     }

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -205,7 +205,8 @@ pub(crate) fn layout_inline_block_group(
                     child_style.font_size,
                     resolved_line_height_factor(&child_style, fonts),
                     child_style.overflow_wrap,
-                ),
+                )
+                .with_rtl(child_style.direction_rtl),
                 fonts,
             )
         } else {

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -1005,7 +1005,8 @@ pub(crate) fn flatten_table(
                     cell_style.font_size,
                     resolved_line_height_factor(&cell_style, fonts),
                     cell_style.overflow_wrap,
-                ),
+                )
+                .with_rtl(cell_style.direction_rtl),
                 fonts,
             );
 

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -99,6 +99,9 @@ pub(crate) struct TextWrapOptions {
     pub(crate) default_font_size: f32,
     pub(crate) line_height_factor: f32,
     pub(crate) overflow_wrap: OverflowWrap,
+    /// Paragraph base direction for the Unicode Bidi Algorithm. Set to `true`
+    /// when the containing block has `direction: rtl` (or `dir="rtl"`).
+    pub(crate) paragraph_rtl: bool,
 }
 
 impl TextWrapOptions {
@@ -113,7 +116,13 @@ impl TextWrapOptions {
             default_font_size,
             line_height_factor,
             overflow_wrap,
+            paragraph_rtl: false,
         }
+    }
+
+    pub(crate) const fn with_rtl(mut self, rtl: bool) -> Self {
+        self.paragraph_rtl = rtl;
+        self
     }
 }
 
@@ -173,12 +182,12 @@ pub(crate) fn wrap_text_runs(
         .fold(options.default_font_size, f32::max);
     let mut line_height = base_font_size * line_height_factor;
 
-    // Apply BiDi reordering if the text contains RTL characters.
-    // This reorders runs into visual order so RTL segments display correctly
-    // in the left-to-right PDF rendering context.
+    // Apply BiDi reordering if the paragraph direction is RTL or the text
+    // contains RTL characters. This reorders runs into visual order so
+    // RTL/LTR segments display correctly in the left-to-right PDF context.
     let full_text: String = runs.iter().map(|r| r.text.as_str()).collect();
-    let runs = if crate::bidi::has_rtl_chars(&full_text) {
-        crate::bidi::reorder_runs_bidi(&runs, false)
+    let runs = if options.paragraph_rtl || crate::bidi::has_rtl_chars(&full_text) {
+        crate::bidi::reorder_runs_bidi(&runs, options.paragraph_rtl)
     } else {
         runs
     };

--- a/src/parser/css/values.rs
+++ b/src/parser/css/values.rs
@@ -297,6 +297,7 @@ pub(crate) fn parse_property_value(property: &str, val: &str) -> Option<CssValue
             | "overflow-wrap"
             | "word-wrap"
             | "text-transform"
+            | "direction"
     ) {
         return Some(CssValue::Keyword(val.to_string()));
     }

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -4210,6 +4210,12 @@ fn merge_runs(runs: &[TextRun]) -> Vec<TextRun> {
                 && prev.background_color == run.background_color
                 && prev.padding == run.padding
                 && prev.border_radius == run.border_radius
+                // Don't merge across an RTL <-> LTR boundary: the bidi pass
+                // split these into separate runs in visual order, and merging
+                // would give the shaper a mixed-script buffer whose guessed
+                // direction flips glyph order for one side. See #139.
+                && crate::bidi::has_rtl_chars(&prev.text)
+                    == crate::bidi::has_rtl_chars(&run.text)
         } else {
             false
         };

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -2074,6 +2074,24 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
         };
     }
 
+    // CSS `direction` property. Inheritable. `dir=` attribute wins over CSS
+    // but is applied earlier in compute_style_with_context; here we only set
+    // from CSS when present.
+    if let Some(CssValue::Keyword(k)) = get_non_special(map, "direction") {
+        match k.as_str() {
+            "rtl" => {
+                style.direction_rtl = true;
+                if style.text_align == TextAlign::Left {
+                    style.text_align = TextAlign::Right;
+                }
+            }
+            "ltr" => {
+                style.direction_rtl = false;
+            }
+            _ => {}
+        }
+    }
+
     // Text-transform
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "text-transform") {
         style.text_transform = match k.as_str() {

--- a/src/style/defaults.rs
+++ b/src/style/defaults.rs
@@ -113,6 +113,7 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
             style.set("font-style", CssValue::Keyword("italic".into()));
         }
         HtmlTag::Pre => {
+            style.set("font-family", CssValue::Keyword("monospace".into()));
             style.set("font-size", CssValue::Length(10.0));
             style.set("margin-top", CssValue::Length(8.0));
             style.set("margin-bottom", CssValue::Length(8.0));
@@ -127,6 +128,7 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
             style.set("white-space", CssValue::Keyword("pre".into()));
         }
         HtmlTag::Code => {
+            style.set("font-family", CssValue::Keyword("monospace".into()));
             style.set("font-size", CssValue::Length(10.0));
             style.set(
                 "background-color",


### PR DESCRIPTION
## Summary

Fixes three reported bugs:

- **#141** — `<pre>` / `<code>` now default to `monospace`, so code blocks no longer inherit the surrounding sans-serif body font.
- **#140** — Markdown "loose" lists (blank lines between items) wrap each item's content in a `<p>`. We now inline that `<p>`'s runs into the `<li>`'s TextBlock so the marker sits on the same baseline as the first line of text (Chrome parity), while keeping the `<p>`'s vertical margins so consecutive loose items remain separated.
- **#139** — RTL text (Hebrew/Arabic) rendered in the wrong order, and CSS `direction: rtl` was silently dropped. Five changes:
  - Parser: added `direction` to the keyword-property allowlist so CSS `direction: rtl` actually applies.
  - Style: parse `direction` in `apply_style_map`; when `rtl`, flip the default text-align to `right` (matches Chrome / UAX #9 defaults).
  - Layout: threaded `paragraph_rtl` through `TextWrapOptions` and passed it from every call site (block / inline / flex / grid / table / engine / helpers).
  - Bidi: `vis_levels` from `unicode-bidi` is per-byte (not per-run) — fixed the index. Also stopped pre-reversing chars inside RTL visual runs; rustybuzz (via `guess_segment_properties`) handles RTL glyph reversal itself, so pre-reversing caused a double-reversal.
  - Render: `merge_runs` no longer fuses adjacent runs across an RTL↔LTR boundary. Merging would hand the shaper a mixed-script buffer whose single guessed direction flips one side's glyphs.

Verified the RTL fix visually against Chrome headless for `<div style="direction: rtl">`, `<div dir="rtl">`, and plain English paragraphs — all match.

## Test plan

- [x] `cargo test --release` — 2176 + 24 + 28 + 15 + 13 tests pass, 0 failures
- [x] Render `/tmp/bugs/139.html` with ironpress and compare to Chrome headless output — visually identical
- [x] Render `/tmp/bugs/140.md` (loose list) — marker sits on the first text baseline
- [x] Render `/tmp/bugs/141.md` (code block) — code renders in monospace