### PR TITLE
add PNG alpha support

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -248,6 +248,7 @@ pub struct RasterImageAsset {
     pub source_height: u32,
     pub format: ImageFormat,
     pub png_metadata: Option<PngMetadata>,
+    pub alpha_mask: Option<Vec<u8>>,
 }
 
 pub use super::context::*;

--- a/src/layout/images.rs
+++ b/src/layout/images.rs
@@ -75,6 +75,15 @@ pub(crate) fn try_parse_svg_bytes(raw: &[u8]) -> Option<crate::parser::svg::SvgT
 pub(crate) fn load_image_bytes(raw: Vec<u8>) -> Option<RasterImageAsset> {
     if png::is_png(&raw) {
         let png_info = png::parse_png(&raw)?;
+
+        if png_info.has_alpha() {
+            // PDF can't decode raw PNG IDAT into a color stream + alpha mask in
+            // a single pass: alpha must live in a separate `/SMask` XObject. We
+            // decode the PNG once here, split color/alpha and FlateDecode each
+            // half so the renderer can embed both streams without further work.
+            return decode_png_with_alpha(&raw);
+        }
+
         let metadata = PngMetadata {
             channels: png_info.channels,
             bit_depth: png_info.bit_depth,
@@ -85,6 +94,7 @@ pub(crate) fn load_image_bytes(raw: Vec<u8>) -> Option<RasterImageAsset> {
             source_height: png_info.height,
             format: ImageFormat::Png,
             png_metadata: Some(metadata),
+            alpha_mask: None,
         })
     } else if raw.starts_with(&[0xFF, 0xD8]) {
         let (source_width, source_height) = crate::parser::jpeg::parse_jpeg_dimensions(&raw)?;
@@ -94,10 +104,66 @@ pub(crate) fn load_image_bytes(raw: Vec<u8>) -> Option<RasterImageAsset> {
             source_height,
             format: ImageFormat::Jpeg,
             png_metadata: None,
+            alpha_mask: None,
         })
     } else {
         None
     }
+}
+
+fn decode_png_with_alpha(raw: &[u8]) -> Option<RasterImageAsset> {
+    let mut decoder = png_decoder::Decoder::new(std::io::Cursor::new(raw));
+    decoder.ignore_checksums(true);
+    let mut reader = decoder.read_info().ok()?;
+    let output_size = reader.output_buffer_size()?;
+    let mut buffer = vec![0; output_size];
+    let info = reader.next_frame(&mut buffer).ok()?;
+    let pixels = buffer.get(..info.buffer_size())?;
+
+    let pixel_count = (info.width as usize).checked_mul(info.height as usize)?;
+    let mut color_data = Vec::new();
+    let mut alpha_data = Vec::with_capacity(pixel_count);
+    let color_channels = match info.color_type {
+        png_decoder::ColorType::Rgba => {
+            color_data.reserve(pixel_count * 3);
+            for chunk in pixels.chunks_exact(4) {
+                color_data.extend_from_slice(&chunk[..3]);
+                alpha_data.push(chunk[3]);
+            }
+            3
+        }
+        png_decoder::ColorType::GrayscaleAlpha => {
+            color_data.reserve(pixel_count);
+            for chunk in pixels.chunks_exact(2) {
+                color_data.push(chunk[0]);
+                alpha_data.push(chunk[1]);
+            }
+            1
+        }
+        _ => return None,
+    };
+
+    let color_compressed = flate_compress(&color_data)?;
+    let alpha_compressed = flate_compress(&alpha_data)?;
+
+    Some(RasterImageAsset {
+        data: color_compressed,
+        source_width: info.width,
+        source_height: info.height,
+        format: ImageFormat::Png,
+        png_metadata: Some(PngMetadata {
+            channels: color_channels,
+            bit_depth: 8,
+        }),
+        alpha_mask: Some(alpha_compressed),
+    })
+}
+
+fn flate_compress(data: &[u8]) -> Option<Vec<u8>> {
+    use std::io::Write;
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(data).ok()?;
+    encoder.finish().ok()
 }
 
 /// Load image data from an <img> element and return a LayoutElement.
@@ -642,6 +708,7 @@ pub(crate) fn blur_image_bytes(raw: &[u8], blur_radius: f32) -> Option<RasterIma
         source_height: decoded.height(),
         format: ImageFormat::Jpeg,
         png_metadata: None,
+        alpha_mask: None,
     })
 }
 

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -7235,6 +7235,103 @@ mod tests {
         assert!(content.contains("/Colors 1"));
     }
 
+    #[test]
+    fn render_rgba_png_image_emits_smask() {
+        let png_bytes = build_test_rgba_png(2, 2);
+        let b64 = simple_base64_encode_test(&png_bytes);
+        let html = format!(r#"<img src="data:image/png;base64,{b64}" width="40" height="40">"#);
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+
+        let image_objects = content.matches("/Subtype /Image").count();
+        assert_eq!(
+            image_objects, 2,
+            "RGBA PNG should produce a color XObject and a separate alpha XObject"
+        );
+        assert!(
+            content.contains("/SMask "),
+            "RGBA PNG color XObject should reference an /SMask"
+        );
+        assert!(
+            content.contains("/ColorSpace /DeviceRGB"),
+            "Color XObject should use DeviceRGB"
+        );
+        assert!(
+            content.contains("/ColorSpace /DeviceGray"),
+            "Alpha XObject should use DeviceGray"
+        );
+        assert!(
+            !content.contains("/Colors 4"),
+            "RGBA must not be embedded as a 4-channel DeviceRGB stream"
+        );
+    }
+
+    #[test]
+    fn render_grayscale_alpha_png_image_emits_smask() {
+        let png_bytes = build_test_grayscale_alpha_png(2, 2);
+        let b64 = simple_base64_encode_test(&png_bytes);
+        let html = format!(r#"<img src="data:image/png;base64,{b64}" width="40" height="40">"#);
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+
+        assert_eq!(
+            content.matches("/Subtype /Image").count(),
+            2,
+            "Grayscale+Alpha PNG should produce two image XObjects"
+        );
+        assert!(content.contains("/SMask "));
+        assert!(
+            !content.contains("/Colors 2"),
+            "Grayscale+Alpha must not be embedded as a 2-channel DeviceGray stream"
+        );
+    }
+
+    fn build_test_rgba_png(width: u32, height: u32) -> Vec<u8> {
+        let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+        for i in 0..(width * height) {
+            let v = (i * 32) as u8;
+            pixels.extend_from_slice(&[v, 255 - v, 128, (v.wrapping_add(16))]);
+        }
+
+        let buffer = image::ImageBuffer::from_raw(width, height, pixels)
+            .expect("rgba buffer should be valid");
+
+        let mut encoded = Vec::new();
+        image::DynamicImage::ImageRgba8(buffer)
+            .write_to(
+                &mut std::io::Cursor::new(&mut encoded),
+                image::ImageFormat::Png,
+            )
+            .expect("png encode");
+        encoded
+    }
+
+    fn build_test_grayscale_alpha_png(width: u32, height: u32) -> Vec<u8> {
+        let mut pixels = Vec::with_capacity((width * height * 2) as usize);
+
+        for i in 0..(width * height) {
+            let v = (i * 32) as u8;
+            pixels.extend_from_slice(&[v, (v.wrapping_add(8))]);
+        }
+
+        let buffer =
+            image::ImageBuffer::from_raw(width, height, pixels)
+                .expect("luma+alpha buffer should be valid");
+
+        let mut encoded = Vec::new();
+        image::DynamicImage::ImageLumaA8(buffer)
+            .write_to(
+                &mut std::io::Cursor::new(&mut encoded),
+                image::ImageFormat::Png,
+            )
+            .expect("png encode");
+        encoded
+    }
+
     /// Build a minimal valid PNG (1x1 RGB, 8-bit).
     fn build_minimal_test_png() -> Vec<u8> {
         build_test_png_with_color_type(2) // RGB

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -2512,6 +2512,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                         image.source_height,
                         image.format,
                         image.png_metadata.as_ref(),
+                        image.alpha_mask.as_deref(),
                     );
                     let img_name = format!("Im{img_obj_id}");
                     content.push_str(&format!(
@@ -5184,6 +5185,10 @@ impl PdfWriter {
     }
 
     /// Add an image as a PDF XObject and return its object ID.
+    ///
+    /// When `alpha_mask` is `Some`, `data` is treated as a FlateDecode-compressed
+    /// raw color stream (no PNG predictor) and a separate `/SMask` XObject is
+    /// emitted carrying the grayscale alpha channel.
     fn add_image_object(
         &mut self,
         data: &[u8],
@@ -5191,7 +5196,19 @@ impl PdfWriter {
         height: u32,
         format: ImageFormat,
         png_metadata: Option<&PngMetadata>,
+        alpha_mask: Option<&[u8]>,
     ) -> usize {
+        let smask_id = alpha_mask.map(|alpha| {
+            let id = self.next_id();
+            let header = format!(
+                "{id} 0 obj\n<< /Type /XObject /Subtype /Image /Width {width} /Height {height} /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter /FlateDecode /Length {len} >>\nstream\n",
+                len = alpha.len(),
+            );
+            self.objects.push(header);
+            self.binary_objects.insert(id, alpha.to_vec());
+            id
+        });
+
         let id = self.next_id();
         let header = match format {
             ImageFormat::Jpeg => {
@@ -5206,12 +5223,23 @@ impl PdfWriter {
                     1 | 2 => "/DeviceGray",
                     _ => "/DeviceRGB",
                 };
-                format!(
-                    "{id} 0 obj\n<< /Type /XObject /Subtype /Image /Width {width} /Height {height} /ColorSpace {color_space} /BitsPerComponent {bpc} /Filter /FlateDecode /DecodeParms << /Predictor 15 /Columns {width} /Colors {channels} /BitsPerComponent {bpc} >> /Length {len} >>\nstream\n",
-                    bpc = meta.bit_depth,
-                    channels = meta.channels,
-                    len = data.len(),
-                )
+                let smask_entry = smask_id
+                    .map(|sid| format!(" /SMask {sid} 0 R"))
+                    .unwrap_or_default();
+                if alpha_mask.is_some() {
+                    // Pre-decoded color stream: raw samples, no PNG predictor.
+                    format!(
+                        "{id} 0 obj\n<< /Type /XObject /Subtype /Image /Width {width} /Height {height} /ColorSpace {color_space} /BitsPerComponent 8 /Filter /FlateDecode /Length {len}{smask_entry} >>\nstream\n",
+                        len = data.len(),
+                    )
+                } else {
+                    format!(
+                        "{id} 0 obj\n<< /Type /XObject /Subtype /Image /Width {width} /Height {height} /ColorSpace {color_space} /BitsPerComponent {bpc} /Filter /FlateDecode /DecodeParms << /Predictor 15 /Columns {width} /Colors {channels} /BitsPerComponent {bpc} >> /Length {len}{smask_entry} >>\nstream\n",
+                        bpc = meta.bit_depth,
+                        channels = meta.channels,
+                        len = data.len(),
+                    )
+                }
             }
         };
         self.objects.push(header);
@@ -5299,7 +5327,7 @@ impl PdfWriter {
         }
 
         let (width, height) = crate::parser::jpeg::parse_jpeg_dimensions(raw_image)?;
-        Some(self.add_image_object(raw_image, width, height, ImageFormat::Jpeg, None))
+        Some(self.add_image_object(raw_image, width, height, ImageFormat::Jpeg, None, None))
     }
 
     /// Embed a TrueType font and return the PDF resource name to reference it.

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -7318,9 +7318,8 @@ mod tests {
             pixels.extend_from_slice(&[v, (v.wrapping_add(8))]);
         }
 
-        let buffer =
-            image::ImageBuffer::from_raw(width, height, pixels)
-                .expect("luma+alpha buffer should be valid");
+        let buffer = image::ImageBuffer::from_raw(width, height, pixels)
+            .expect("luma+alpha buffer should be valid");
 
         let mut encoded = Vec::new();
         image::DynamicImage::ImageLumaA8(buffer)


### PR DESCRIPTION
This pull request adds support for preserving and embedding PNG images with alpha channels (transparency) in PDF output. 

Previously, PNG images with alpha would not have their transparency properly represented in the generated PDF. 

The changes ensure that images with alpha are split into separate color and alpha streams, and the alpha channel is embedded as a PDF `/SMask` XObject for correct rendering. The code also includes new tests to verify this behavior.

Previously: 

With a PNG with background: [InformeTCSO_2026-04-29_20-59-59.pdf](https://github.com/user-attachments/files/27223757/InformeTCSO_2026-04-29_20-59-59.pdf)

With a PNG without background: [InformeTCSO_2026-04-29_21-01-02.pdf](https://github.com/user-attachments/files/27223777/InformeTCSO_2026-04-29_21-01-02.pdf)


Now:

With a PNG with background: [InformeTCSO_2026-04-29_20-58-43.pdf](https://github.com/user-attachments/files/27223741/InformeTCSO_2026-04-29_20-58-43.pdf)


With a PNG without background (transparency): [InformeTCSO_2026-04-29_20-54-50.pdf](https://github.com/user-attachments/files/27223709/InformeTCSO_2026-04-29_20-54-50.pdf)

Besides I note that some tests are not passing but I don't know why

```bash
test parity_pseudo_elements ... FAILED
test parity_unicode ... FAILED

failures:

---- parity_pseudo_elements stdout ----

thread 'parity_pseudo_elements' (1680016) panicked at tests/parity_tests.rs:156:9:
Fixture 'features/pseudo-elements': PDF size 21599350 bytes exceeds maximum 15000000 bytes
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- parity_unicode stdout ----

thread 'parity_unicode' (1680064) panicked at tests/parity_tests.rs:156:9:
Fixture 'edge-cases/unicode': PDF size 21660673 bytes exceeds maximum 15000000 bytes


failures:
    parity_pseudo_elements
    parity_unicode

test result: FAILED. 22 passed; 2 failed; 1 ignored; 0 measured; 0 filtered out; finished in 11.10s

error: test failed, to rerun pass `--test parity_tests`
```