### PR TITLE
Minor feature for CLI tool: arg for optional extra CSS

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,8 @@ pub struct CliOptions {
     pub sanitize: bool,
     /// Read from stdin instead of a file.
     pub from_stdin: bool,
+    /// Path to an extra CSS file to inject before document styles (useful for .md).
+    pub css: Option<String>,
     /// Positional arguments (input, output).
     pub positional: Vec<String>,
     /// Print help and exit.
@@ -41,6 +43,7 @@ impl Default for CliOptions {
             footer: None,
             sanitize: true,
             from_stdin: false,
+            css: None,
             positional: Vec::new(),
             help: false,
             version: false,
@@ -108,6 +111,10 @@ pub fn parse_args(args: &[String]) -> Result<CliOptions, String> {
                 opts.sanitize = val != "false" && val != "0";
             }
             "--stdin" => opts.from_stdin = true,
+            "--css" => {
+                i += 1;
+                opts.css = Some(args.get(i).ok_or("--css requires a value")?.clone());
+            }
             arg if arg.starts_with('-') => {
                 return Err(format!("Unknown option: {arg}"));
             }
@@ -119,8 +126,7 @@ pub fn parse_args(args: &[String]) -> Result<CliOptions, String> {
     Ok(opts)
 }
 
-/// Run the conversion with parsed options and input content.
-pub fn convert(opts: &CliOptions, html: &str) -> Result<Vec<u8>, IronpressError> {
+fn build_converter(opts: &CliOptions) -> Result<HtmlConverter, IronpressError> {
     let mut page_size = opts.page_size;
     if opts.landscape {
         page_size = PageSize::new(page_size.height, page_size.width);
@@ -137,30 +143,22 @@ pub fn convert(opts: &CliOptions, html: &str) -> Result<Vec<u8>, IronpressError>
     if let Some(ref f) = opts.footer {
         converter = converter.footer(f.as_str());
     }
+    if let Some(ref path) = opts.css {
+        let css = std::fs::read_to_string(path)?;
+        converter = converter.extra_css(css);
+    }
 
-    converter.convert(html)
+    Ok(converter)
+}
+
+/// Run the conversion with parsed options and input content.
+pub fn convert(opts: &CliOptions, html: &str) -> Result<Vec<u8>, IronpressError> {
+    build_converter(opts)?.convert(html)
 }
 
 /// Run the markdown conversion with parsed options.
 pub fn convert_markdown(opts: &CliOptions, md: &str) -> Result<Vec<u8>, IronpressError> {
-    let mut page_size = opts.page_size;
-    if opts.landscape {
-        page_size = PageSize::new(page_size.height, page_size.width);
-    }
-
-    let mut converter = HtmlConverter::new()
-        .page_size(page_size)
-        .margin(opts.margin)
-        .sanitize(opts.sanitize);
-
-    if let Some(ref h) = opts.header {
-        converter = converter.header(h.as_str());
-    }
-    if let Some(ref f) = opts.footer {
-        converter = converter.footer(f.as_str());
-    }
-
-    converter.convert_markdown(md)
+    build_converter(opts)?.convert_markdown(md)
 }
 
 /// Help text.
@@ -182,6 +180,7 @@ OPTIONS:
     --header <TEXT>         Header text on each page
     --footer <TEXT>         Footer text ({page} and {pages} for numbering)
     --sanitize <BOOL>       Enable/disable HTML sanitization (default: true)
+    --css <FILE>            Extra CSS file to inject before document styles
     --stdin                 Read HTML from stdin instead of a file
     --version               Print version
     --help                  Print this help
@@ -351,6 +350,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_css() {
+        let opts = parse_args(&args("--css style.css input.html out.pdf")).unwrap();
+        assert_eq!(opts.css.as_deref(), Some("style.css"));
+    }
+
+    #[test]
+    fn parse_css_missing_value() {
+        let result = parse_args(&args("--css"));
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn parse_unknown_option() {
         let result = parse_args(&args("--bogus input.html out.pdf"));
         assert!(result.is_err());
@@ -452,6 +463,27 @@ mod tests {
         };
         let pdf = convert(&opts, "<p>Tight margins</p>").unwrap();
         assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn convert_with_css_file() {
+        let path = std::env::temp_dir().join("ironpress_test_extra.css");
+        std::fs::write(&path, "p { color: red; }").unwrap();
+        let opts = CliOptions {
+            css: Some(path.to_str().unwrap().to_string()),
+            ..Default::default()
+        };
+        let pdf = convert(&opts, "<p>Styled</p>").unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn convert_with_css_file_not_found() {
+        let opts = CliOptions {
+            css: Some("/nonexistent/path/style.css".into()),
+            ..Default::default()
+        };
+        assert!(convert(&opts, "<p>Hi</p>").is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,8 @@ pub struct HtmlConverter {
     /// Optional footer text rendered at the bottom of each page.
     /// Use `{page}` for current page number and `{pages}` for total page count.
     footer: Option<String>,
+    /// Extra CSS injected before any stylesheet in the document (useful for .md, or specify default CSS).
+    extra_css: Option<String>,
 }
 
 impl HtmlConverter {
@@ -255,6 +257,7 @@ impl HtmlConverter {
             base_path: None,
             header: None,
             footer: None,
+            extra_css: None,
         }
     }
 
@@ -339,6 +342,12 @@ impl HtmlConverter {
         self
     }
 
+    /// Inject extra CSS that is applied before any stylesheet in the document.
+    pub fn extra_css(mut self, css: impl Into<String>) -> Self {
+        self.extra_css = Some(css.into());
+        self
+    }
+
     /// Convert a Markdown string to PDF bytes.
     ///
     /// The Markdown is first converted to HTML using the built-in parser,
@@ -382,7 +391,7 @@ impl HtmlConverter {
         let result = parser::html::parse_html_with_styles(&html)?;
 
         // Step 2b: Resolve @import rules in stylesheets (if base_path is set)
-        let stylesheets: Vec<String> = if let Some(ref base) = self.base_path {
+        let mut stylesheets: Vec<String> = if let Some(ref base) = self.base_path {
             result
                 .stylesheets
                 .iter()
@@ -391,6 +400,11 @@ impl HtmlConverter {
         } else {
             result.stylesheets
         };
+
+        // Step 2c: Insert extra CSS (from --css flag) so it applies before document styles.
+        if let Some(ref css) = self.extra_css {
+            stylesheets.insert(0, css.clone());
+        }
 
         // Step 3: Parse @page rules first (they affect page dimensions for media queries)
         let mut page_rules = Vec::new();


### PR DESCRIPTION
**Add optional CLI arg --css <file>: injects specified CSS file before any CSS in document.** 

Useful 
- for .md files, or 
- to specify default CSS.

CSS import can be also specified in .md files (as HTML sniplet), but if you want to automatize your PDF creation, it's easier to specify CSS externally, instead of modifying .md.

_(Other edit: eliminated duplicated code by separating functions to build_converter() and convert_<format>()).