### PR TITLE
Improve HTML whitespace and image rendering fidelity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm = ["wasm-bindgen", "js-sys", "getrandom/wasm_js"]
 
 [dependencies]
 html5ever = "0.38"
-lightningcss = { version = "1.0.0-alpha.71", default-features = false }
+lightningcss = { version = "1.0.0-alpha.72", default-features = false }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 png_decoder = { package = "png", version = "0.18" }
 pulldown-cmark = "0.13"

--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -349,8 +349,7 @@ pub(crate) fn layout_block_element(
         && early_has_visual
         && el.children.iter().any(|c| {
             matches!(c, DomNode::Element(e)
-                if (e.tag.is_block() || e.tag == HtmlTag::Svg)
-                    && !collects_as_inline_text(e.tag))
+                if recurses_as_layout_child(e.tag))
         });
 
     if has_math_children {
@@ -482,7 +481,7 @@ pub(crate) fn layout_block_element(
             && el.children.iter().any(|c| {
                 matches!(c, DomNode::Element(e)
                     if (has_own_margins(e.tag)
-                        || (e.tag.is_block() && !collects_as_inline_text(e.tag))
+                        || recurses_as_layout_child(e.tag)
                         || element_has_css_display_block(e, style, env.rules, child_ancestors))
                         && !element_is_inline_block(
                             e, style, env.rules, child_ancestors, 0, 0, &[]))
@@ -651,15 +650,22 @@ pub(crate) fn layout_block_element(
                         );
                     }
                     DomNode::Element(child_el)
-                        if (child_el.tag.is_block()
-                            || child_el.tag == HtmlTag::Svg
+                        if (recurses_as_layout_child(child_el.tag)
                             || element_has_css_display_block(
                                 child_el,
                                 style,
                                 env.rules,
                                 child_ancestors,
                             ))
-                            && !collects_as_inline_text(child_el.tag) =>
+                            && !element_is_inline_block(
+                                child_el,
+                                style,
+                                env.rules,
+                                child_ancestors,
+                                0,
+                                0,
+                                &[],
+                            ) =>
                     {
                         // Flush inline runs before block child
                         flush_runs(

--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -15,6 +15,7 @@ use super::helpers::{
     collects_as_inline_text, has_background_paint, heading_level,
     patch_absolute_children_containing_block, pseudo_is_block_like, push_block_pseudo,
     recurses_as_layout_child, resolve_abs_containing_block, resolve_padding_box_height,
+    subtree_contains_atomic_layout_child,
 };
 use super::inline::{
     element_has_css_display_block, element_is_inline_block, layout_inline_block_group,
@@ -349,7 +350,8 @@ pub(crate) fn layout_block_element(
         && early_has_visual
         && el.children.iter().any(|c| {
             matches!(c, DomNode::Element(e)
-                if recurses_as_layout_child(e.tag))
+                if recurses_as_layout_child(e.tag)
+                    || (collects_as_inline_text(e.tag) && subtree_contains_atomic_layout_child(e)))
         });
 
     if has_math_children {
@@ -383,6 +385,43 @@ pub(crate) fn layout_block_element(
                         margin_top: 0.0,
                         margin_bottom: 0.0,
                     });
+                }
+                DomNode::Element(child_el)
+                    if recurses_as_layout_child(child_el.tag)
+                        || (collects_as_inline_text(child_el.tag)
+                            && subtree_contains_atomic_layout_child(child_el)) =>
+                {
+                    flush_runs(
+                        &mut runs,
+                        inner_width,
+                        style,
+                        available_width,
+                        block_w,
+                        effective_height,
+                        auto_offset_left,
+                        el,
+                        output,
+                        env.fonts,
+                    );
+                    let n_children = el
+                        .children
+                        .iter()
+                        .filter(|c| matches!(c, DomNode::Element(_)))
+                        .count();
+                    flatten_element(
+                        child_el,
+                        style,
+                        &ctx.with_parent(inner_width, Some(available_height), style.font_size)
+                            .with_containing_block(None),
+                        output,
+                        None,
+                        child_ancestors,
+                        positioned_depth,
+                        0,
+                        n_children,
+                        &[],
+                        env,
+                    );
                 }
                 _ => {
                     // Collect text from this child
@@ -482,6 +521,7 @@ pub(crate) fn layout_block_element(
                 matches!(c, DomNode::Element(e)
                     if (has_own_margins(e.tag)
                         || recurses_as_layout_child(e.tag)
+                        || (collects_as_inline_text(e.tag) && subtree_contains_atomic_layout_child(e))
                         || element_has_css_display_block(e, style, env.rules, child_ancestors))
                         && !element_is_inline_block(
                             e, style, env.rules, child_ancestors, 0, 0, &[]))
@@ -651,6 +691,8 @@ pub(crate) fn layout_block_element(
                     }
                     DomNode::Element(child_el)
                         if (recurses_as_layout_child(child_el.tag)
+                            || (collects_as_inline_text(child_el.tag)
+                                && subtree_contains_atomic_layout_child(child_el))
                             || element_has_css_display_block(
                                 child_el,
                                 style,
@@ -887,6 +929,8 @@ pub(crate) fn layout_block_element(
                     }
                     DomNode::Element(child_el)
                         if collects_as_inline_text(child_el.tag)
+                            && !(collects_as_inline_text(child_el.tag)
+                                && subtree_contains_atomic_layout_child(child_el))
                             && !element_has_css_display_block(
                                 child_el,
                                 style,
@@ -1181,7 +1225,9 @@ pub(crate) fn layout_block_element(
         let mut ib_group_wrapper: Vec<&ElementNode> = Vec::new();
         for child in &el.children {
             if let DomNode::Element(child_el) = child {
-                if recurses_as_layout_child(child_el.tag)
+                if (recurses_as_layout_child(child_el.tag)
+                    || (collects_as_inline_text(child_el.tag)
+                        && subtree_contains_atomic_layout_child(child_el)))
                     && element_is_inline_block(
                         child_el,
                         style,
@@ -1208,7 +1254,10 @@ pub(crate) fn layout_block_element(
                             env.fonts,
                         );
                     }
-                    if recurses_as_layout_child(child_el.tag) {
+                    if recurses_as_layout_child(child_el.tag)
+                        || (collects_as_inline_text(child_el.tag)
+                            && subtree_contains_atomic_layout_child(child_el))
+                    {
                         let child_cb = if effective_height.is_some() {
                             Some(ContainingBlock {
                                 x: 0.0,
@@ -1444,7 +1493,9 @@ pub(crate) fn layout_block_element(
         let mut ib_group: Vec<&ElementNode> = Vec::new();
         for child in &el.children {
             if let DomNode::Element(child_el) = child {
-                if recurses_as_layout_child(child_el.tag)
+                if (recurses_as_layout_child(child_el.tag)
+                    || (collects_as_inline_text(child_el.tag)
+                        && subtree_contains_atomic_layout_child(child_el)))
                     && element_is_inline_block(
                         child_el,
                         style,
@@ -1471,7 +1522,10 @@ pub(crate) fn layout_block_element(
                             env.fonts,
                         );
                     }
-                    if recurses_as_layout_child(child_el.tag) {
+                    if recurses_as_layout_child(child_el.tag)
+                        || (collects_as_inline_text(child_el.tag)
+                            && subtree_contains_atomic_layout_child(child_el))
+                    {
                         flatten_element(
                             child_el,
                             style,

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -1836,7 +1836,10 @@ pub(crate) fn flatten_element(
                         &[],
                         env,
                     );
-                } else if recurses_as_layout_child(child_el.tag) {
+                } else if recurses_as_layout_child(child_el.tag)
+                    || (collects_as_inline_text(child_el.tag)
+                        && subtree_contains_atomic_layout_child(child_el))
+                {
                     let child_ctx = layout_ctx
                         .with_parent(available_width, Some(available_height), style.font_size)
                         .with_containing_block(None);
@@ -1953,7 +1956,10 @@ fn inline_loose_list_p(
                 return (Some(raw_idx), p_style.margin.top, p_style.margin.bottom);
             }
             child_el_ordinal += 1;
-            if recurses_as_layout_child(child_el.tag) {
+            if recurses_as_layout_child(child_el.tag)
+                || (collects_as_inline_text(child_el.tag)
+                    && subtree_contains_atomic_layout_child(child_el))
+            {
                 break;
             }
         }
@@ -2775,6 +2781,34 @@ mod tests {
             .any(|(_, el)| layout_element_has_image(el))
     }
 
+    fn layout_element_first_image_size(el: &LayoutElement) -> Option<(f32, f32)> {
+        match el {
+            LayoutElement::Image { width, height, .. } => Some((*width, *height)),
+            LayoutElement::Container { children, .. } => {
+                children.iter().find_map(layout_element_first_image_size)
+            }
+            LayoutElement::FlexRow { cells, .. } => cells.iter().find_map(|cell| {
+                cell.nested_elements
+                    .iter()
+                    .find_map(layout_element_first_image_size)
+            }),
+            LayoutElement::TableRow { cells, .. } | LayoutElement::GridRow { cells, .. } => {
+                cells.iter().find_map(|cell| {
+                    cell.nested_rows
+                        .iter()
+                        .find_map(layout_element_first_image_size)
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn page_first_image_size(page: &Page) -> Option<(f32, f32)> {
+        page.elements
+            .iter()
+            .find_map(|(_, el)| layout_element_first_image_size(el))
+    }
+
     fn page_text(page: &Page) -> String {
         fn collect_text(el: &LayoutElement, out: &mut String) {
             match el {
@@ -2843,6 +2877,115 @@ mod tests {
     }
 
     #[test]
+    fn table_cell_image() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><table><tbody><tr><td><img width="100" height="100" src="data:image/png;base64,{b64}"></td></tr></tbody></table></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty(), "expected non-empty layout");
+        assert!(
+            page_has_image(&pages[0]),
+            "expected img inside td to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn table_cell_styled_image() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><table><tr><td><img style="width:100px;height:100px" src="data:image/png;base64,{b64}"></td></tr></table></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert!(
+            page_has_image(&pages[0]),
+            "expected styled img inside td to produce an Image layout element"
+        );
+        assert_eq!(
+            page_first_image_size(&pages[0]),
+            Some((75.0, 75.0)),
+            "expected 100px styled image to resolve to 75pt by CSS px conversion"
+        );
+    }
+
+    #[test]
+    fn table_cell_span_wrapped_image() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><table><tr><td><span style="font-size:9pt"><img width="100" height="100" src="data:image/png;base64,{b64}"></span></td></tr></table></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert!(
+            page_has_image(&pages[0]),
+            "expected span-wrapped img inside td to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn table_cell_text_image_text() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><table><tr><td>Before <img width="100" height="100" src="data:image/png;base64,{b64}"> After</td></tr></table></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let text = page_text(&pages[0]);
+
+        assert!(text.contains("Before"), "expected leading text to remain");
+        assert!(text.contains("After"), "expected trailing text to remain");
+        assert!(
+            page_has_image(&pages[0]),
+            "expected img between table-cell text to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn layout_img_inside_span_inside_div_is_not_collected_as_text() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><div><span style="font-size:9pt"><img style="width:100px;height:100px" src="data:image/png;base64,{b64}"></span></div></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert_eq!(pages.len(), 1);
+        assert!(!pages[0].elements.is_empty(), "expected non-empty layout");
+        assert!(
+            page_has_image(&pages[0]),
+            "expected span-wrapped img inside div to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn layout_img_inside_nested_inline_wrappers_inside_div_renders() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><div><b><i><span><img width="100" height="100" src="data:image/png;base64,{b64}"></span></i></b></div></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert_eq!(pages.len(), 1);
+        assert!(
+            page_has_image(&pages[0]),
+            "expected deeply inline-wrapped img inside div to produce an Image layout element"
+        );
+    }
+
+    #[test]
     fn layout_img_between_text_in_div_is_not_swallowed() {
         let png_bytes = build_test_png_bytes();
         let b64 = base64_encode(&png_bytes);
@@ -2858,6 +3001,42 @@ mod tests {
         assert!(
             page_has_image(&pages[0]),
             "expected img between text to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn layout_img_inside_span_between_text_in_div_is_not_swallowed() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><div>Before <span><img width="100" height="100" src="data:image/png;base64,{b64}"></span> After</div></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let text = page_text(&pages[0]);
+
+        assert!(text.contains("Before"), "expected leading text to remain");
+        assert!(text.contains("After"), "expected trailing text to remain");
+        assert!(
+            page_has_image(&pages[0]),
+            "expected span-wrapped img between text to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn layout_top_level_span_wrapped_img_still_renders() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><span><img width="100" height="100" src="data:image/png;base64,{b64}"></span></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert_eq!(pages.len(), 1);
+        assert!(
+            page_has_image(&pages[0]),
+            "expected top-level span-wrapped img to continue producing an Image layout element"
         );
     }
 

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2109,6 +2109,163 @@ mod tests {
         assert!(pages[0].elements.len() >= 3);
     }
 
+    fn first_table_y(html: &str) -> f32 {
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        pages[0]
+            .elements
+            .iter()
+            .find_map(|(y, el)| matches!(el, LayoutElement::TableRow { .. }).then_some(*y))
+            .expect("expected a table row")
+    }
+
+    fn text_block_y(html: &str, needle: &str) -> f32 {
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        pages[0]
+            .elements
+            .iter()
+            .find_map(|(y, el)| match el {
+                LayoutElement::TextBlock { lines, .. } => {
+                    let text: String = lines
+                        .iter()
+                        .flat_map(|line| line.runs.iter())
+                        .map(|run| run.text.as_str())
+                        .collect();
+                    text.contains(needle).then_some(*y)
+                }
+                _ => None,
+            })
+            .expect("expected text block containing needle")
+    }
+
+    #[test]
+    fn nbsp_paragraph_before_table_preserves_vertical_space() {
+        let baseline = first_table_y(
+            r#"<html><body>
+                <p>Before</p>
+                <table><tr><td><p>After</p></td></tr></table>
+            </body></html>"#,
+        );
+        let with_nbsp = first_table_y(
+            r#"<html><body>
+                <p>Before</p>
+                <p>&nbsp;</p>
+                <table><tr><td><p>After</p></td></tr></table>
+            </body></html>"#,
+        );
+
+        assert!(
+            with_nbsp > baseline,
+            "NBSP paragraph should move table down"
+        );
+        assert!(
+            with_nbsp - baseline >= 14.4,
+            "NBSP paragraph should contribute at least one normal line height before the table"
+        );
+    }
+
+    #[test]
+    fn span_nbsp_paragraph_before_table_preserves_vertical_space() {
+        let baseline = first_table_y(
+            r#"<html><body>
+                <p>Before</p>
+                <table><tr><td><p>After</p></td></tr></table>
+            </body></html>"#,
+        );
+        let with_nbsp = first_table_y(
+            r#"<html><body>
+                <p>Before</p>
+                <p><span style="font-size:9pt">&nbsp;</span></p>
+                <table><tr><td><p>After</p></td></tr></table>
+            </body></html>"#,
+        );
+
+        assert!(
+            with_nbsp > baseline,
+            "span-wrapped NBSP should move table down"
+        );
+        assert!(
+            with_nbsp - baseline >= 10.8,
+            "span-wrapped NBSP paragraph should contribute at least its line height before the table"
+        );
+    }
+
+    #[test]
+    fn unknown_inline_nbsp_paragraph_before_table_preserves_vertical_space() {
+        let baseline = first_table_y(
+            r#"<html><body>
+                <p>Before</p>
+                <table><tr><td><p>After</p></td></tr></table>
+            </body></html>"#,
+        );
+        let with_nbsp = first_table_y(
+            r#"<html><body>
+                <p>Before</p>
+                <p><span style="font-size:9pt"><o:p>&nbsp;</o:p></span></p>
+                <table><tr><td><p>After</p></td></tr></table>
+            </body></html>"#,
+        );
+
+        assert!(
+            with_nbsp > baseline,
+            "unknown inline wrapper around NBSP should move table down"
+        );
+        assert!(
+            with_nbsp - baseline >= 10.8,
+            "unknown inline NBSP paragraph should contribute at least its line height before the table"
+        );
+    }
+
+    #[test]
+    fn nbsp_only_paragraph_has_line_height() {
+        let baseline = text_block_y(
+            r#"<html><body>
+                <p>Before</p>
+                <p>After</p>
+            </body></html>"#,
+            "After",
+        );
+        let with_nbsp = text_block_y(
+            r#"<html><body>
+                <p>Before</p>
+                <p>&nbsp;</p>
+                <p>After</p>
+            </body></html>"#,
+            "After",
+        );
+
+        assert!(
+            with_nbsp > baseline,
+            "NBSP paragraph should move following paragraph down"
+        );
+        assert!(
+            with_nbsp - baseline >= 14.4,
+            "NBSP paragraph should contribute at least one normal line height before the following paragraph"
+        );
+    }
+
+    #[test]
+    fn ascii_space_only_paragraph_behavior_unchanged() {
+        let baseline = text_block_y(
+            r#"<html><body>
+                <p>Before</p>
+                <p>After</p>
+            </body></html>"#,
+            "After",
+        );
+        let with_spaces = text_block_y(
+            r#"<html><body>
+                <p>Before</p>
+                <p>     </p>
+                <p>After</p>
+            </body></html>"#,
+            "After",
+        );
+
+        assert_eq!(with_spaces, baseline);
+    }
+
     #[test]
     fn layout_empty() {
         let nodes = parse_html("").unwrap();

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2759,6 +2759,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn png_asset_keeps_full_png_bytes() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(r#"<img src="data:image/png;base64,{b64}" width="20" height="20">"#);
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        match &pages[0].elements[0].1 {
+            LayoutElement::Image { image, .. } => {
+                assert_eq!(image.format, ImageFormat::Png);
+                assert!(image.data.starts_with(&[137, 80, 78, 71, 13, 10, 26, 10]));
+            }
+            _ => panic!("Expected Image layout element"),
+        }
+    }
+
     fn layout_element_has_image(el: &LayoutElement) -> bool {
         match el {
             LayoutElement::Image { .. } => true,

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2753,6 +2753,148 @@ mod tests {
         }
     }
 
+    fn layout_element_has_image(el: &LayoutElement) -> bool {
+        match el {
+            LayoutElement::Image { .. } => true,
+            LayoutElement::Container { children, .. } => {
+                children.iter().any(layout_element_has_image)
+            }
+            LayoutElement::FlexRow { cells, .. } => cells
+                .iter()
+                .any(|cell| cell.nested_elements.iter().any(layout_element_has_image)),
+            LayoutElement::TableRow { cells, .. } | LayoutElement::GridRow { cells, .. } => cells
+                .iter()
+                .any(|cell| cell.nested_rows.iter().any(layout_element_has_image)),
+            _ => false,
+        }
+    }
+
+    fn page_has_image(page: &Page) -> bool {
+        page.elements
+            .iter()
+            .any(|(_, el)| layout_element_has_image(el))
+    }
+
+    fn page_text(page: &Page) -> String {
+        fn collect_text(el: &LayoutElement, out: &mut String) {
+            match el {
+                LayoutElement::TextBlock { lines, .. } => {
+                    for line in lines {
+                        for run in &line.runs {
+                            out.push_str(&run.text);
+                        }
+                    }
+                }
+                LayoutElement::Container { children, .. } => {
+                    for child in children {
+                        collect_text(child, out);
+                    }
+                }
+                LayoutElement::FlexRow { cells, .. } => {
+                    for cell in cells {
+                        for line in &cell.lines {
+                            for run in &line.runs {
+                                out.push_str(&run.text);
+                            }
+                        }
+                        for child in &cell.nested_elements {
+                            collect_text(child, out);
+                        }
+                    }
+                }
+                LayoutElement::TableRow { cells, .. } | LayoutElement::GridRow { cells, .. } => {
+                    for cell in cells {
+                        for line in &cell.lines {
+                            for run in &line.runs {
+                                out.push_str(&run.text);
+                            }
+                        }
+                        for child in &cell.nested_rows {
+                            collect_text(child, out);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut text = String::new();
+        for (_, el) in &page.elements {
+            collect_text(el, &mut text);
+        }
+        text
+    }
+
+    #[test]
+    fn layout_img_direct_child_of_div_is_not_collected_as_text() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><div><img width="100" height="100" src="data:image/png;base64,{b64}"></div></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert_eq!(pages.len(), 1);
+        assert!(
+            page_has_image(&pages[0]),
+            "expected img inside div to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn layout_img_between_text_in_div_is_not_swallowed() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><div>Before <img width="100" height="100" src="data:image/png;base64,{b64}"> After</div></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let text = page_text(&pages[0]);
+
+        assert!(text.contains("Before"), "expected leading text to remain");
+        assert!(text.contains("After"), "expected trailing text to remain");
+        assert!(
+            page_has_image(&pages[0]),
+            "expected img between text to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn layout_img_inside_paragraph_is_not_collected_as_text() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><p><img width="100" height="100" src="data:image/png;base64,{b64}"></p></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert_eq!(pages.len(), 1);
+        assert!(
+            page_has_image(&pages[0]),
+            "expected img inside paragraph to produce an Image layout element"
+        );
+    }
+
+    #[test]
+    fn layout_link_wrapped_img_still_renders() {
+        let png_bytes = build_test_png_bytes();
+        let b64 = base64_encode(&png_bytes);
+        let html = format!(
+            r#"<html><body><a href="https://example.com"><img width="100" height="100" src="data:image/png;base64,{b64}"></a></body></html>"#,
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+
+        assert_eq!(pages.len(), 1);
+        assert!(
+            page_has_image(&pages[0]),
+            "expected link-wrapped img to continue producing an Image layout element"
+        );
+    }
+
     #[test]
     fn layout_image_without_dimensions_gets_defaults() {
         let png_bytes = build_test_png_bytes();

--- a/src/layout/helpers.rs
+++ b/src/layout/helpers.rs
@@ -211,12 +211,16 @@ pub(crate) fn collapse_margins_through_parent(
 // Group 6 — Element classification
 // ---------------------------------------------------------------------------
 
+pub(crate) fn is_atomic_layout_child(tag: HtmlTag) -> bool {
+    matches!(tag, HtmlTag::Img | HtmlTag::Svg)
+}
+
 pub(crate) fn recurses_as_layout_child(tag: HtmlTag) -> bool {
-    tag.is_block() || tag == HtmlTag::Svg
+    tag.is_block() || is_atomic_layout_child(tag)
 }
 
 pub(crate) fn collects_as_inline_text(tag: HtmlTag) -> bool {
-    tag != HtmlTag::Svg && tag.is_inline()
+    tag.is_inline() && !is_atomic_layout_child(tag)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/layout/helpers.rs
+++ b/src/layout/helpers.rs
@@ -1,4 +1,4 @@
-use crate::parser::dom::{ElementNode, HtmlTag};
+use crate::parser::dom::{DomNode, ElementNode, HtmlTag};
 use crate::parser::ttf::TtfFont;
 use crate::style::computed::{
     BackgroundOrigin, BackgroundPosition, BackgroundRepeat, BackgroundSize, BoxSizing,
@@ -221,6 +221,21 @@ pub(crate) fn recurses_as_layout_child(tag: HtmlTag) -> bool {
 
 pub(crate) fn collects_as_inline_text(tag: HtmlTag) -> bool {
     tag.is_inline() && !is_atomic_layout_child(tag)
+}
+
+pub(crate) fn subtree_contains_atomic_layout_child(el: &ElementNode) -> bool {
+    let mut stack = vec![el];
+    while let Some(current) = stack.pop() {
+        if is_atomic_layout_child(current.tag) {
+            return true;
+        }
+        for child in &current.children {
+            if let DomNode::Element(child_el) = child {
+                stack.push(child_el);
+            }
+        }
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------

--- a/src/layout/images.rs
+++ b/src/layout/images.rs
@@ -80,7 +80,11 @@ pub(crate) fn load_image_bytes(raw: Vec<u8>) -> Option<RasterImageAsset> {
             bit_depth: png_info.bit_depth,
         };
         Some(RasterImageAsset {
-            data: png_info.idat_data,
+            // Keep complete PNG bytes for rendering. PDF XObjects cannot embed
+            // alpha interleaved in the main color stream, so the renderer needs
+            // the full PNG container to decode pixels and split any alpha into
+            // an /SMask.
+            data: raw,
             source_width: png_info.width,
             source_height: png_info.height,
             format: ImageFormat::Png,

--- a/src/layout/images.rs
+++ b/src/layout/images.rs
@@ -162,9 +162,13 @@ pub(crate) fn load_image_from_element(
     // Fall back to raster image using the same bytes.
     let image = load_raster_image_bytes(raw, style.blur_radius)?;
 
-    // Determine dimensions from attributes
-    let attr_width = parse_html_image_dimension(el.attributes.get("width"));
-    let attr_height = parse_html_image_dimension(el.attributes.get("height"));
+    // Determine dimensions from CSS first, then HTML attributes.
+    let attr_width = style
+        .width
+        .or_else(|| parse_html_image_dimension(el.attributes.get("width")));
+    let attr_height = style
+        .height
+        .or_else(|| parse_html_image_dimension(el.attributes.get("height")));
 
     let (width, height) = match (attr_width, attr_height) {
         (Some(w), Some(h)) => (w, h),

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -11,6 +11,7 @@ use super::context::{LayoutContext, LayoutEnv, ParentBox, Viewport};
 use super::engine::{
     CounterState, LayoutBorder, LayoutElement, TextLine, TextRun, collects_as_inline_text,
     flatten_element, has_background_paint, recurses_as_layout_child,
+    subtree_contains_atomic_layout_child,
 };
 use super::paginate::{estimate_element_height, table_row_content_width};
 use super::text::{
@@ -46,6 +47,60 @@ pub(crate) fn table_cell_content_height(cell: &TableCell) -> f32 {
     let text_h: f32 = cell.lines.iter().map(|l| l.height).sum();
     let nested_h: f32 = cell.nested_rows.iter().map(estimate_element_height).sum();
     cell.padding_top + text_h + nested_h + cell.padding_bottom
+}
+
+fn table_nested_content_width(element: &LayoutElement, fonts: &HashMap<String, TtfFont>) -> f32 {
+    match element {
+        LayoutElement::Image { width, .. } | LayoutElement::Svg { width, .. } => *width,
+        LayoutElement::TextBlock {
+            lines,
+            block_width,
+            padding_left,
+            padding_right,
+            border,
+            ..
+        } => block_width.unwrap_or_else(|| {
+            let text_width = lines
+                .iter()
+                .map(|line| {
+                    line.runs
+                        .iter()
+                        .map(|run| {
+                            estimate_word_width(
+                                &run.text,
+                                run.font_size,
+                                &run.font_family,
+                                run.bold,
+                                run.italic,
+                                fonts,
+                            )
+                        })
+                        .sum::<f32>()
+                })
+                .fold(0.0f32, f32::max);
+            text_width + padding_left + padding_right + border.horizontal_width()
+        }),
+        LayoutElement::Container {
+            children,
+            block_width,
+            padding_left,
+            padding_right,
+            border,
+            ..
+        } => block_width.unwrap_or_else(|| {
+            children
+                .iter()
+                .map(|child| table_nested_content_width(child, fonts))
+                .fold(0.0f32, f32::max)
+                + padding_left
+                + padding_right
+                + border.horizontal_width()
+        }),
+        LayoutElement::TableRow { .. } | LayoutElement::GridRow { .. } => {
+            table_row_content_width(element)
+        }
+        _ => 0.0,
+    }
 }
 
 /// Parse a width for a `<col>` / `<colgroup>` element.
@@ -704,9 +759,12 @@ pub(crate) fn flatten_table(
                         );
                         let mut runs = Vec::new();
                         let mut nested_rows = Vec::new();
-                        let recurse_descendants = cell_el.children.iter().any(
-                            |node| matches!(node, DomNode::Element(e) if recurses_as_layout_child(e.tag)),
-                        );
+                        let recurse_descendants = cell_el.children.iter().any(|node| {
+                            matches!(node, DomNode::Element(e)
+                                if recurses_as_layout_child(e.tag)
+                                    || (collects_as_inline_text(e.tag)
+                                        && subtree_contains_atomic_layout_child(e)))
+                        });
                         let mut text_ancestors = cell_sizing_ctx.ancestors.clone();
                         text_ancestors.push(AncestorInfo {
                             element: cell_el,
@@ -765,7 +823,7 @@ pub(crate) fn flatten_table(
                             .sum();
                         let nested_width = nested_rows
                             .iter()
-                            .map(table_row_content_width)
+                            .map(|row| table_nested_content_width(row, fonts))
                             .fold(0.0f32, f32::max);
                         let total_preferred = content_width.max(nested_width)
                             + cell_style.padding.left
@@ -966,10 +1024,12 @@ pub(crate) fn flatten_table(
 
             let mut runs = Vec::new();
             let mut nested_rows = Vec::new();
-            let recurse_descendants = cell_el
-                .children
-                .iter()
-                .any(|node| matches!(node, DomNode::Element(e) if recurses_as_layout_child(e.tag)));
+            let recurse_descendants = cell_el.children.iter().any(|node| {
+                matches!(node, DomNode::Element(e)
+                        if recurses_as_layout_child(e.tag)
+                            || (collects_as_inline_text(e.tag)
+                                && subtree_contains_atomic_layout_child(e)))
+            });
             let mut text_ancestors = cell_selector_ctx.ancestors.clone();
             text_ancestors.push(AncestorInfo {
                 element: cell_el,
@@ -1303,7 +1363,9 @@ fn collect_table_cell_content_inner(
                         element_sibling_count,
                         &mut inner_env,
                     );
-                } else if el.tag == HtmlTag::Svg
+                } else if recurses_as_layout_child(el.tag)
+                    || (collects_as_inline_text(el.tag) && subtree_contains_atomic_layout_child(el))
+                    || el.tag == HtmlTag::Svg
                     || (recurse_blocks
                         && style.display != Display::Inline
                         && el.tag != HtmlTag::Br

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -694,6 +694,11 @@ fn collect_text_runs_inner(
                 }
             }
             DomNode::Element(el) => {
+                if super::engine::is_atomic_layout_child(el.tag) {
+                    // Replaced elements are layout children, not text runs. Block layout
+                    // must route atomic-containing subtrees through flatten_element first.
+                    continue;
+                }
                 if super::engine::collects_as_inline_text(el.tag) || el.tag == HtmlTag::Br {
                     if el.tag == HtmlTag::Br {
                         runs.push(TextRun {

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -1,6 +1,9 @@
 use crate::parser::css::{AncestorInfo, CssRule, SelectorContext};
 use crate::parser::dom::{DomNode, HtmlTag};
 use crate::parser::ttf::TtfFont;
+use crate::util::{
+    contains_nbsp, is_html_collapsible_whitespace, trim_html_collapsible_whitespace_end,
+};
 // Re-export OverflowWrap so callers of TextWrapOptions::new can use it
 // without a separate import.
 pub(crate) use crate::style::computed::OverflowWrap;
@@ -52,18 +55,21 @@ pub(crate) fn resolved_line_height_factor(
 pub(crate) fn collapse_whitespace(text: &str) -> String {
     let mut result = String::new();
     let mut last_was_space = false;
+
     for c in text.chars() {
-        if c.is_whitespace() {
+        if is_html_collapsible_whitespace(c) {
             if !last_was_space && !result.is_empty() {
                 result.push(' ');
                 last_was_space = true;
             }
         } else {
+            // Preserve NBSP U+00A0 and every other non-collapsible char.
             result.push(c);
             last_was_space = false;
         }
     }
-    result.trim_end().to_string()
+
+    trim_html_collapsible_whitespace_end(&result)
 }
 
 // ---------------------------------------------------------------------------
@@ -202,9 +208,18 @@ pub(crate) fn wrap_text_runs(
             continue;
         }
         let has_newlines = run.text.contains('\n');
-        let has_preserved_spacing = run.text.chars().next().is_some_and(char::is_whitespace)
-            || run.text.chars().last().is_some_and(char::is_whitespace)
-            || run.text.contains("  ");
+        let has_preserved_spacing = run
+            .text
+            .chars()
+            .next()
+            .is_some_and(is_html_collapsible_whitespace)
+            || run
+                .text
+                .chars()
+                .last()
+                .is_some_and(is_html_collapsible_whitespace)
+            || run.text.contains("  ")
+            || contains_nbsp(&run.text);
         if has_newlines {
             for (seg_idx, segment) in run.text.split('\n').enumerate() {
                 if seg_idx > 0 {
@@ -213,9 +228,16 @@ pub(crate) fn wrap_text_runs(
                 if segment.is_empty() {
                     continue;
                 }
-                if segment.chars().next().is_some_and(char::is_whitespace)
-                    || segment.chars().last().is_some_and(char::is_whitespace)
+                if segment
+                    .chars()
+                    .next()
+                    .is_some_and(is_html_collapsible_whitespace)
+                    || segment
+                        .chars()
+                        .last()
+                        .is_some_and(is_html_collapsible_whitespace)
                     || segment.contains("  ")
+                    || contains_nbsp(segment)
                 {
                     styled_words.push((segment.to_string(), run.clone(), true));
                 } else {
@@ -913,5 +935,95 @@ impl<'a> FlexTextRunCollector<'a> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_run(text: &str) -> TextRun {
+        TextRun {
+            text: text.to_string(),
+            font_size: 12.0,
+            bold: false,
+            italic: false,
+            underline: false,
+            line_through: false,
+            overline: false,
+            color: (0.0, 0.0, 0.0),
+            link_url: None,
+            font_family: FontFamily::Helvetica,
+            background_color: None,
+            padding: (0.0, 0.0),
+            border_radius: 0.0,
+        }
+    }
+
+    #[test]
+    fn collapse_whitespace_preserves_nbsp_only_text() {
+        assert_eq!(collapse_whitespace("\u{00A0}"), "\u{00A0}");
+    }
+
+    #[test]
+    fn collapse_whitespace_preserves_multiple_nbsp_only_text() {
+        assert_eq!(
+            collapse_whitespace("\u{00A0}\u{00A0}\u{00A0}"),
+            "\u{00A0}\u{00A0}\u{00A0}"
+        );
+    }
+
+    #[test]
+    fn collapse_whitespace_preserves_nbsp_between_words() {
+        assert_eq!(collapse_whitespace("A\u{00A0}B"), "A\u{00A0}B");
+    }
+
+    #[test]
+    fn collapse_whitespace_preserves_multiple_nbsp_between_words() {
+        assert_eq!(
+            collapse_whitespace("A\u{00A0}\u{00A0}\u{00A0}B"),
+            "A\u{00A0}\u{00A0}\u{00A0}B"
+        );
+    }
+
+    #[test]
+    fn collapse_whitespace_preserves_mixed_space_and_nbsp() {
+        assert_eq!(
+            collapse_whitespace("A \u{00A0} \u{00A0} B"),
+            "A \u{00A0} \u{00A0} B"
+        );
+    }
+
+    #[test]
+    fn collapse_whitespace_does_not_trim_trailing_nbsp() {
+        assert_eq!(collapse_whitespace("A\u{00A0}"), "A\u{00A0}");
+    }
+
+    #[test]
+    fn collapse_whitespace_still_collapses_normal_html_spaces() {
+        assert_eq!(collapse_whitespace("A   B"), "A B");
+        assert_eq!(collapse_whitespace("A\n\t B"), "A B");
+        assert_eq!(collapse_whitespace("A\r\nB"), "A B");
+        assert_eq!(collapse_whitespace("A\x0CB"), "A B");
+    }
+
+    #[test]
+    fn collapse_whitespace_still_trims_trailing_normal_space() {
+        assert_eq!(collapse_whitespace("A   "), "A");
+    }
+
+    #[test]
+    fn wrap_text_runs_preserves_nbsp_as_unbreakable_text() {
+        let fonts = HashMap::new();
+        let lines = wrap_text_runs(
+            vec![test_run("A\u{00A0}B")],
+            TextWrapOptions::new(500.0, 12.0, 1.2, OverflowWrap::Normal),
+            &fonts,
+        );
+
+        assert_eq!(lines.len(), 1);
+        let text: String = lines[0].runs.iter().map(|r| r.text.as_str()).collect();
+        assert_eq!(text, "A\u{00A0}B");
+        assert_eq!(lines[0].runs.len(), 1);
     }
 }

--- a/src/parser/css/lightning.rs
+++ b/src/parser/css/lightning.rs
@@ -55,8 +55,7 @@ fn declaration_block_to_style_map(
     map
 }
 
-fn parser_options<'i>(input: &'i str) -> ParserOptions<'static, 'i> {
-    let _ = input;
+fn parser_options<'i>(_: &'i str) -> ParserOptions<'i> {
     ParserOptions {
         filename: String::new(),
         css_modules: None,

--- a/src/parser/dom.rs
+++ b/src/parser/dom.rs
@@ -223,6 +223,9 @@ impl HtmlTag {
                 | Self::Audio
                 | Self::Progress
                 | Self::Meter
+                // Unknown/custom HTML elements default to inline in browsers;
+                // keep their inline text content participating in layout.
+                | Self::Unknown
         )
     }
 }

--- a/src/parser/html.rs
+++ b/src/parser/html.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use super::dom::{DomNode, ElementNode, HtmlTag};
 use crate::error::IronpressError;
+use crate::util::is_html_collapsible_whitespace;
 
 /// Result of parsing HTML — nodes plus any embedded stylesheets.
 pub struct ParseResult {
@@ -45,17 +46,17 @@ fn convert_handle(handle: &Handle, stylesheets: &mut Vec<String>) -> Vec<DomNode
         }
         NodeData::Text { contents } => {
             let text = contents.borrow().to_string();
-            if text.trim().is_empty() {
-                // Preserve whitespace-only text nodes that contain at least
-                // one space (as opposed to consisting solely of newlines and
-                // tabs).  These often represent inter-element spacing, e.g.
-                // `<span>A</span> <span>B</span>`.
+
+            if text.chars().all(is_html_collapsible_whitespace) {
+                // Preserve one normal inter-element space when the source had an actual space.
+                // Drop whitespace-only text that is only tabs/newlines/form-feeds/carriage returns.
                 if text.contains(' ') {
                     vec![DomNode::Text(" ".to_string())]
                 } else {
                     vec![]
                 }
             } else {
+                // Preserve NBSP and other non-collapsible characters.
                 vec![DomNode::Text(text)]
             }
         }
@@ -182,6 +183,84 @@ mod tests {
     fn parse_empty() {
         let nodes = parse_html("").unwrap();
         assert!(nodes.is_empty());
+    }
+
+    #[test]
+    fn parse_nbsp_text_node() {
+        let nodes = parse_html("&nbsp;").unwrap();
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            DomNode::Text(text) => assert_eq!(text, "\u{00A0}"),
+            _ => panic!("Expected text node"),
+        }
+    }
+
+    #[test]
+    fn parse_paragraph_preserves_nbsp_only_child() {
+        let nodes = parse_html("<html><body><p>&nbsp;</p></body></html>").unwrap();
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            DomNode::Element(el) => {
+                assert_eq!(el.tag, HtmlTag::P);
+                assert_eq!(el.children.len(), 1);
+                match &el.children[0] {
+                    DomNode::Text(text) => assert_eq!(text, "\u{00A0}"),
+                    _ => panic!("Expected text node"),
+                }
+            }
+            _ => panic!("Expected paragraph"),
+        }
+    }
+
+    #[test]
+    fn parse_paragraph_preserves_multiple_nbsp_only_child() {
+        let nodes = parse_html("<html><body><p>&nbsp;&nbsp;&nbsp;</p></body></html>").unwrap();
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            DomNode::Element(el) => {
+                assert_eq!(el.tag, HtmlTag::P);
+                assert_eq!(el.children.len(), 1);
+                match &el.children[0] {
+                    DomNode::Text(text) => assert_eq!(text, "\u{00A0}\u{00A0}\u{00A0}"),
+                    _ => panic!("Expected text node"),
+                }
+            }
+            _ => panic!("Expected paragraph"),
+        }
+    }
+
+    #[test]
+    fn parse_paragraph_preserves_nbsp_between_words() {
+        let nodes = parse_html("<html><body><p>A&nbsp;B</p></body></html>").unwrap();
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            DomNode::Element(el) => {
+                assert_eq!(el.tag, HtmlTag::P);
+                assert_eq!(el.children.len(), 1);
+                match &el.children[0] {
+                    DomNode::Text(text) => assert_eq!(text, "A\u{00A0}B"),
+                    _ => panic!("Expected text node"),
+                }
+            }
+            _ => panic!("Expected paragraph"),
+        }
+    }
+
+    #[test]
+    fn parse_paragraph_preserves_multiple_nbsp_between_words() {
+        let nodes = parse_html("<html><body><p>A&nbsp;&nbsp;&nbsp;B</p></body></html>").unwrap();
+        assert_eq!(nodes.len(), 1);
+        match &nodes[0] {
+            DomNode::Element(el) => {
+                assert_eq!(el.tag, HtmlTag::P);
+                assert_eq!(el.children.len(), 1);
+                match &el.children[0] {
+                    DomNode::Text(text) => assert_eq!(text, "A\u{00A0}\u{00A0}\u{00A0}B"),
+                    _ => panic!("Expected text node"),
+                }
+            }
+            _ => panic!("Expected paragraph"),
+        }
     }
 
     #[test]

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -2506,13 +2506,22 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     let img_x = margin.left;
                     // PDF y-axis is bottom-up; y_pos is top of margin, image draws from bottom-left
                     let img_y = page_size.height - margin.top - y_pos - height;
-                    let img_obj_id = pdf_writer.add_image_object(
-                        &image.data,
-                        image.source_width,
-                        image.source_height,
-                        image.format,
-                        image.png_metadata.as_ref(),
-                    );
+                    let img_obj_id = match image.format {
+                        ImageFormat::Jpeg => pdf_writer.add_image_object(
+                            &image.data,
+                            image.source_width,
+                            image.source_height,
+                            image.format,
+                            image.png_metadata.as_ref(),
+                        ),
+                        ImageFormat::Png => {
+                            let Some(img_obj_id) = pdf_writer.add_raw_png_image_object(&image.data)
+                            else {
+                                continue;
+                            };
+                            img_obj_id
+                        }
+                    };
                     let img_name = format!("Im{img_obj_id}");
                     content.push_str(&format!(
                         "q\n{w} 0 0 {h} {x} {y} cm\n/{name} Do\nQ\n",
@@ -5083,6 +5092,7 @@ struct DecodedPngImage {
 fn decode_png_for_pdf(raw: &[u8]) -> Option<DecodedPngImage> {
     let mut decoder = png_decoder::Decoder::new(std::io::Cursor::new(raw));
     decoder.ignore_checksums(true);
+    decoder.set_transformations(png_decoder::Transformations::normalize_to_color8());
     let mut reader = decoder.read_info().ok()?;
     let output_size = reader.output_buffer_size()?;
     let mut buffer = vec![0; output_size];
@@ -5201,6 +5211,9 @@ impl PdfWriter {
                 )
             }
             ImageFormat::Png => {
+                // This path expects already predictor-compatible color data without alpha.
+                // Do not use for normal PNG files with alpha. Normal PNG files should go
+                // through add_raw_png_image_object(), which decodes and separates /SMask.
                 let meta = png_metadata.expect("PNG metadata required for PNG images");
                 let color_space = match meta.channels {
                     1 | 2 => "/DeviceGray",
@@ -7158,6 +7171,57 @@ mod tests {
     }
 
     #[test]
+    fn png_rgba_alpha_uses_smask() {
+        let png_bytes = encode_test_png_rgba();
+        let b64 = simple_base64_encode_test(&png_bytes);
+        let html = format!(
+            r#"<html><body><img width="20" height="20" src="data:image/png;base64,{b64}"></body></html>"#
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+
+        assert!(content.contains("/SMask"));
+        assert!(content.contains("/ColorSpace /DeviceRGB"));
+        assert!(!content.contains("/Colors 4"));
+    }
+
+    #[test]
+    fn png_grayscale_alpha_uses_smask() {
+        let png_bytes = encode_test_png_grayscale_alpha();
+        let b64 = simple_base64_encode_test(&png_bytes);
+        let html = format!(
+            r#"<html><body><img width="20" height="20" src="data:image/png;base64,{b64}"></body></html>"#
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+
+        assert!(content.contains("/SMask"));
+        assert!(content.contains("/ColorSpace /DeviceGray"));
+        assert!(!content.contains("/Colors 2"));
+    }
+
+    #[test]
+    fn png_rgb_without_alpha_still_works() {
+        let png_bytes = encode_test_png_rgb();
+        let b64 = simple_base64_encode_test(&png_bytes);
+        let html = format!(
+            r#"<html><body><img width="20" height="20" src="data:image/png;base64,{b64}"></body></html>"#
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+
+        assert!(!content.contains("/SMask"));
+        assert!(content.contains("/ColorSpace /DeviceRGB"));
+        assert!(content.contains("/Subtype /Image"));
+    }
+
+    #[test]
     fn render_png_image_contains_flatedecode() {
         // Build a minimal valid PNG as base64 data URI
         let png_bytes = build_minimal_test_png();
@@ -7180,12 +7244,12 @@ mod tests {
             "PNG image should use FlateDecode filter"
         );
         assert!(
-            content.contains("/Predictor 15"),
-            "PNG image should have Predictor 15 in DecodeParms"
+            content.contains("/ColorSpace /DeviceRGB"),
+            "RGB PNG should use a DeviceRGB image XObject"
         );
         assert!(
-            content.contains("/Colors 3"),
-            "RGB PNG should have Colors 3"
+            !content.contains("/DecodeParms"),
+            "normal PNG rendering should decode pixels instead of embedding predictor streams"
         );
         assert!(
             content.contains("Do"),
@@ -7204,7 +7268,7 @@ mod tests {
         let content = String::from_utf8_lossy(&pdf);
         assert!(content.contains("/Filter /FlateDecode"));
         assert!(content.contains("/ColorSpace /DeviceGray"));
-        assert!(content.contains("/Colors 1"));
+        assert!(!content.contains("/DecodeParms"));
     }
 
     /// Build a minimal valid PNG (1x1 RGB, 8-bit).
@@ -7213,34 +7277,55 @@ mod tests {
     }
 
     fn build_test_png_with_color_type(color_type: u8) -> Vec<u8> {
-        let mut png = Vec::new();
-        // PNG signature
-        png.extend_from_slice(&[137, 80, 78, 71, 13, 10, 26, 10]);
-        // IHDR chunk (13 bytes data)
-        let mut ihdr = Vec::new();
-        ihdr.extend_from_slice(&1u32.to_be_bytes()); // width
-        ihdr.extend_from_slice(&1u32.to_be_bytes()); // height
-        ihdr.push(8); // bit depth
-        ihdr.push(color_type);
-        ihdr.push(0); // compression
-        ihdr.push(0); // filter
-        ihdr.push(0); // interlace
-        append_png_chunk(&mut png, b"IHDR", &ihdr);
-        // IDAT chunk with dummy zlib-compressed data
-        let idat = [
-            0x78, 0x01, 0x62, 0x60, 0x60, 0x60, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01,
-        ];
-        append_png_chunk(&mut png, b"IDAT", &idat);
-        // IEND
-        append_png_chunk(&mut png, b"IEND", &[]);
-        png
+        match color_type {
+            0 => encode_test_png_grayscale(),
+            2 => encode_test_png_rgb(),
+            4 => encode_test_png_grayscale_alpha(),
+            6 => encode_test_png_rgba(),
+            _ => panic!("unsupported test PNG color type {color_type}"),
+        }
     }
 
-    fn append_png_chunk(buf: &mut Vec<u8>, chunk_type: &[u8; 4], data: &[u8]) {
-        buf.extend_from_slice(&(data.len() as u32).to_be_bytes());
-        buf.extend_from_slice(chunk_type);
-        buf.extend_from_slice(data);
-        buf.extend_from_slice(&[0, 0, 0, 0]); // CRC placeholder
+    fn encode_test_png_rgb() -> Vec<u8> {
+        let image =
+            image::RgbImage::from_raw(2, 2, vec![255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 0])
+                .unwrap();
+        encode_dynamic_png(image::DynamicImage::ImageRgb8(image))
+    }
+
+    fn encode_test_png_rgba() -> Vec<u8> {
+        let image = image::RgbaImage::from_raw(
+            2,
+            2,
+            vec![
+                255, 0, 0, 255, 0, 255, 0, 128, 0, 0, 255, 64, 255, 255, 0, 0,
+            ],
+        )
+        .unwrap();
+        encode_dynamic_png(image::DynamicImage::ImageRgba8(image))
+    }
+
+    fn encode_test_png_grayscale() -> Vec<u8> {
+        let image = image::GrayImage::from_raw(2, 2, vec![0, 85, 170, 255]).unwrap();
+        encode_dynamic_png(image::DynamicImage::ImageLuma8(image))
+    }
+
+    fn encode_test_png_grayscale_alpha() -> Vec<u8> {
+        let image = image::ImageBuffer::<image::LumaA<u8>, Vec<u8>>::from_raw(
+            2,
+            2,
+            vec![0, 255, 85, 128, 170, 64, 255, 0],
+        )
+        .unwrap();
+        encode_dynamic_png(image::DynamicImage::ImageLumaA8(image))
+    }
+
+    fn encode_dynamic_png(image: image::DynamicImage) -> Vec<u8> {
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        image
+            .write_to(&mut cursor, image::ImageFormat::Png)
+            .unwrap();
+        cursor.into_inner()
     }
 
     fn simple_base64_encode_test(data: &[u8]) -> String {

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -8531,6 +8531,28 @@ mod tests {
     }
 
     #[test]
+    fn table_cell_image_pdf_renders_xobject() {
+        let png_bytes = build_minimal_test_png();
+        let b64 = simple_base64_encode_test(&png_bytes);
+        let html = format!(
+            r#"<table><tr><td><img width="100" height="100" src="data:image/png;base64,{b64}"></td></tr></table>"#
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let pdf_str = String::from_utf8_lossy(&pdf);
+
+        assert!(
+            pdf_str.contains("/XObject"),
+            "Expected nested table-cell image to emit an image XObject"
+        );
+        assert!(
+            pdf_str.contains(" Do\n"),
+            "Expected nested table-cell image to be painted"
+        );
+    }
+
+    #[test]
     fn nested_text_block_padding_top_offsets_text() {
         let lines = vec![test_text_line(vec![test_text_run("Nested")])];
         let custom_fonts = HashMap::new();

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -679,26 +679,31 @@ pub(super) fn render_nested_layout_elements(
             } => {
                 let img_x = planned_element.origin_x;
                 let img_y = planned_element.top_y - height;
-                let img_obj_id = ctx.pdf_writer.add_image_object(
-                    &image.data,
-                    image.source_width,
-                    image.source_height,
-                    image.format,
-                    image.png_metadata.as_ref(),
-                );
-                let img_name = format!("Im{img_obj_id}");
-                content.push_str(&format!(
-                    "q\n{w} 0 0 {h} {x} {y} cm\n/{name} Do\nQ\n",
-                    w = width,
-                    h = height,
-                    x = img_x,
-                    y = img_y,
-                    name = img_name,
-                ));
-                ctx.page_images.push(ImageRef {
-                    name: img_name,
-                    obj_id: img_obj_id,
-                });
+                let img_obj_id = match image.format {
+                    ImageFormat::Jpeg => Some(ctx.pdf_writer.add_image_object(
+                        &image.data,
+                        image.source_width,
+                        image.source_height,
+                        image.format,
+                        image.png_metadata.as_ref(),
+                    )),
+                    ImageFormat::Png => ctx.pdf_writer.add_raw_png_image_object(&image.data),
+                };
+                if let Some(img_obj_id) = img_obj_id {
+                    let img_name = format!("Im{img_obj_id}");
+                    content.push_str(&format!(
+                        "q\n{w} 0 0 {h} {x} {y} cm\n/{name} Do\nQ\n",
+                        w = width,
+                        h = height,
+                        x = img_x,
+                        y = img_y,
+                        name = img_name,
+                    ));
+                    ctx.page_images.push(ImageRef {
+                        name: img_name,
+                        obj_id: img_obj_id,
+                    });
+                }
             }
             LayoutElement::Svg {
                 tree,

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -671,6 +671,86 @@ pub(super) fn render_nested_layout_elements(
                     ctx,
                 );
             }
+            LayoutElement::Image {
+                image,
+                width,
+                height,
+                ..
+            } => {
+                let img_x = planned_element.origin_x;
+                let img_y = planned_element.top_y - height;
+                let img_obj_id = ctx.pdf_writer.add_image_object(
+                    &image.data,
+                    image.source_width,
+                    image.source_height,
+                    image.format,
+                    image.png_metadata.as_ref(),
+                );
+                let img_name = format!("Im{img_obj_id}");
+                content.push_str(&format!(
+                    "q\n{w} 0 0 {h} {x} {y} cm\n/{name} Do\nQ\n",
+                    w = width,
+                    h = height,
+                    x = img_x,
+                    y = img_y,
+                    name = img_name,
+                ));
+                ctx.page_images.push(ImageRef {
+                    name: img_name,
+                    obj_id: img_obj_id,
+                });
+            }
+            LayoutElement::Svg {
+                tree,
+                width,
+                height,
+                ..
+            } => {
+                let svg_x = planned_element.origin_x;
+                let svg_y = planned_element.top_y - height;
+
+                content.push_str("q\n");
+                content.push_str(&format!("1 0 0 -1 {} {} cm\n", svg_x, svg_y + height));
+                if let Some(placement) = crate::render::svg_geometry::compute_svg_placement(
+                    tree,
+                    crate::render::svg_geometry::SvgPlacementRequest::from_rect(
+                        0.0,
+                        0.0,
+                        *width,
+                        *height,
+                        tree.preserve_aspect_ratio,
+                    ),
+                ) {
+                    content.push_str("q\n");
+                    content.push_str(&placement.viewport.clip_path());
+                    content.push_str(&format!(
+                        "{sx} 0 0 {sy} {tx} {ty} cm\n",
+                        sx = placement.scale_x,
+                        sy = placement.scale_y,
+                        tx = placement.translate_x,
+                        ty = placement.translate_y,
+                    ));
+                    {
+                        let mut image_sink = SvgPageImageSink {
+                            pdf_writer: ctx.pdf_writer,
+                            page_images: ctx.page_images,
+                        };
+                        let mut resources = crate::render::svg_to_pdf::SvgPdfResources {
+                            shadings: ctx.shadings,
+                            shading_counter: ctx.shading_counter,
+                            ext_gstates: Some(ctx.page_ext_gstates),
+                            image_sink: Some(&mut image_sink),
+                        };
+                        crate::render::svg_to_pdf::render_svg_tree_with_resources(
+                            tree,
+                            content,
+                            &mut resources,
+                        );
+                    }
+                    content.push_str("Q\n");
+                }
+                content.push_str("Q\n");
+            }
             _ => {}
         }
     }
@@ -773,6 +853,32 @@ pub(super) fn plan_nested_layout_elements(
                         )
                         - *margin_bottom;
                 }
+            }
+            LayoutElement::Image {
+                margin_top,
+                margin_bottom,
+                height,
+                flow_extra_bottom,
+                ..
+            }
+            | LayoutElement::Svg {
+                margin_top,
+                margin_bottom,
+                height,
+                flow_extra_bottom,
+                ..
+            } => {
+                cursor_y -= *margin_top;
+                let top_y = cursor_y;
+                planned.push(PlannedNestedElement {
+                    element,
+                    source_index: element_idx,
+                    origin_x: frame.origin_x,
+                    top_y,
+                    available_width: frame.available_width,
+                    blur_canvas_box: None,
+                });
+                cursor_y -= *height + *flow_extra_bottom + *margin_bottom;
             }
             _ => {}
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,30 @@
 //! Shared helpers used across the parser, layout, and renderer.
 
+/// Return true for the five HTML collapsible whitespace characters.
+pub(crate) fn is_html_collapsible_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\r' | '\x0C')
+}
+
+/// Trim only HTML collapsible whitespace from the end of a string.
+pub(crate) fn trim_html_collapsible_whitespace_end(s: &str) -> String {
+    let mut end = s.len();
+
+    for (idx, c) in s.char_indices().rev() {
+        if is_html_collapsible_whitespace(c) {
+            end = idx;
+        } else {
+            break;
+        }
+    }
+
+    s[..end].to_string()
+}
+
+/// Return true when a string contains a Unicode non-breaking space.
+pub(crate) fn contains_nbsp(s: &str) -> bool {
+    s.contains('\u{00A0}')
+}
+
 /// Decode a standard Base64 string without pulling in an extra dependency.
 pub(crate) fn decode_base64(input: &str) -> Option<Vec<u8>> {
     fn table(c: u8) -> Option<u8> {


### PR DESCRIPTION
Title

Improve HTML whitespace and image rendering fidelity

Description

Hi! Thank you for building ironpress — I have been testing it as a lightweight HTML-to-PDF renderer and it has been very useful.

While testing real-world HTML documents, I ran into a few rendering issues around NBSP whitespace, images inside nested layout structures, table-cell images, and PNG alpha handling.

I am not a Rust expert, so please feel free to adjust, split, or rewrite any part of this PR if there is a better way to fit the project architecture.

## What this PR fixes

### NBSP / HTML whitespace handling

- Preserves `&nbsp;` / `U+00A0` during HTML parsing.
- Collapses only normal HTML collapsible whitespace: space, tab, LF, CR, and form feed.
- Avoids trimming or dropping NBSP-only text.
- Preserves repeated NBSPs such as `&nbsp;&nbsp;&nbsp;`.
- Avoids splitting text containing NBSP with `split_whitespace()`, so `A&nbsp;B` remains non-breaking.
- Preserves line height for NBSP-only paragraphs, including before following block/table content.

Examples fixed:

```html
<p>&nbsp;</p>
<p><span>&nbsp;</span></p>
<p><span><o:p>&nbsp;</o:p></span></p>
<p>A&nbsp;&nbsp;&nbsp;B</p>
Image layout
Treats <img> as an atomic/replaced layout child, similar to SVG handling.
Prevents images from being swallowed by text collection inside block containers.
Preserves images through nested inline wrappers.
Fixes images inside table cells.
Fixes span-wrapped images inside table cells.
Ensures table intrinsic sizing accounts for nested image/SVG width.
Renders nested table-cell image/SVG elements in PDF output.
Respects CSS width / height for raster images, not only HTML attributes.

Examples fixed:

<div><img src="..."></div>
<div><span><img src="..."></span></div>
<table><tr><td><img src="..."></td></tr></table>
<table><tr><td><span><img src="..."></span></td></tr></table>
PNG alpha rendering
Stores full PNG file bytes for PNG image assets.
Renders PNGs through a decoded PNG path.
Splits RGBA and grayscale+alpha PNGs into color data plus a PDF /SMask.
Avoids embedding interleaved RGBA bytes directly as /DeviceRGB, which caused distorted/shifted PNG output.
Keeps JPEG handling unchanged.
Tests added

Focused regression tests were added for:

NBSP parsing and whitespace collapsing
multiple NBSP preservation
NBSP-only paragraph spacing
images inside block containers
images inside nested inline wrappers
images inside table cells
CSS-sized raster images
PNG RGB, RGBA, grayscale, and grayscale+alpha rendering
PNG assets keeping full PNG bytes

I kept the tests focused on the changed behavior rather than adding broad unrelated coverage.

Thanks again for the project. I hope this is useful, and I am happy to adjust the PR if you prefer the fixes split differently.