### PR TITLE
Fix/table cell image svg 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ fuzz/target/
 tests/fixtures/references/**/*.png
 bindings/python/target/
 bindings/ruby/target/
+.omc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ fontdb = "0.23"
 flate2 = "1"
 resvg = "0.47"
 rustybuzz = "0.20"
-subsetter = "0.2.3"
+subsetter = "0.2.6"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "rt"], optional = true }
 ureq = { version = "3", optional = true }

--- a/src/bidi.rs
+++ b/src/bidi.rs
@@ -144,6 +144,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         }
     }
 

--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -342,11 +342,19 @@ pub(crate) fn layout_block_element(
         || style.border.has_any()
         || style.border_radius > 0.0
         || style.box_shadow.is_some();
+    // An absolutely-positioned element is out of normal flow. Its block/SVG
+    // children must be nested inside a single positioned Container so they are
+    // taken out of flow during pagination too — otherwise they leak into the
+    // page's in-flow content as bare elements, advancing the pagination cursor
+    // and producing phantom page breaks (the parent's `position:absolute` is
+    // lost on the child). A style-less absolute wrapper (no bg/border/height)
+    // would otherwise skip the wrapper path, so trigger it explicitly here.
+    let is_absolute = style.position == Position::Absolute;
     // Limit nesting depth to prevent stack overflow on deeply nested HTML.
     // Beyond depth 40, fall back to flat text collection instead of Containers.
     let nesting_depth = ancestors.len();
     let has_block_kids_for_wrapper = nesting_depth < 40
-        && early_has_visual
+        && (early_has_visual || is_absolute)
         && el.children.iter().any(|c| {
             matches!(c, DomNode::Element(e)
                 if (e.tag.is_block() || e.tag == HtmlTag::Svg)
@@ -1157,7 +1165,8 @@ pub(crate) fn layout_block_element(
         || style.aspect_ratio.is_some()
         || style.height.is_some()
         || (positioned_container && (before_is_abs || after_is_abs))
-        || has_abs_children;
+        || has_abs_children
+        || (is_absolute && has_block_kids_for_wrapper);
     let no_inline_content = !had_inline_runs;
 
     let has_abs_pseudo = positioned_container && (before_is_abs || after_is_abs);

--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -354,7 +354,7 @@ pub(crate) fn layout_block_element(
     // Beyond depth 40, fall back to flat text collection instead of Containers.
     let nesting_depth = ancestors.len();
     let has_block_kids_for_wrapper = nesting_depth < 40
-        && (early_has_visual || is_absolute)
+        && (early_has_visual || is_absolute || style.page_break_inside_avoid)
         && el.children.iter().any(|c| {
             matches!(c, DomNode::Element(e)
                 if (e.tag.is_block() || e.tag == HtmlTag::Svg)
@@ -487,6 +487,10 @@ pub(crate) fn layout_block_element(
         let has_block_children = !parent_has_visual
             && !early_has_abs_children
             && !has_abs_pseudo_early
+            // page-break-inside: avoid must take the Container wrapper path so
+            // the block paginates as one atom; the fast path would splice its
+            // children into the flat stream where they can split across pages.
+            && !style.page_break_inside_avoid
             && el.children.iter().any(|c| {
                 matches!(c, DomNode::Element(e)
                     if (has_own_margins(e.tag)
@@ -1166,7 +1170,10 @@ pub(crate) fn layout_block_element(
         || style.height.is_some()
         || (positioned_container && (before_is_abs || after_is_abs))
         || has_abs_children
-        || (is_absolute && has_block_kids_for_wrapper);
+        || (is_absolute && has_block_kids_for_wrapper)
+        // page-break-inside: avoid — a Container is the pagination atom, so
+        // wrapping the block makes paginate() move it across pages whole.
+        || style.page_break_inside_avoid;
     let no_inline_content = !had_inline_runs;
 
     let has_abs_pseudo = positioned_container && (before_is_abs || after_is_abs);

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -252,6 +252,23 @@ pub enum ImageFormat {
 pub struct PngMetadata {
     pub channels: u8,
     pub bit_depth: u8,
+    pub color_space: PngColorSpace,
+    pub alpha_data: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PngColorSpace {
+    DeviceGray,
+    DeviceRgb,
+}
+
+impl PngColorSpace {
+    pub(crate) const fn pdf_name(self) -> &'static str {
+        match self {
+            Self::DeviceGray => "/DeviceGray",
+            Self::DeviceRgb => "/DeviceRGB",
+        }
+    }
 }
 
 /// Raster image bytes plus the source pixel dimensions required by the PDF renderer.
@@ -2905,30 +2922,14 @@ mod tests {
 
     fn build_test_png_bytes() -> Vec<u8> {
         let mut png_data = Vec::new();
-        png_data.extend_from_slice(&[137, 80, 78, 71, 13, 10, 26, 10]);
-        // IHDR
-        let mut ihdr = Vec::new();
-        ihdr.extend_from_slice(&1u32.to_be_bytes());
-        ihdr.extend_from_slice(&1u32.to_be_bytes());
-        ihdr.push(8); // bit depth
-        ihdr.push(2); // color type RGB
-        ihdr.push(0);
-        ihdr.push(0);
-        ihdr.push(0);
-        append_test_chunk(&mut png_data, b"IHDR", &ihdr);
-        let idat = [
-            0x78, 0x01, 0x62, 0x60, 0x60, 0x60, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01,
-        ];
-        append_test_chunk(&mut png_data, b"IDAT", &idat);
-        append_test_chunk(&mut png_data, b"IEND", &[]);
+        let image = image::RgbImage::from_pixel(1, 1, image::Rgb([255, 0, 0]));
+        image::DynamicImage::ImageRgb8(image)
+            .write_to(
+                &mut std::io::Cursor::new(&mut png_data),
+                image::ImageFormat::Png,
+            )
+            .unwrap();
         png_data
-    }
-
-    fn append_test_chunk(buf: &mut Vec<u8>, chunk_type: &[u8; 4], data: &[u8]) {
-        buf.extend_from_slice(&(data.len() as u32).to_be_bytes());
-        buf.extend_from_slice(chunk_type);
-        buf.extend_from_slice(data);
-        buf.extend_from_slice(&[0, 0, 0, 0]);
     }
 
     #[test]

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -154,7 +154,7 @@ pub(crate) enum ListContext {
 }
 
 pub use super::table::TableCell;
-pub(crate) use super::table::table_cell_content_height;
+pub(crate) use super::table::{table_cell_box_height, table_cell_content_height};
 
 /// A cell within a flex row, with its computed x-offset and width.
 #[derive(Debug, Clone)]

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2157,6 +2157,136 @@ mod tests {
         assert!(pages.len() >= 2);
     }
 
+    /// Find the single Container on a page and return how many of its children
+    /// match `pred`. Panics when the page has no Container.
+    fn container_children_matching(page: &Page, pred: fn(&LayoutElement) -> bool) -> usize {
+        page.elements
+            .iter()
+            .find_map(|(_, el)| match el {
+                LayoutElement::Container { children, .. } => {
+                    Some(children.iter().filter(|c| pred(c)).count())
+                }
+                _ => None,
+            })
+            .expect("expected a Container on the page")
+    }
+
+    // A4 content height with default 72pt margins is ~697.9pt. A 450pt filler
+    // leaves ~248pt — too little for the 320pt keep-together pair, but enough
+    // for its first 160pt child. The control (no avoid) therefore splits the
+    // pair across the page boundary; `page-break-inside: avoid` must move the
+    // pair to page 2 as a whole. (Text-carrying divs lay out as single
+    // TextBlocks; the avoid wrapper around two block children must become an
+    // atomic Container.)
+    const KEEP_TOGETHER_HTML: &str = r#"
+        <div style="height: 450pt; background: #eee;">filler</div>
+        <div PROP>
+            <div style="height: 160pt; background: #ddd;">keep-a</div>
+            <div style="height: 160pt; background: #ccc;">keep-b</div>
+        </div>
+    "#;
+
+    #[test]
+    fn block_without_avoid_splits_across_pages() {
+        let html = KEEP_TOGETHER_HTML.replace("PROP", "");
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 2, "control doc should span two pages");
+        // filler + keep-a fit on page 1; keep-b overflows to page 2.
+        assert_eq!(pages[0].elements.len(), 2);
+        assert_eq!(pages[1].elements.len(), 1);
+    }
+
+    #[test]
+    fn page_break_inside_avoid_moves_block_to_next_page_whole() {
+        let html = KEEP_TOGETHER_HTML.replace("PROP", r#"style="page-break-inside: avoid;""#);
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 2, "doc should span two pages");
+        // Page 1 keeps only the filler; the avoid pair moves whole to page 2
+        // as one atomic Container wrapping both children.
+        assert_eq!(pages[0].elements.len(), 1);
+        assert!(matches!(
+            pages[0].elements[0].1,
+            LayoutElement::TextBlock { .. }
+        ));
+        assert_eq!(pages[1].elements.len(), 1);
+        let kids = container_children_matching(&pages[1], |c| {
+            matches!(c, LayoutElement::TextBlock { .. })
+        });
+        assert_eq!(kids, 2, "both children stay inside the wrapper");
+    }
+
+    #[test]
+    fn break_inside_avoid_alias_also_keeps_block_together() {
+        let html = KEEP_TOGETHER_HTML.replace("PROP", r#"style="break-inside: avoid;""#);
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].elements.len(), 1);
+        assert_eq!(pages[1].elements.len(), 1);
+        assert!(matches!(
+            pages[1].elements[0].1,
+            LayoutElement::Container { .. }
+        ));
+    }
+
+    #[test]
+    fn page_break_inside_avoid_fitting_block_stays_on_page() {
+        // 2 x 100pt children fit in the ~248pt remainder: no break at all.
+        let html = r#"
+            <div style="height: 450pt; background: #eee;">filler</div>
+            <div style="page-break-inside: avoid;">
+                <div style="height: 100pt; background: #ddd;">keep-a</div>
+                <div style="height: 100pt; background: #ccc;">keep-b</div>
+            </div>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1, "fitting block must not force a page break");
+        assert_eq!(pages[0].elements.len(), 2);
+    }
+
+    #[test]
+    fn page_break_inside_avoid_taller_than_page_does_not_loop() {
+        // Degenerate: the keep-together block alone exceeds a full page. It
+        // cannot fit anywhere, so it must stay in place (clipped) rather than
+        // page-break forever.
+        let html = r#"
+            <div style="page-break-inside: avoid;">
+                <div style="height: 400pt;">a</div>
+                <div style="height: 400pt;">b</div>
+            </div>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].elements.len(), 1);
+    }
+
+    #[test]
+    fn page_break_inside_avoid_does_not_inherit_to_children() {
+        // The avoid wrapper's plain-text child divs (no own avoid property)
+        // must not each become Containers; only the wrapper does. CSS break
+        // properties do not inherit.
+        let html = r#"
+            <div style="page-break-inside: avoid;">
+                <div><p>plain child</p></div>
+            </div>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].elements.len(), 1);
+        let nested_containers = container_children_matching(&pages[0], |c| {
+            matches!(c, LayoutElement::Container { .. })
+        });
+        assert_eq!(
+            nested_containers, 0,
+            "child blocks must not inherit the avoid wrapper"
+        );
+    }
+
     #[test]
     fn bare_text_node() {
         // Text not wrapped in any element — exercises DomNode::Text branch in flatten_nodes

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -623,6 +623,10 @@ pub fn layout_with_rules_and_fonts(
     rules: &[CssRule],
     custom_fonts: &HashMap<String, TtfFont>,
 ) -> Vec<Page> {
+    // Fresh document: drop any table-sizing memo from a previous layout so
+    // cell pointers from a freed DOM are never reused as cache keys.
+    crate::layout::table::reset_table_sizing_cache();
+
     // Apply body/html/:root rules to the root style so that inherited root
     // properties still take effect even though the HTML parser unwraps the
     // <html>/<body> elements before layout.

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -217,6 +217,20 @@ pub struct TextRun {
     pub padding: (f32, f32),
     /// Border radius for inline spans (e.g. badge with rounded corners).
     pub border_radius: f32,
+    /// Explicit `width` (pt) for an atomic `display:inline-block` box carried on
+    /// this run. When `Some`, line layout reserves this advance and any
+    /// `background_color`/`border_bottom` is painted at this width rather than
+    /// the text-glyph width (used for form fill-in underlines and checkbox
+    /// squares inside table cells).
+    pub box_width: Option<f32>,
+    /// Explicit `height` (pt) for an atomic inline-block box carried on this
+    /// run. When `Some`, the box/background is drawn this tall (vertically
+    /// centred on the text line, approximating `vertical-align: middle`).
+    pub box_height: Option<f32>,
+    /// Bottom border of an atomic inline-block box: `(width_pt, rgb)`. When
+    /// `Some`, a line of this width/colour is stroked along the bottom of the
+    /// box spanning `box_width` (or the run advance when no `box_width`).
+    pub border_bottom: Option<(f32, (f32, f32, f32))>,
 }
 
 /// A laid-out line of text runs.
@@ -817,6 +831,9 @@ fn flatten_nodes(
                             background_color: None,
                             padding: (0.0, 0.0),
                             border_radius: 0.0,
+                            box_width: None,
+                            box_height: None,
+                            border_bottom: None,
                         },
                         &mut text_runs,
                         env.fonts,
@@ -1054,6 +1071,9 @@ pub(crate) fn flatten_element(
                 background_color: None,
                 padding: (0.0, 0.0),
                 border_radius: 0.0,
+                box_width: None,
+                box_height: None,
+                border_bottom: None,
             }],
             height: style.font_size * resolved_line_height_factor(&style, env.fonts),
         };
@@ -1219,6 +1239,9 @@ pub(crate) fn flatten_element(
                     background_color: None,
                     padding: (0.0, 0.0),
                     border_radius: 0.0,
+                    box_width: None,
+                    box_height: None,
+                    border_bottom: None,
                 },
                 &mut runs,
                 env.fonts,
@@ -1375,6 +1398,9 @@ pub(crate) fn flatten_element(
                 background_color: None,
                 padding: (0.0, 0.0),
                 border_radius: 0.0,
+                box_width: None,
+                box_height: None,
+                border_bottom: None,
             },
             &mut runs,
             env.fonts,
@@ -1651,6 +1677,9 @@ pub(crate) fn flatten_element(
                         background_color: None,
                         padding: (0.0, 0.0),
                         border_radius: 0.0,
+                        box_width: None,
+                        box_height: None,
+                        border_bottom: None,
                     },
                     &mut runs,
                     env.fonts,
@@ -1701,6 +1730,9 @@ pub(crate) fn flatten_element(
                     background_color: None,
                     padding: (0.0, 0.0),
                     border_radius: 0.0,
+                    box_width: None,
+                    box_height: None,
+                    border_bottom: None,
                 },
                 &mut runs,
                 env.fonts,
@@ -5450,6 +5482,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         // At 12pt, each char ~6pt. "Hi" = 12pt.
         // "Supercalifragilisticexpialidocious" = 34*6 = 204pt.
@@ -5494,6 +5529,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let lines = wrap_text_runs(
             vec![run],
@@ -5525,6 +5563,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let lines = wrap_text_runs(
             vec![run],

--- a/src/layout/grid.rs
+++ b/src/layout/grid.rs
@@ -311,6 +311,7 @@ pub(crate) fn layout_grid_container(
                 border: LayoutBorder::from_computed(&child_style.border),
                 text_align: child_style.text_align,
                 vertical_align: child_style.vertical_align,
+                min_height: 0.0,
             });
         }
 
@@ -330,6 +331,7 @@ pub(crate) fn layout_grid_container(
                 border: LayoutBorder::default(),
                 text_align: TextAlign::Left,
                 vertical_align: VerticalAlign::Baseline,
+                min_height: 0.0,
             });
         }
 

--- a/src/layout/helpers.rs
+++ b/src/layout/helpers.rs
@@ -443,6 +443,9 @@ pub(crate) fn build_pseudo_block(
                 background_color: None,
                 padding: (0.0, 0.0),
                 border_radius: 0.0,
+                box_width: None,
+                box_height: None,
+                border_bottom: None,
             },
             &mut runs,
             fonts,
@@ -655,6 +658,9 @@ pub(crate) fn build_pseudo_inline_run(
         background_color: pseudo_style.background_color.map(|c| c.to_f32_rgba()),
         padding: (0.0, 0.0),
         border_radius: 0.0,
+        box_width: None,
+        box_height: None,
+        border_bottom: None,
     }
 }
 

--- a/src/layout/images.rs
+++ b/src/layout/images.rs
@@ -5,7 +5,7 @@ use crate::style::computed::{ComputedStyle, Display, FontStyle, FontWeight, Vert
 use crate::util::decode_base64;
 use std::collections::HashMap;
 
-use super::engine::{ImageFormat, LayoutElement, PngMetadata, RasterImageAsset};
+use super::engine::{ImageFormat, LayoutElement, PngColorSpace, PngMetadata, RasterImageAsset};
 use super::text::resolve_style_font_family;
 
 /// Load raw bytes from a `src` attribute value.
@@ -74,19 +74,17 @@ pub(crate) fn try_parse_svg_bytes(raw: &[u8]) -> Option<crate::parser::svg::SvgT
 /// Detect PNG/JPEG format and return a raster asset with source dimensions.
 pub(crate) fn load_image_bytes(raw: Vec<u8>) -> Option<RasterImageAsset> {
     if png::is_png(&raw) {
-        let png_info = png::parse_png(&raw)?;
+        let png_info = decode_png_for_layout(&raw)?;
         let metadata = PngMetadata {
             channels: png_info.channels,
-            bit_depth: png_info.bit_depth,
+            bit_depth: 8,
+            color_space: png_info.color_space,
+            alpha_data: png_info.alpha_data,
         };
         Some(RasterImageAsset {
-            // Store the FULL raw PNG bytes (not the deflated IDAT) so the PDF
-            // renderer can fully decode it into a DeviceRGB image + alpha SMask
-            // via add_raw_png_image_object. The legacy Predictor-15 path mishandles
-            // RGBA (DecodeParms /Colors 4 vs /DeviceRGB's 3 components → scanline shear).
-            data: raw,
-            source_width: png_info.width,
-            source_height: png_info.height,
+            data: png_info.color_data,
+            source_width: png_info.source_width,
+            source_height: png_info.source_height,
             format: ImageFormat::Png,
             png_metadata: Some(metadata),
         })
@@ -102,6 +100,66 @@ pub(crate) fn load_image_bytes(raw: Vec<u8>) -> Option<RasterImageAsset> {
     } else {
         None
     }
+}
+
+struct DecodedLayoutPng {
+    source_width: u32,
+    source_height: u32,
+    channels: u8,
+    color_space: PngColorSpace,
+    color_data: Vec<u8>,
+    alpha_data: Option<Vec<u8>>,
+}
+
+fn decode_png_for_layout(raw: &[u8]) -> Option<DecodedLayoutPng> {
+    let mut decoder = png_decoder::Decoder::new(std::io::Cursor::new(raw));
+    decoder.ignore_checksums(true);
+    let mut reader = decoder.read_info().ok()?;
+    let output_size = reader.output_buffer_size()?;
+    let mut buffer = vec![0; output_size];
+    let info = reader.next_frame(&mut buffer).ok()?;
+    let pixels = buffer.get(..info.buffer_size())?;
+
+    let mut color_data = Vec::new();
+    let mut alpha_data = Vec::new();
+    let (channels, color_space, has_alpha) = match info.color_type {
+        png_decoder::ColorType::Rgba => {
+            color_data.reserve((info.width * info.height * 3) as usize);
+            alpha_data.reserve((info.width * info.height) as usize);
+            for chunk in pixels.chunks_exact(4) {
+                color_data.extend_from_slice(&chunk[..3]);
+                alpha_data.push(chunk[3]);
+            }
+            (3, PngColorSpace::DeviceRgb, true)
+        }
+        png_decoder::ColorType::Rgb => {
+            color_data.extend_from_slice(pixels);
+            (3, PngColorSpace::DeviceRgb, false)
+        }
+        png_decoder::ColorType::Grayscale => {
+            color_data.extend_from_slice(pixels);
+            (1, PngColorSpace::DeviceGray, false)
+        }
+        png_decoder::ColorType::GrayscaleAlpha => {
+            color_data.reserve((info.width * info.height) as usize);
+            alpha_data.reserve((info.width * info.height) as usize);
+            for chunk in pixels.chunks_exact(2) {
+                color_data.push(chunk[0]);
+                alpha_data.push(chunk[1]);
+            }
+            (1, PngColorSpace::DeviceGray, true)
+        }
+        _ => return None,
+    };
+
+    Some(DecodedLayoutPng {
+        source_width: info.width,
+        source_height: info.height,
+        channels,
+        color_space,
+        color_data,
+        alpha_data: has_alpha.then_some(alpha_data),
+    })
 }
 
 /// Load image data from an <img> element and return a LayoutElement.
@@ -1024,6 +1082,35 @@ mod tests {
         assert!(
             try_parse_svg_bytes(raw).is_none(),
             "Comment without <svg> should return None"
+        );
+    }
+
+    #[test]
+    fn load_image_bytes_stores_decoded_png_payload_not_source_file() {
+        let mut encoded = Vec::new();
+        let image = image::RgbImage::from_fn(2, 1, |x, _| {
+            if x == 0 {
+                image::Rgb([255, 0, 0])
+            } else {
+                image::Rgb([0, 0, 255])
+            }
+        });
+        image::DynamicImage::ImageRgb8(image)
+            .write_to(
+                &mut std::io::Cursor::new(&mut encoded),
+                image::ImageFormat::Png,
+            )
+            .unwrap();
+
+        let asset = load_image_bytes(encoded.clone()).expect("valid PNG should load");
+
+        assert_eq!(asset.format, ImageFormat::Png);
+        assert_eq!(asset.source_width, 2);
+        assert_eq!(asset.source_height, 1);
+        assert_eq!(asset.data.len(), 6);
+        assert!(
+            asset.data.len() < encoded.len(),
+            "layout PNG assets should keep decoded image payloads, not the full PNG file"
         );
     }
 

--- a/src/layout/images.rs
+++ b/src/layout/images.rs
@@ -166,13 +166,28 @@ pub(crate) fn load_image_from_element(
     // Fall back to raster image using the same bytes.
     let image = load_raster_image_bytes(raw, style.blur_radius)?;
 
-    // Determine dimensions from attributes
-    let attr_width = parse_html_image_dimension(el.attributes.get("width"));
-    let attr_height = parse_html_image_dimension(el.attributes.get("height"));
+    // Intrinsic pixel size → points (1px = 0.75pt, the 96dpi convention used by
+    // parse_html_image_dimension) so a single specified dimension preserves the
+    // image's natural aspect ratio instead of squaring it.
+    let intrinsic_w = image.source_width as f32 * 0.75;
+    let intrinsic_h = image.source_height as f32 * 0.75;
 
-    let (width, height) = match (attr_width, attr_height) {
+    // Honour CSS width/height first (e.g. style="width:46mm"), then the HTML
+    // width/height attributes. The raster path previously read only the HTML
+    // attributes, so CSS-sized images fell back to the 200x150 default and
+    // lost their aspect ratio.
+    let spec_width = style
+        .width
+        .or_else(|| parse_html_image_dimension(el.attributes.get("width")));
+    let spec_height = style
+        .height
+        .or_else(|| parse_html_image_dimension(el.attributes.get("height")));
+
+    let (width, height) = match (spec_width, spec_height) {
         (Some(w), Some(h)) => (w, h),
-        (Some(w), None) => (w, w), // fallback: square
+        (Some(w), None) if intrinsic_w > 0.0 => (w, intrinsic_h * (w / intrinsic_w)),
+        (Some(w), None) => (w, w), // degenerate: no intrinsic size
+        (None, Some(h)) if intrinsic_h > 0.0 => (intrinsic_w * (h / intrinsic_h), h),
         (None, Some(h)) => (h, h),
         (None, None) => (available_width.min(200.0), 150.0),
     };

--- a/src/layout/images.rs
+++ b/src/layout/images.rs
@@ -80,7 +80,11 @@ pub(crate) fn load_image_bytes(raw: Vec<u8>) -> Option<RasterImageAsset> {
             bit_depth: png_info.bit_depth,
         };
         Some(RasterImageAsset {
-            data: png_info.idat_data,
+            // Store the FULL raw PNG bytes (not the deflated IDAT) so the PDF
+            // renderer can fully decode it into a DeviceRGB image + alpha SMask
+            // via add_raw_png_image_object. The legacy Predictor-15 path mishandles
+            // RGBA (DecodeParms /Colors 4 vs /DeviceRGB's 3 components → scanline shear).
+            data: raw,
             source_width: png_info.width,
             source_height: png_info.height,
             format: ImageFormat::Png,

--- a/src/layout/paginate.rs
+++ b/src/layout/paginate.rs
@@ -253,6 +253,26 @@ pub(crate) fn paginate(
                 *containing_block,
                 *positioned_depth,
             ),
+            // A Container can also be positioned (e.g. a style-less
+            // `position:absolute` wrapper around block/SVG children). Extract
+            // its position/offset so the absolute handler below takes it out of
+            // flow; otherwise it would advance the pagination cursor like an
+            // in-flow block and force a phantom page break. Container carries no
+            // clear/containing_block/positioned_depth fields, so those default.
+            LayoutElement::Container {
+                float,
+                position,
+                offset_top,
+                ..
+            } => (
+                *float,
+                Clear::None,
+                *position,
+                *offset_top,
+                0.0,
+                None,
+                0,
+            ),
             _ => (
                 Float::None,
                 Clear::None,

--- a/src/layout/paginate.rs
+++ b/src/layout/paginate.rs
@@ -1,4 +1,4 @@
-use super::engine::{LayoutElement, Page, layout_element_paint_order, table_cell_content_height};
+use super::engine::{LayoutElement, Page, layout_element_paint_order, table_cell_box_height};
 use crate::style::computed::{BorderCollapse, Clear, Float, Overflow, Position};
 use std::collections::HashMap;
 
@@ -81,7 +81,7 @@ fn estimate_element_height_bounded(element: &LayoutElement, depth: usize) -> f32
         } => {
             let row_h = cells
                 .iter()
-                .map(table_cell_content_height)
+                .map(table_cell_box_height)
                 .fold(0.0f32, f32::max);
             margin_top + row_h + margin_bottom
         }
@@ -95,7 +95,7 @@ fn estimate_element_height_bounded(element: &LayoutElement, depth: usize) -> f32
         } => {
             let row_h = cells
                 .iter()
-                .map(table_cell_content_height)
+                .map(table_cell_box_height)
                 .fold(0.0f32, f32::max);
             margin_top + padding_top + row_h + padding_bottom + margin_bottom
         }
@@ -325,7 +325,7 @@ pub(crate) fn paginate(
             } => {
                 let row_height = cells
                     .iter()
-                    .map(table_cell_content_height)
+                    .map(table_cell_box_height)
                     .fold(0.0f32, f32::max);
                 (row_height, *margin_top, *margin_bottom)
             }
@@ -337,7 +337,7 @@ pub(crate) fn paginate(
             } => {
                 let row_height = cells
                     .iter()
-                    .map(table_cell_content_height)
+                    .map(table_cell_box_height)
                     .fold(0.0f32, f32::max);
                 (row_height, *margin_top, *margin_bottom)
             }
@@ -510,7 +510,7 @@ pub(crate) fn paginate(
                     let header_h = match &header {
                         LayoutElement::TableRow { cells, .. } => cells
                             .iter()
-                            .map(table_cell_content_height)
+                            .map(table_cell_box_height)
                             .fold(0.0f32, f32::max),
                         _ => 0.0,
                     };

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -40,12 +40,59 @@ pub struct TableCell {
     pub text_align: TextAlign,
     /// Vertical alignment within the row box.
     pub vertical_align: VerticalAlign,
+    /// Resolved CSS `height`/`min-height` floor for this cell's box, in points.
+    /// Includes any height inherited from the owning `<tr>` and any surplus
+    /// distributed from a fixed-height `<table>`. `0.0` means content-driven.
+    pub min_height: f32,
 }
 
 pub(crate) fn table_cell_content_height(cell: &TableCell) -> f32 {
     let text_h: f32 = cell.lines.iter().map(|l| l.height).sum();
     let nested_h: f32 = cell.nested_rows.iter().map(estimate_element_height).sum();
     cell.padding_top + text_h + nested_h + cell.padding_bottom
+}
+
+/// The cell's box height: the larger of its natural content height and any
+/// CSS-specified height floor. Row height aggregates this across cells, while
+/// `table_cell_content_height` stays content-only so `vertical-align` can offset
+/// content within the (possibly taller) box.
+pub(crate) fn table_cell_box_height(cell: &TableCell) -> f32 {
+    table_cell_content_height(cell).max(cell.min_height)
+}
+
+/// Resolve a `<table>`/`<tr>`/`<td>` element's CSS `height` (and `min-height`,
+/// `max-height`) to a concrete points value used as a row/cell height floor.
+///
+/// Percentage heights resolve against `containing_height` (the table's own
+/// resolved height) when one is known, mirroring the block-flow resolver in
+/// `helpers.rs`. Returns `0.0` when no height is specified, which is the
+/// content-driven default for ordinary tables.
+fn resolve_specified_height(style: &ComputedStyle, containing_height: Option<f32>) -> f32 {
+    let mut h = style.height;
+    if let Some(cb) = containing_height
+        && let Some(percent) = style.percentage_sizing.height
+    {
+        h = Some(cb * percent / 100.0);
+    }
+    if let Some(min_h) = style.min_height {
+        h = Some(h.map_or(min_h, |v| v.max(min_h)));
+    }
+    if let Some(cb) = containing_height
+        && let Some(percent) = style.percentage_sizing.min_height
+    {
+        let min_h = cb * percent / 100.0;
+        h = Some(h.map_or(min_h, |v| v.max(min_h)));
+    }
+    if let Some(max_h) = style.max_height {
+        h = h.map(|v| v.min(max_h));
+    }
+    if let Some(cb) = containing_height
+        && let Some(percent) = style.percentage_sizing.max_height
+    {
+        let max_h = cb * percent / 100.0;
+        h = h.map_or(Some(max_h), |v| Some(v.min(max_h)));
+    }
+    h.unwrap_or(0.0).max(0.0)
 }
 
 /// Parse a width for a `<col>` / `<colgroup>` element.
@@ -828,10 +875,23 @@ pub(crate) fn flatten_table(
         }
     };
 
+    // Resolve the table's own CSS height. Row/cell percentage heights resolve
+    // against it; any surplus beyond the summed row heights is distributed back
+    // across the rows so a fixed-height table fills its box.
+    let table_specified_height = resolve_specified_height(style, Some(style.viewport_height));
+    let row_height_basis = if table_specified_height > 0.0 {
+        Some(table_specified_height)
+    } else {
+        None
+    };
+
     // Build layout rows, tracking cells occupied by rowspan from previous rows.
     // Each entry in `occupied` tracks the remaining rowspan count for that column.
     let mut occupied: Vec<usize> = vec![0; num_cols];
     let mut is_first = true;
+    // Collect this table's rows locally so the table-height surplus can be
+    // distributed across them before they are appended to `output`.
+    let mut table_rows: Vec<LayoutElement> = Vec::new();
     for (row_idx, row) in rows.iter().enumerate() {
         let row_classes = row.class_list();
         // Use section-relative index for nth-child matching (browsers count
@@ -866,6 +926,8 @@ pub(crate) fn flatten_table(
             &row_selector_ctx,
         );
         row_style.width = Some(inner_width);
+        // A `<tr style="height">` floor applies to every cell in the row.
+        let row_specified_height = resolve_specified_height(&row_style, row_height_basis);
         let mut cells = Vec::new();
 
         // Current logical column position in the grid
@@ -908,6 +970,7 @@ pub(crate) fn flatten_table(
                     border: LayoutBorder::default(),
                     text_align: TextAlign::Left,
                     vertical_align: VerticalAlign::Baseline,
+                    min_height: row_specified_height,
                 });
                 for i in 0..span_cols {
                     occupied[col_pos + i] -= 1;
@@ -1015,6 +1078,10 @@ pub(crate) fn flatten_table(
                 .or(row_style.background_color)
                 .map(|c: crate::types::Color| c.to_f32_rgba());
 
+            // The cell's height floor is the larger of its own CSS height and
+            // the row's height; either expands the row beyond its content.
+            let cell_specified_height = resolve_specified_height(&cell_style, row_height_basis);
+
             cells.push(TableCell {
                 lines,
                 nested_rows,
@@ -1029,6 +1096,7 @@ pub(crate) fn flatten_table(
                 border: LayoutBorder::from_computed(&cell_style.border),
                 text_align: cell_style.text_align,
                 vertical_align: cell_style.vertical_align,
+                min_height: cell_specified_height.max(row_specified_height),
             });
 
             // Mark subsequent rows as occupied if rowspan > 1
@@ -1047,7 +1115,7 @@ pub(crate) fn flatten_table(
             let is_header = row_section_elements[row_idx]
                 .map(|s| s.tag == HtmlTag::Thead)
                 .unwrap_or(false);
-            output.push(LayoutElement::TableRow {
+            table_rows.push(LayoutElement::TableRow {
                 cells,
                 col_widths: col_widths.clone(),
                 margin_top: if is_first {
@@ -1067,8 +1135,60 @@ pub(crate) fn flatten_table(
     }
 
     // Add bottom margin after the last row
-    if let Some(LayoutElement::TableRow { margin_bottom, .. }) = output.last_mut() {
+    if let Some(LayoutElement::TableRow { margin_bottom, .. }) = table_rows.last_mut() {
         *margin_bottom = style.margin.bottom;
+    }
+
+    // When the table specifies a height larger than the sum of its rows,
+    // distribute the surplus across the rows (proportionally to their current
+    // heights) so the table fills its box. Tables with no specified height are
+    // left untouched, keeping the common content-driven case unchanged.
+    distribute_table_height_surplus(&mut table_rows, table_specified_height);
+
+    output.append(&mut table_rows);
+}
+
+/// Grow each row so the rows together fill `table_height` when the table
+/// specifies a height beyond their natural sum. The surplus is shared in
+/// proportion to each row's current height (falling back to an even split when
+/// every row is zero-height). A `0.0` or already-satisfied target is a no-op,
+/// preserving content-driven tables.
+fn distribute_table_height_surplus(table_rows: &mut [LayoutElement], table_height: f32) {
+    if table_height <= 0.0 || table_rows.is_empty() {
+        return;
+    }
+    let row_heights: Vec<f32> = table_rows
+        .iter()
+        .map(|row| match row {
+            LayoutElement::TableRow { cells, .. } => {
+                cells.iter().map(table_cell_box_height).fold(0.0f32, f32::max)
+            }
+            _ => 0.0,
+        })
+        .collect();
+    let total: f32 = row_heights.iter().sum();
+    let surplus = table_height - total;
+    if surplus <= 0.0 {
+        return;
+    }
+    let row_count = table_rows.len() as f32;
+    for (row, &row_h) in table_rows.iter_mut().zip(row_heights.iter()) {
+        let extra = if total > 0.0 {
+            surplus * (row_h / total)
+        } else {
+            surplus / row_count
+        };
+        let target = row_h + extra;
+        if let LayoutElement::TableRow { cells, .. } = row {
+            for cell in cells.iter_mut() {
+                // Phantom cells (rowspan == 0) belong to a rowspan from an
+                // earlier row; leave their height to that origin row.
+                if cell.rowspan == 0 {
+                    continue;
+                }
+                cell.min_height = cell.min_height.max(target);
+            }
+        }
     }
 }
 

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -1304,6 +1304,7 @@ fn collect_table_cell_content_inner(
                         &mut inner_env,
                     );
                 } else if el.tag == HtmlTag::Svg
+                    || el.tag == HtmlTag::Img
                     || (recurse_blocks
                         && style.display != Display::Inline
                         && el.tag != HtmlTag::Br

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -782,6 +782,12 @@ pub(crate) fn flatten_table(
                         let content_width: f32 = runs
                             .iter()
                             .map(|run| {
+                                // Atomic inline-block boxes (fill-in underlines /
+                                // checkbox squares) reserve their explicit width so
+                                // the column is wide enough not to truncate them.
+                                if let Some(box_width) = run.box_width {
+                                    return box_width;
+                                }
                                 // Measure full text width using estimate_word_width
                                 let full_width = estimate_word_width(
                                     &run.text,
@@ -1266,6 +1272,31 @@ fn table_cell_edge_block_margins(
     )
 }
 
+/// Concatenate all descendant text of a node subtree into one string. Used to
+/// build the single atomic text run for a `display:inline-block` box inside a
+/// table cell (its box/border/size are carried on the run; its text is its
+/// flattened content). Whitespace collapsing and `&nbsp;`→space handling are
+/// applied by the caller via `collapse_whitespace`.
+fn flatten_descendant_text(nodes: &[DomNode]) -> String {
+    let mut out = String::new();
+    for node in nodes {
+        match node {
+            DomNode::Text(text) => out.push_str(text),
+            DomNode::Element(el) => out.push_str(&flatten_descendant_text(&el.children)),
+        }
+    }
+    out
+}
+
+/// Whether an inline-block element carries a renderable atomic box: an explicit
+/// `width`/`height`, or any non-zero border. Such boxes (form fill-in
+/// underlines, checkbox squares) must render their geometry rather than being
+/// flattened to plain text runs that drop the border and size.
+fn inline_block_has_box(style: &ComputedStyle) -> bool {
+    style.display == Display::InlineBlock
+        && (style.width.is_some() || style.height.is_some() || style.border.has_any())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn collect_table_cell_content_inner(
     nodes: &[DomNode],
@@ -1351,6 +1382,9 @@ fn collect_table_cell_content_inner(
                             background_color: bg,
                             padding: pad,
                             border_radius: br,
+                            box_width: None,
+                            box_height: None,
+                            border_bottom: None,
                         },
                     );
                 }
@@ -1393,6 +1427,56 @@ fn collect_table_cell_content_inner(
                     &selector_ctx,
                 );
                 if style.display == Display::None {
+                    continue;
+                }
+                // Atomic inline-block box (form fill-in underline / checkbox
+                // square): emit ONE text run carrying the box geometry so the
+                // border and explicit width/height survive, flowing inline with
+                // sibling text. Without this the box is flattened to plain runs
+                // that drop the border and size. Only applies to SVG-free inline
+                // blocks; SVG/Img keep their dedicated branches below.
+                if el.tag != HtmlTag::Svg && el.tag != HtmlTag::Img && inline_block_has_box(&style) {
+                    let raw = flatten_descendant_text(&el.children);
+                    let collapsed = collapse_whitespace(&raw);
+                    // Keep a single space when empty so the run survives merge /
+                    // wrap (which skip empty text); its advance comes from the
+                    // box_width, not the glyph.
+                    let text = if collapsed.is_empty() {
+                        " ".to_string()
+                    } else {
+                        collapsed
+                    };
+                    let bottom = style.border.bottom;
+                    let border_bottom = if bottom.width > 0.0 {
+                        let rgb = bottom
+                            .color
+                            .map(|c| c.to_f32_rgb())
+                            .unwrap_or_else(|| style.color.to_f32_rgb());
+                        Some((bottom.width, rgb))
+                    } else {
+                        None
+                    };
+                    push_text_run(
+                        runs,
+                        TextRun {
+                            text,
+                            font_size: style.font_size,
+                            bold: style.font_weight == FontWeight::Bold,
+                            italic: style.font_style == FontStyle::Italic,
+                            underline: style.text_decoration_underline,
+                            line_through: style.text_decoration_line_through,
+                            overline: style.text_decoration_overline,
+                            color: style.color.to_f32_rgb(),
+                            link_url: link_url.map(String::from),
+                            font_family: resolve_style_font_family(&style, fonts),
+                            background_color: style.background_color.map(|c| c.to_f32_rgba()),
+                            padding: (0.0, 0.0),
+                            border_radius: style.border_radius,
+                            box_width: style.width,
+                            box_height: style.height,
+                            border_bottom,
+                        },
+                    );
                     continue;
                 }
                 let url = if el.tag == HtmlTag::A {
@@ -1522,6 +1606,9 @@ fn push_line_break_run(
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         },
     );
 }

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -449,6 +449,41 @@ fn resolve_fixed_table_columns(
     resolved_widths
 }
 
+thread_local! {
+    /// Per-document memo of the table auto-sizing pass's per-cell preferred
+    /// width, keyed by `(cell element pointer, table inner-width bits)`.
+    ///
+    /// The sizing pass measures every cell — including flattening any nested
+    /// tables just to read their width — and an ancestor table is re-flattened
+    /// once per pass (sizing + placement) at every nesting level, so nested
+    /// cells are otherwise re-measured `2^depth` times. Caching the reduced
+    /// width collapses that to once per `(cell, width)`.
+    ///
+    /// Only populated for cells whose subtree touches no CSS counters (see
+    /// [`flatten_table`]), so a cached width never depends on counter context.
+    /// Cleared at the start of every top-level layout via
+    /// [`reset_table_sizing_cache`], so pointers from a freed DOM are never
+    /// reused as keys.
+    static TABLE_CELL_PREF_WIDTH_CACHE: std::cell::RefCell<HashMap<(usize, u32), f32>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+/// Clear the per-document table auto-sizing memo. Called once at the start of
+/// each top-level layout.
+pub(crate) fn reset_table_sizing_cache() {
+    TABLE_CELL_PREF_WIDTH_CACHE.with(|c| c.borrow_mut().clear());
+}
+
+fn table_cell_pref_width_get(key: (usize, u32)) -> Option<f32> {
+    TABLE_CELL_PREF_WIDTH_CACHE.with(|c| c.borrow().get(&key).copied())
+}
+
+fn table_cell_pref_width_insert(key: (usize, u32), width: f32) {
+    TABLE_CELL_PREF_WIDTH_CACHE.with(|c| {
+        c.borrow_mut().insert(key, width);
+    });
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn flatten_table(
     el: &ElementNode,
@@ -724,105 +759,123 @@ pub(crate) fn flatten_table(
                             .and_then(|v| v.parse::<usize>().ok())
                             .unwrap_or(1)
                             .max(1);
-                        let cell_classes = cell_el.class_list();
-                        let mut cell_sizing_ancestors = sizing_row_ctx.ancestors.clone();
-                        cell_sizing_ancestors.push(AncestorInfo {
-                            element: row,
-                            child_index: row_section_indices[sizing_row_idx],
-                            sibling_count: row_section_sizes[sizing_row_idx],
-                            preceding_siblings: Vec::new(),
-                        });
-                        let cell_sizing_ctx = SelectorContext {
-                            ancestors: cell_sizing_ancestors,
-                            child_index: col_pos,
-                            sibling_count: num_cols,
-                            preceding_siblings: Vec::new(),
-                        };
-                        let cell_style = compute_style_with_context(
-                            cell_el.tag,
-                            cell_el.style_attr(),
-                            &row_style,
-                            rules,
-                            cell_el.tag_name(),
-                            &cell_classes,
-                            cell_el.id(),
-                            &cell_el.attributes,
-                            &cell_sizing_ctx,
-                        );
-                        let mut runs = Vec::new();
-                        let mut nested_rows = Vec::new();
-                        let recurse_descendants = cell_el.children.iter().any(
+                        // Memoize this cell's preferred width by (cell, inner
+                        // width). Only safe to read/store when no CSS counters
+                        // are active in the subtree, so the width can't depend
+                        // on — or leak — counter state (see the thread-local).
+                        let cache_key =
+                            (std::ptr::from_ref(cell_el) as usize, inner_width.to_bits());
+                        let counters_empty_before = counter_state.stacks.is_empty();
+                        let total_preferred: f32 = 'cell_pref: {
+                            if counters_empty_before {
+                                if let Some(w) = table_cell_pref_width_get(cache_key) {
+                                    break 'cell_pref w;
+                                }
+                            }
+                            let cell_classes = cell_el.class_list();
+                            let mut cell_sizing_ancestors = sizing_row_ctx.ancestors.clone();
+                            cell_sizing_ancestors.push(AncestorInfo {
+                                element: row,
+                                child_index: row_section_indices[sizing_row_idx],
+                                sibling_count: row_section_sizes[sizing_row_idx],
+                                preceding_siblings: Vec::new(),
+                            });
+                            let cell_sizing_ctx = SelectorContext {
+                                ancestors: cell_sizing_ancestors,
+                                child_index: col_pos,
+                                sibling_count: num_cols,
+                                preceding_siblings: Vec::new(),
+                            };
+                            let cell_style = compute_style_with_context(
+                                cell_el.tag,
+                                cell_el.style_attr(),
+                                &row_style,
+                                rules,
+                                cell_el.tag_name(),
+                                &cell_classes,
+                                cell_el.id(),
+                                &cell_el.attributes,
+                                &cell_sizing_ctx,
+                            );
+                            let mut runs = Vec::new();
+                            let mut nested_rows = Vec::new();
+                            let recurse_descendants = cell_el.children.iter().any(
                             |node| matches!(node, DomNode::Element(e) if recurses_as_layout_child(e.tag)),
                         );
-                        let mut text_ancestors = cell_sizing_ctx.ancestors.clone();
-                        text_ancestors.push(AncestorInfo {
-                            element: cell_el,
-                            child_index: col_pos,
-                            sibling_count: num_cols,
-                            preceding_siblings: Vec::new(),
-                        });
-                        collect_table_cell_content_inner(
-                            &cell_el.children,
-                            &cell_style,
-                            &mut runs,
-                            &mut nested_rows,
-                            None,
-                            rules,
-                            fonts,
-                            false,
-                            recurse_descendants,
-                            recurse_descendants,
-                            &text_ancestors,
-                            inner_width.max(1.0),
-                            counter_state,
-                        );
-                        // Estimate content width using estimate_word_width for accurate
-                        // measurement. Use the maximum of (full text width, longest word
-                        // width) to avoid hyphenation of short columns like "Unit Price".
-                        let content_width: f32 = runs
-                            .iter()
-                            .map(|run| {
-                                // Atomic inline-block boxes (fill-in underlines /
-                                // checkbox squares) reserve their explicit width so
-                                // the column is wide enough not to truncate them.
-                                if let Some(box_width) = run.box_width {
-                                    return box_width;
-                                }
-                                // Measure full text width using estimate_word_width
-                                let full_width = estimate_word_width(
-                                    &run.text,
-                                    run.font_size,
-                                    &run.font_family,
-                                    run.bold,
-                                    run.italic,
-                                    fonts,
-                                );
-                                // Also ensure the column is at least as wide as
-                                // the longest word to prevent hyphenation.
-                                let longest_word_width = run
-                                    .text
-                                    .split_whitespace()
-                                    .map(|w| {
-                                        estimate_word_width(
-                                            w,
-                                            run.font_size,
-                                            &run.font_family,
-                                            run.bold,
-                                            run.italic,
-                                            fonts,
-                                        )
-                                    })
-                                    .fold(0.0f32, f32::max);
-                                full_width.max(longest_word_width)
-                            })
-                            .sum();
-                        let nested_width = nested_rows
-                            .iter()
-                            .map(table_row_content_width)
-                            .fold(0.0f32, f32::max);
-                        let total_preferred = content_width.max(nested_width)
-                            + cell_style.padding.left
-                            + cell_style.padding.right;
+                            let mut text_ancestors = cell_sizing_ctx.ancestors.clone();
+                            text_ancestors.push(AncestorInfo {
+                                element: cell_el,
+                                child_index: col_pos,
+                                sibling_count: num_cols,
+                                preceding_siblings: Vec::new(),
+                            });
+                            collect_table_cell_content_inner(
+                                &cell_el.children,
+                                &cell_style,
+                                &mut runs,
+                                &mut nested_rows,
+                                None,
+                                rules,
+                                fonts,
+                                false,
+                                recurse_descendants,
+                                recurse_descendants,
+                                &text_ancestors,
+                                inner_width.max(1.0),
+                                counter_state,
+                            );
+                            // Estimate content width using estimate_word_width for accurate
+                            // measurement. Use the maximum of (full text width, longest word
+                            // width) to avoid hyphenation of short columns like "Unit Price".
+                            let content_width: f32 = runs
+                                .iter()
+                                .map(|run| {
+                                    // Atomic inline-block boxes (fill-in underlines /
+                                    // checkbox squares) reserve their explicit width so
+                                    // the column is wide enough not to truncate them.
+                                    if let Some(box_width) = run.box_width {
+                                        return box_width;
+                                    }
+                                    // Measure full text width using estimate_word_width
+                                    let full_width = estimate_word_width(
+                                        &run.text,
+                                        run.font_size,
+                                        &run.font_family,
+                                        run.bold,
+                                        run.italic,
+                                        fonts,
+                                    );
+                                    // Also ensure the column is at least as wide as
+                                    // the longest word to prevent hyphenation.
+                                    let longest_word_width = run
+                                        .text
+                                        .split_whitespace()
+                                        .map(|w| {
+                                            estimate_word_width(
+                                                w,
+                                                run.font_size,
+                                                &run.font_family,
+                                                run.bold,
+                                                run.italic,
+                                                fonts,
+                                            )
+                                        })
+                                        .fold(0.0f32, f32::max);
+                                    full_width.max(longest_word_width)
+                                })
+                                .sum();
+                            let nested_width = nested_rows
+                                .iter()
+                                .map(table_row_content_width)
+                                .fold(0.0f32, f32::max);
+                            let total_preferred = content_width.max(nested_width)
+                                + cell_style.padding.left
+                                + cell_style.padding.right;
+                            if counters_empty_before && counter_state.stacks.is_empty() {
+                                table_cell_pref_width_insert(cache_key, total_preferred);
+                            }
+                            total_preferred
+                        };
                         if colspan == 1 {
                             if col_pos < num_cols {
                                 preferred_widths[col_pos] =

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -90,7 +90,7 @@ fn resolve_specified_height(style: &ComputedStyle, containing_height: Option<f32
         && let Some(percent) = style.percentage_sizing.max_height
     {
         let max_h = cb * percent / 100.0;
-        h = h.map_or(Some(max_h), |v| Some(v.min(max_h)));
+        h = h.map(|v| v.min(max_h));
     }
     h.unwrap_or(0.0).max(0.0)
 }
@@ -1166,9 +1166,10 @@ fn distribute_table_height_surplus(table_rows: &mut [LayoutElement], table_heigh
     let row_heights: Vec<f32> = table_rows
         .iter()
         .map(|row| match row {
-            LayoutElement::TableRow { cells, .. } => {
-                cells.iter().map(table_cell_box_height).fold(0.0f32, f32::max)
-            }
+            LayoutElement::TableRow { cells, .. } => cells
+                .iter()
+                .map(table_cell_box_height)
+                .fold(0.0f32, f32::max),
             _ => 0.0,
         })
         .collect();
@@ -1294,7 +1295,7 @@ fn flatten_descendant_text(nodes: &[DomNode]) -> String {
 /// flattened to plain text runs that drop the border and size.
 fn inline_block_has_box(style: &ComputedStyle) -> bool {
     style.display == Display::InlineBlock
-        && (style.width.is_some() || style.height.is_some() || style.border.has_any())
+        && (style.width.is_some() || style.height.is_some() || style.border.bottom.width > 0.0)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1435,7 +1436,8 @@ fn collect_table_cell_content_inner(
                 // sibling text. Without this the box is flattened to plain runs
                 // that drop the border and size. Only applies to SVG-free inline
                 // blocks; SVG/Img keep their dedicated branches below.
-                if el.tag != HtmlTag::Svg && el.tag != HtmlTag::Img && inline_block_has_box(&style) {
+                if el.tag != HtmlTag::Svg && el.tag != HtmlTag::Img && inline_block_has_box(&style)
+                {
                     let raw = flatten_descendant_text(&el.children);
                     let collapsed = collapse_whitespace(&raw);
                     // Keep a single space when empty so the run survives merge /
@@ -1611,4 +1613,28 @@ fn push_line_break_run(
             border_bottom: None,
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentage_max_height_without_height_does_not_create_floor() {
+        let mut style = ComputedStyle::default();
+        style.percentage_sizing.max_height = Some(50.0);
+
+        assert_eq!(resolve_specified_height(&style, Some(200.0)), 0.0);
+    }
+
+    #[test]
+    fn percentage_max_height_clamps_existing_height() {
+        let mut style = ComputedStyle {
+            height: Some(150.0),
+            ..Default::default()
+        };
+        style.percentage_sizing.max_height = Some(50.0);
+
+        assert_eq!(resolve_specified_height(&style, Some(200.0)), 100.0);
+    }
 }

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -168,6 +168,45 @@ pub(crate) fn split_word_to_fit(
 }
 
 // ---------------------------------------------------------------------------
+// split_preserved_segment
+// ---------------------------------------------------------------------------
+
+/// Whether `c` is a space character a preserved-whitespace segment may break
+/// at. Only ASCII space and tab qualify: U+00A0 and the other Unicode spaces
+/// must stay inside their word so they remain non-breaking.
+const fn is_preserved_space(c: char) -> bool {
+    matches!(c, ' ' | '\t')
+}
+
+/// Split a preserved-whitespace segment (`white-space: pre`/`pre-wrap`,
+/// newlines already handled by the caller) into alternating space-run and
+/// word tokens. The tokens concatenate back to the original segment
+/// byte-for-byte — spacing is never collapsed — but queueing them separately
+/// restores the soft-wrap opportunities CSS keeps at preserved spaces.
+/// Previously such a segment was queued as one indivisible word, so any
+/// segment wider than the line (e.g. a clinical note containing a double
+/// space) could never wrap and overflowed the page edge.
+fn split_preserved_segment(segment: &str) -> Vec<&str> {
+    let mut tokens = Vec::new();
+    let mut start = 0;
+    let mut prev_is_space: Option<bool> = None;
+    for (idx, c) in segment.char_indices() {
+        let is_space = is_preserved_space(c);
+        if let Some(prev) = prev_is_space {
+            if prev != is_space {
+                tokens.push(&segment[start..idx]);
+                start = idx;
+            }
+        }
+        prev_is_space = Some(is_space);
+    }
+    if start < segment.len() {
+        tokens.push(&segment[start..]);
+    }
+    tokens
+}
+
+// ---------------------------------------------------------------------------
 // wrap_text_runs
 // ---------------------------------------------------------------------------
 
@@ -232,7 +271,9 @@ pub(crate) fn wrap_text_runs(
                     || segment.chars().last().is_some_and(char::is_whitespace)
                     || segment.contains("  ")
                 {
-                    styled_words.push((segment.to_string(), run.clone(), true));
+                    for token in split_preserved_segment(segment) {
+                        styled_words.push((token.to_string(), run.clone(), true));
+                    }
                 } else {
                     for word in segment.split_whitespace() {
                         styled_words.push((word.to_string(), run.clone(), false));
@@ -240,7 +281,9 @@ pub(crate) fn wrap_text_runs(
                 }
             }
         } else if has_preserved_spacing {
-            styled_words.push((run.text.clone(), run.clone(), true));
+            for token in split_preserved_segment(&run.text) {
+                styled_words.push((token.to_string(), run.clone(), true));
+            }
         } else {
             for word in run.text.split_whitespace() {
                 styled_words.push((word.to_string(), run.clone(), false));
@@ -337,7 +380,13 @@ pub(crate) fn wrap_text_runs(
             }
         }
 
-        if overflows && current_width > 0.0 {
+        // A preserved space-run never forces a wrap: CSS lets preserved
+        // spaces hang past a soft-wrapped line end rather than starting the
+        // next line with them. The run still adds its width, so the next
+        // word token wraps.
+        let is_space_run =
+            preserve_spacing && !word.is_empty() && word.chars().all(is_preserved_space);
+        if overflows && current_width > 0.0 && !is_space_run {
             lines.push(TextLine {
                 runs: std::mem::take(&mut current_runs),
                 height: line_height,
@@ -954,5 +1003,107 @@ impl<'a> FlexTextRunCollector<'a> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(text: &str) -> TextRun {
+        TextRun {
+            text: text.to_string(),
+            font_size: 10.0,
+            bold: false,
+            italic: false,
+            underline: false,
+            line_through: false,
+            overline: false,
+            color: (0.0, 0.0, 0.0),
+            link_url: None,
+            font_family: FontFamily::Helvetica,
+            background_color: None,
+            padding: (0.0, 0.0),
+            border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
+        }
+    }
+
+    fn line_text(line: &TextLine) -> String {
+        line.runs.iter().map(|r| r.text.as_str()).collect()
+    }
+
+    fn wrap(text: &str, max_width: f32) -> Vec<TextLine> {
+        wrap_text_runs(
+            vec![run(text)],
+            TextWrapOptions::new(max_width, 10.0, 1.2, OverflowWrap::Normal),
+            &HashMap::new(),
+        )
+    }
+
+    fn width_of(text: &str) -> f32 {
+        estimate_word_width(
+            text,
+            10.0,
+            &FontFamily::Helvetica,
+            false,
+            false,
+            &HashMap::new(),
+        )
+    }
+
+    #[test]
+    fn split_preserved_segment_is_lossless_and_alternating() {
+        let seg = "  recieved patient  to\tPACU ";
+        let tokens = split_preserved_segment(seg);
+        assert_eq!(tokens.concat(), seg);
+        for pair in tokens.windows(2) {
+            let a = pair[0].chars().all(is_preserved_space);
+            let b = pair[1].chars().all(is_preserved_space);
+            assert_ne!(a, b, "adjacent tokens must alternate: {pair:?}");
+        }
+    }
+
+    #[test]
+    fn nbsp_stays_inside_its_word() {
+        let tokens = split_preserved_segment("a\u{a0}b  c");
+        assert_eq!(tokens, vec!["a\u{a0}b", "  ", "c"]);
+    }
+
+    /// Regression for the clinical-note overflow (gwd #4585): a pre-wrap
+    /// segment containing a double space must still soft-wrap at its spaces
+    /// instead of laying out as one line that overflows the page edge.
+    #[test]
+    fn preserved_double_space_segment_wraps() {
+        let text = "alpha bravo  charlie delta echo foxtrot golf hotel india juliet";
+        let lines = wrap(text, width_of(text) / 3.0);
+        assert!(
+            lines.len() > 1,
+            "expected multiple lines, got {}",
+            lines.len()
+        );
+        let joined: String = lines.iter().map(line_text).collect();
+        assert_eq!(joined, text, "wrapping must not alter the preserved bytes");
+    }
+
+    #[test]
+    fn preserved_space_run_hangs_at_line_end() {
+        // Width sized to one word: the double space after "aaaa" must hang at
+        // the end of line 1, not start line 2.
+        let lines = wrap("aaaa  bbbb", width_of("aaaa") * 1.2);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(line_text(&lines[0]), "aaaa  ");
+        assert_eq!(line_text(&lines[1]), "bbbb");
+    }
+
+    #[test]
+    fn preserved_leading_indent_is_kept() {
+        let text = "  indent one two three four five six seven eight nine ten";
+        let lines = wrap(text, width_of(text) / 3.0);
+        assert!(line_text(&lines[0]).starts_with("  indent"));
+        let joined: String = lines.iter().map(line_text).collect();
+        assert_eq!(joined, text);
     }
 }

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -89,6 +89,13 @@ pub(crate) fn estimate_word_width(
     crate::fonts::str_width(word, font_size, font_family, false)
 }
 
+/// Whether a run carries an atomic inline-block box (explicit width/height or a
+/// bottom border). Such runs must stay indivisible during wrapping and reserve
+/// their `box_width` rather than the glyph width.
+pub(crate) fn run_has_box(run: &TextRun) -> bool {
+    run.box_width.is_some() || run.box_height.is_some() || run.border_bottom.is_some()
+}
+
 // ---------------------------------------------------------------------------
 // TextWrapOptions
 // ---------------------------------------------------------------------------
@@ -201,6 +208,14 @@ pub(crate) fn wrap_text_runs(
             styled_words.push(("\n".to_string(), run.clone(), false));
             continue;
         }
+        // An atomic inline-block box (form fill-in underline / checkbox square)
+        // must stay one indivisible word: never split on whitespace, and reserve
+        // its `box_width` rather than the glyph width. Treat it as preserved
+        // spacing so the consumption loop measures it via `run_advance`.
+        if run_has_box(run) {
+            styled_words.push((run.text.clone(), run.clone(), true));
+            continue;
+        }
         let has_newlines = run.text.contains('\n');
         let has_preserved_spacing = run.text.chars().next().is_some_and(char::is_whitespace)
             || run.text.chars().last().is_some_and(char::is_whitespace)
@@ -256,14 +271,18 @@ pub(crate) fn wrap_text_runs(
             continue;
         }
 
-        let word_width = estimate_word_width(
-            &word,
-            template.font_size,
-            &template.font_family,
-            template.bold,
-            template.italic,
-            fonts,
-        );
+        let word_width = if let Some(box_width) = template.box_width {
+            box_width
+        } else {
+            estimate_word_width(
+                &word,
+                template.font_size,
+                &template.font_family,
+                template.bold,
+                template.italic,
+                fonts,
+            )
+        };
         let space_width = estimate_word_width(
             " ",
             template.font_size,
@@ -365,6 +384,9 @@ pub(crate) fn wrap_text_runs(
                     background_color: None,
                     padding: (0.0, 0.0),
                     border_radius: 0.0,
+                    box_width: None,
+                    box_height: None,
+                    border_bottom: None,
                 });
                 word
             } else {
@@ -374,14 +396,18 @@ pub(crate) fn wrap_text_runs(
             word
         };
 
-        let w = estimate_word_width(
-            &text,
-            template.font_size,
-            &template.font_family,
-            template.bold,
-            template.italic,
-            fonts,
-        );
+        let w = if let Some(box_width) = template.box_width {
+            box_width
+        } else {
+            estimate_word_width(
+                &text,
+                template.font_size,
+                &template.font_family,
+                template.bold,
+                template.italic,
+                fonts,
+            )
+        };
         current_width += w;
         line_height = line_height.max(template.font_size * line_height_factor);
 
@@ -665,6 +691,9 @@ fn collect_text_runs_inner(
                             background_color: bg,
                             padding: pad,
                             border_radius: br,
+                            box_width: None,
+                            box_height: None,
+                            border_bottom: None,
                         },
                         runs,
                         fonts,
@@ -688,6 +717,9 @@ fn collect_text_runs_inner(
                             background_color: None,
                             padding: (0.0, 0.0),
                             border_radius: 0.0,
+                            box_width: None,
+                            box_height: None,
+                            border_bottom: None,
                         });
                     } else if el.attributes.contains_key("data-math") {
                         // Skip math elements — they are rendered as MathBlock
@@ -815,6 +847,9 @@ impl<'a> FlexTextRunCollector<'a> {
                                     .map(|c| c.to_f32_rgba()),
                                 padding: text_padding,
                                 border_radius: 0.0,
+                                box_width: None,
+                                box_height: None,
+                                border_bottom: None,
                             },
                             self.runs,
                             self.fonts,
@@ -875,6 +910,9 @@ impl<'a> FlexTextRunCollector<'a> {
                             background_color: None,
                             padding: (0.0, 0.0),
                             border_radius: 0.0,
+                            box_width: None,
+                            box_height: None,
+                            border_bottom: None,
                         });
                         continue;
                     }
@@ -908,6 +946,9 @@ impl<'a> FlexTextRunCollector<'a> {
                             background_color: None,
                             padding: (0.0, 0.0),
                             border_radius: 0.0,
+                            box_width: None,
+                            box_height: None,
+                            border_bottom: None,
                         });
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,7 +570,7 @@ impl HtmlConverter {
             };
 
             if let Some(data) = ttf_data {
-                if let Ok(font) = parser::ttf::parse_ttf(data) {
+                if let Some(font) = parser::ttf::parse_ttf_cached(&data) {
                     parsed_fonts.insert(ff_rule.font_family.to_ascii_lowercase(), font);
                 }
             }
@@ -669,7 +669,7 @@ impl HtmlConverter {
     fn parse_custom_fonts(&self) -> std::collections::HashMap<String, parser::ttf::TtfFont> {
         let mut fonts = std::collections::HashMap::new();
         for (name, data) in &self.custom_fonts {
-            if let Ok(font) = parser::ttf::parse_ttf(data.clone()) {
+            if let Some(font) = parser::ttf::parse_ttf_cached(data) {
                 fonts.insert(name.clone(), font);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1667,6 +1667,53 @@ fn main() {
     }
 
     #[test]
+    fn add_font_used_by_svg_text() {
+        // A real shapeable face: SVG custom-font emission requires shaped
+        // glyph output, exactly like the HTML custom-font text path.
+        let ttf_data = include_bytes!("../assets/LiberationSans-Regular.ttf").to_vec();
+        let pdf = HtmlConverter::new()
+            .add_font("testfont", ttf_data)
+            .convert(
+                r##"<svg width="200" height="50" viewBox="0 0 200 50"><text x="10" y="30" font-family="testfont, Helvetica" font-size="20" fill="#000000">Hello</text></svg>"##,
+            )
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("/testfont 20 Tf"),
+            "SVG text should bind the registered custom font"
+        );
+        assert!(
+            content.contains("] TJ"),
+            "SVG text with a custom font should emit shaped glyph IDs"
+        );
+        assert!(
+            content.contains("/Subtype /CIDFontType2"),
+            "a custom font used only by SVG text should still be embedded"
+        );
+        assert!(
+            !content.contains("(Hello) Tj"),
+            "custom-font SVG text should not fall back to WinAnsi literal text"
+        );
+    }
+
+    #[test]
+    fn svg_text_with_unregistered_family_falls_back_to_base14() {
+        let pdf = html_to_pdf(
+            r#"<svg width="200" height="50" viewBox="0 0 200 50"><text x="10" y="30" font-family="NoSuchFont" font-size="20">Hello</text></svg>"#,
+        )
+        .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("/Helvetica 20 Tf"),
+            "unregistered SVG font families should keep the base-14 mapping"
+        );
+        assert!(
+            content.contains("(Hello) Tj"),
+            "base-14 SVG text should keep literal text emission"
+        );
+    }
+
+    #[test]
     fn custom_font_falls_back_to_helvetica_when_not_registered() {
         let pdf = html_to_pdf(r#"<p style="font-family: 'UnknownFont'">Text</p>"#).unwrap();
         let content = String::from_utf8_lossy(&pdf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,46 @@ pub async fn convert_markdown_file_async(input: &str, output: &str) -> Result<()
     Ok(())
 }
 
+/// A document laid out into pages, plus the effective geometry and fonts the
+/// layout resolved — everything the PDF renderer or a measurement pass needs.
+struct LaidOutDocument {
+    pages: Vec<layout::engine::Page>,
+    page_size: PageSize,
+    margin: Margin,
+    fonts: std::collections::HashMap<String, parser::ttf::TtfFont>,
+}
+
+/// True when a laid-out element is a measurement sentinel: an empty block
+/// whose fixed height and solid background color both match the caller's
+/// signature (see [`HtmlConverter::measure_sentinel_tops`]). An empty div can
+/// lay out as either a childless `Container` or a line-less `TextBlock`, so
+/// both are recognised.
+fn sentinel_matches(el: &layout::engine::LayoutElement, height: f32, color: (f32, f32, f32)) -> bool {
+    let (block_height, background) = match el {
+        layout::engine::LayoutElement::TextBlock {
+            lines,
+            block_height,
+            background_color,
+            ..
+        } if lines.is_empty() => (*block_height, *background_color),
+        layout::engine::LayoutElement::Container {
+            children,
+            block_height,
+            background_color,
+            ..
+        } if children.is_empty() => (*block_height, *background_color),
+        _ => return false,
+    };
+
+    let close = |a: f32, b: f32| (a - b).abs() < 1e-3;
+    match (block_height, background) {
+        (Some(h), Some((r, g, b, a))) => {
+            close(h, height) && a > 0.99 && close(r, color.0) && close(g, color.1) && close(b, color.2)
+        }
+        _ => false,
+    }
+}
+
 /// Builder for HTML-to-PDF conversion with custom options.
 ///
 /// Use [`HtmlConverter::new`] to start, chain configuration methods,
@@ -371,6 +411,33 @@ impl HtmlConverter {
         html: &str,
         writer: &mut W,
     ) -> Result<(), IronpressError> {
+        let doc = self.layout_document(html)?;
+
+        // Step 6: Render PDF
+        let decoration = if self.header.is_some() || self.footer.is_some() {
+            Some(render::pdf::PageDecoration {
+                header: self.header.clone(),
+                footer: self.footer.clone(),
+            })
+        } else {
+            None
+        };
+
+        render::pdf::render_pdf_to_writer_full(
+            &doc.pages,
+            doc.page_size,
+            doc.margin,
+            writer,
+            &doc.fonts,
+            decoration.as_ref(),
+        )
+    }
+
+    /// Lay out `html` without rendering: run the full pipeline (sanitize,
+    /// parse, style, fonts, layout) and return the laid-out pages plus the
+    /// effective geometry and fonts — everything the PDF renderer or a
+    /// measurement pass needs.
+    fn layout_document(&self, html: &str) -> Result<LaidOutDocument, IronpressError> {
         // Step 1: Sanitize
         let html = if self.sanitize {
             security::sanitizer::sanitize_html(html)?
@@ -525,24 +592,65 @@ impl HtmlConverter {
             &parsed_fonts,
         );
 
-        // Step 6: Render PDF
-        let decoration = if self.header.is_some() || self.footer.is_some() {
-            Some(render::pdf::PageDecoration {
-                header: self.header.clone(),
-                footer: self.footer.clone(),
-            })
-        } else {
-            None
-        };
+        Ok(LaidOutDocument {
+            pages,
+            page_size: effective_page_size,
+            margin: effective_margin,
+            fonts: parsed_fonts,
+        })
+    }
 
-        render::pdf::render_pdf_to_writer_full(
-            &pages,
-            effective_page_size,
-            effective_margin,
-            writer,
-            &parsed_fonts,
-            decoration.as_ref(),
-        )
+    /// Lay out `html` (without rendering a PDF) and return the top y-position,
+    /// in points from the top of the page content box, of every "sentinel"
+    /// element, in flow order.
+    ///
+    /// A sentinel is an empty block whose computed `height` AND solid
+    /// `background-color` both match the given signature — both values are
+    /// author-controlled, so exact matching is reliable, e.g.
+    /// `.msr { height: 2.5pt; background-color: #010203; margin: 0; }`.
+    ///
+    /// Interleave sentinel divs between the blocks you want measured: the
+    /// distance between consecutive sentinel tops, minus the sentinel height,
+    /// is the exact flow height (content plus vertical margins) of the block
+    /// between them. Wrapping, fonts and CSS resolve exactly as in `convert`,
+    /// so the numbers match the rendered PDF.
+    ///
+    /// Declare a page tall enough for the whole document (e.g.
+    /// `@page { size: 612pt 14000pt; }`) — band geometry is only meaningful
+    /// when nothing paginates, so this returns `LayoutError` if layout
+    /// produced more than one page.
+    pub fn measure_sentinel_tops(
+        &self,
+        html: &str,
+        sentinel_height: f32,
+        sentinel_color: (u8, u8, u8),
+    ) -> Result<Vec<f32>, IronpressError> {
+        let doc = self.layout_document(html)?;
+        if doc.pages.len() > 1 {
+            return Err(IronpressError::LayoutError(format!(
+                "measure_sentinel_tops needs the whole document on one page, got {} pages — declare a taller @page size",
+                doc.pages.len()
+            )));
+        }
+
+        let color = (
+            f32::from(sentinel_color.0) / 255.0,
+            f32::from(sentinel_color.1) / 255.0,
+            f32::from(sentinel_color.2) / 255.0,
+        );
+        let mut tops: Vec<f32> = doc
+            .pages
+            .first()
+            .map(|page| {
+                page.elements
+                    .iter()
+                    .filter(|(_, el)| sentinel_matches(el, sentinel_height, color))
+                    .map(|(y, _)| *y)
+                    .collect()
+            })
+            .unwrap_or_default();
+        tops.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        Ok(tops)
     }
 
     /// Convert a Markdown string to PDF, writing directly to any `std::io::Write` implementation.
@@ -664,6 +772,56 @@ pub mod wasm {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Sentinel bands: interleaved marker divs report exact per-block flow
+    /// heights (content + margins), the contract PHP-side pagination relies on.
+    #[test]
+    fn measure_sentinel_tops_reports_block_heights() {
+        let html = r##"<html><head><style>
+            @page { size: 612pt 5000pt; margin: 20pt; }
+            .msr { height: 2.5pt; background-color: #010203; margin: 0; padding: 0; }
+            p { margin: 0 0 10pt 0; font-size: 12pt; }
+        </style></head><body>
+            <div class="msr"></div>
+            <p>one line</p>
+            <div class="msr"></div>
+            <p>one line</p>
+            <p>another line</p>
+            <div class="msr"></div>
+        </body></html>"##;
+
+        let tops = HtmlConverter::new()
+            .measure_sentinel_tops(html, 2.5, (1, 2, 3))
+            .expect("measurement must succeed on a single tall page");
+
+        assert_eq!(tops.len(), 3, "all three sentinels must be found, got {tops:?}");
+        let band1 = tops[1] - tops[0] - 2.5;
+        let band2 = tops[2] - tops[1] - 2.5;
+        assert!(band1 > 10.0, "one-paragraph band must include line + margin, got {band1}");
+        assert!(
+            band2 > band1 * 1.6 && band2 < band1 * 2.4,
+            "two-paragraph band must be roughly double one paragraph, got {band1} vs {band2}"
+        );
+    }
+
+    /// The one-page contract: a document too tall for its declared page must
+    /// error rather than silently return cross-page geometry.
+    #[test]
+    fn measure_sentinel_tops_rejects_multi_page_documents() {
+        let mut html = String::from(
+            r##"<html><head><style>
+            @page { size: 612pt 200pt; margin: 20pt; }
+            .msr { height: 2.5pt; background-color: #010203; margin: 0; padding: 0; }
+        </style></head><body><div class="msr"></div>"##,
+        );
+        for i in 0..60 {
+            html.push_str(&format!("<p>filler paragraph number {i}</p>"));
+        }
+        html.push_str(r##"<div class="msr"></div></body></html>"##);
+
+        let result = HtmlConverter::new().measure_sentinel_tops(&html, 2.5, (1, 2, 3));
+        assert!(matches!(result, Err(IronpressError::LayoutError(_))), "must reject multi-page docs");
+    }
 
     /// Check if a PDF contains a given text string, handling both WinAnsi
     /// (plain text in parentheses) and CID encoding (hex glyph IDs with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1697,6 +1697,23 @@ fn main() {
     }
 
     #[test]
+    fn svg_text_letter_spacing_emits_character_spacing() {
+        let pdf = html_to_pdf(
+            r#"<svg width="200" height="50" viewBox="0 0 200 50"><text x="10" y="30" font-size="20" letter-spacing="3">Hello</text></svg>"#,
+        )
+        .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("3 Tc"),
+            "letter-spacing should map to the PDF character-spacing operator"
+        );
+        assert!(
+            content.contains("0 Tc"),
+            "character spacing should be reset after the text object"
+        );
+    }
+
+    #[test]
     fn svg_text_with_unregistered_family_falls_back_to_base14() {
         let pdf = html_to_pdf(
             r#"<svg width="200" height="50" viewBox="0 0 200 50"><text x="10" y="30" font-family="NoSuchFont" font-size="20">Hello</text></svg>"#,

--- a/src/parser/css/mod.rs
+++ b/src/parser/css/mod.rs
@@ -32,7 +32,7 @@ pub use page::{parse_font_face_rules, parse_page_rules};
 pub(crate) use rules::parse_stylesheet;
 pub(crate) use rules::parse_stylesheet_with_context;
 pub(crate) use selectors::selector_matches_with_context;
-pub(crate) use values::{is_css_wide_keyword, parse_length};
+pub(crate) use values::{absolute_length_unit_to_points, is_css_wide_keyword, parse_length};
 #[cfg(test)]
 pub(crate) use values::{
     parse_border_spacing_component, parse_calc_expression, parse_color, parse_property_value,

--- a/src/parser/css/values.rs
+++ b/src/parser/css/values.rs
@@ -51,6 +51,29 @@ pub(crate) fn parse_length(val: &str) -> Option<CssValue> {
         return number.parse::<f32>().ok().map(CssValue::Number);
     }
 
+    // Absolute physical units resolve straight to points (1in = 72pt).
+    // `mm` is matched before `cm`/`in` so "40mm" is not mistaken for another unit.
+    if let Some(number) = val.strip_suffix("mm") {
+        return number
+            .parse::<f32>()
+            .ok()
+            .map(|value| CssValue::Length(value * 72.0 / 25.4));
+    }
+
+    if let Some(number) = val.strip_suffix("cm") {
+        return number
+            .parse::<f32>()
+            .ok()
+            .map(|value| CssValue::Length(value * 72.0 / 2.54));
+    }
+
+    if let Some(number) = val.strip_suffix("in") {
+        return number
+            .parse::<f32>()
+            .ok()
+            .map(|value| CssValue::Length(value * 72.0));
+    }
+
     val.parse::<f32>().ok().map(CssValue::Length)
 }
 
@@ -298,6 +321,7 @@ pub(crate) fn parse_property_value(property: &str, val: &str) -> Option<CssValue
             | "word-wrap"
             | "text-transform"
             | "direction"
+            | "vertical-align"
     ) {
         return Some(CssValue::Keyword(val.to_string()));
     }

--- a/src/parser/css/values.rs
+++ b/src/parser/css/values.rs
@@ -9,6 +9,30 @@ pub(crate) fn is_css_wide_keyword(value: &str) -> bool {
     )
 }
 
+pub(crate) fn absolute_length_unit_to_points(val: &str) -> Option<f32> {
+    if let Some(number) = val.strip_suffix("px") {
+        return number.parse::<f32>().ok().map(|value| value * 0.75);
+    }
+
+    if let Some(number) = val.strip_suffix("pt") {
+        return number.parse::<f32>().ok();
+    }
+
+    if let Some(number) = val.strip_suffix("mm") {
+        return number.parse::<f32>().ok().map(|value| value * 72.0 / 25.4);
+    }
+
+    if let Some(number) = val.strip_suffix("cm") {
+        return number.parse::<f32>().ok().map(|value| value * 72.0 / 2.54);
+    }
+
+    if let Some(number) = val.strip_suffix("in") {
+        return number.parse::<f32>().ok().map(|value| value * 72.0);
+    }
+
+    None
+}
+
 pub(crate) fn parse_length(val: &str) -> Option<CssValue> {
     let val = val.trim();
 
@@ -20,15 +44,8 @@ pub(crate) fn parse_length(val: &str) -> Option<CssValue> {
         return Some(calc_value);
     }
 
-    if let Some(number) = val.strip_suffix("px") {
-        return number
-            .parse::<f32>()
-            .ok()
-            .map(|value| CssValue::Length(value * 0.75));
-    }
-
-    if let Some(number) = val.strip_suffix("pt") {
-        return number.parse::<f32>().ok().map(CssValue::Length);
+    if let Some(points) = absolute_length_unit_to_points(val) {
+        return Some(CssValue::Length(points));
     }
 
     if let Some(number) = val.strip_suffix("rem") {
@@ -49,29 +66,6 @@ pub(crate) fn parse_length(val: &str) -> Option<CssValue> {
 
     if let Some(number) = val.strip_suffix("em") {
         return number.parse::<f32>().ok().map(CssValue::Number);
-    }
-
-    // Absolute physical units resolve straight to points (1in = 72pt).
-    // `mm` is matched before `cm`/`in` so "40mm" is not mistaken for another unit.
-    if let Some(number) = val.strip_suffix("mm") {
-        return number
-            .parse::<f32>()
-            .ok()
-            .map(|value| CssValue::Length(value * 72.0 / 25.4));
-    }
-
-    if let Some(number) = val.strip_suffix("cm") {
-        return number
-            .parse::<f32>()
-            .ok()
-            .map(|value| CssValue::Length(value * 72.0 / 2.54));
-    }
-
-    if let Some(number) = val.strip_suffix("in") {
-        return number
-            .parse::<f32>()
-            .ok()
-            .map(|value| CssValue::Length(value * 72.0));
     }
 
     val.parse::<f32>().ok().map(CssValue::Length)

--- a/src/parser/css/values.rs
+++ b/src/parser/css/values.rs
@@ -236,7 +236,7 @@ pub(crate) fn parse_property_value(property: &str, val: &str) -> Option<CssValue
         return Some(CssValue::Keyword(lower));
     }
 
-    if property.starts_with("page-break") {
+    if property.starts_with("page-break") || property == "break-inside" {
         return Some(CssValue::Keyword(lower));
     }
 

--- a/src/parser/css/values_tests.rs
+++ b/src/parser/css/values_tests.rs
@@ -52,6 +52,18 @@ fn parse_length_units() {
         parse_length("1.5em"),
         Some(CssValue::Number(v)) if (v - 1.5).abs() < 0.01
     ));
+    assert!(matches!(
+        parse_length("25.4mm"),
+        Some(CssValue::Length(v)) if (v - 72.0).abs() < 0.01
+    ));
+    assert!(matches!(
+        parse_length("2.54cm"),
+        Some(CssValue::Length(v)) if (v - 72.0).abs() < 0.01
+    ));
+    assert!(matches!(
+        parse_length("1in"),
+        Some(CssValue::Length(v)) if (v - 72.0).abs() < 0.01
+    ));
 }
 
 #[test]

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -231,6 +231,8 @@ pub enum SvgNode {
         font_bold: Option<bool>,
         /// Per-element font-style override (true = italic/oblique).
         font_italic: Option<bool>,
+        /// `letter-spacing` in SVG user units (plain number / px values only).
+        letter_spacing: Option<f32>,
         /// SVG text-anchor: "start" (default), "middle", or "end".
         text_anchor: SvgTextAnchor,
         content: String,
@@ -735,6 +737,7 @@ fn parse_svg_node_with_viewport(
             let fill_specified = has_fill_specified(el);
             let fill_raw = parse_fill_raw(el);
             let (font_family, font_bold, font_italic) = parse_svg_font_attrs(el);
+            let letter_spacing = parse_svg_letter_spacing(el);
             let content = collect_text_content(el);
             let style = parse_svg_style(el);
             let text_anchor = match el.attributes.get("text-anchor").map(|s| s.as_str()) {
@@ -752,6 +755,7 @@ fn parse_svg_node_with_viewport(
                 font_family,
                 font_bold,
                 font_italic,
+                letter_spacing,
                 text_anchor,
                 content,
                 style,
@@ -1229,6 +1233,19 @@ fn parse_svg_style(el: &ElementNode) -> SvgStyle {
         font_italic,
         opacity,
     }
+}
+
+/// Parse `letter-spacing` from a `<text>` element (attribute or inline style).
+///
+/// Only plain numbers and `px` values are supported (SVG user units);
+/// `normal`, `em`, and percentage values resolve to `None`.
+fn parse_svg_letter_spacing(el: &ElementNode) -> Option<f32> {
+    let raw = style_property_value(el, "letter-spacing")
+        .map(str::to_string)
+        .or_else(|| el.attributes.get("letter-spacing").map(|v| v.to_string()))?;
+    let raw = raw.trim();
+    let raw = raw.strip_suffix("px").unwrap_or(raw).trim();
+    raw.parse::<f32>().ok().filter(|v| v.is_finite())
 }
 
 /// Extract the raw `font-size` value from a `<text>` element.

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -224,7 +224,8 @@ pub enum SvgNode {
         /// True when the element explicitly set `fill` (including `none`).
         fill_specified: bool,
         fill_raw: Option<String>,
-        /// Per-element font-family override (resolved PDF name, e.g. "Helvetica-Bold").
+        /// Per-element font-family override (raw CSS family stack; resolved
+        /// render-side against custom fonts, then base-14 families).
         font_family: Option<String>,
         /// Per-element font-weight override (true = bold).
         font_bold: Option<bool>,
@@ -269,7 +270,7 @@ pub struct SvgStyle {
     pub clip_path: Option<String>,
     /// `stroke-width` is inherited in SVG.
     pub stroke_width: Option<f32>,
-    /// Inherited SVG font-family, resolved to a PDF base family name.
+    /// Inherited SVG font-family (raw CSS family stack; resolved render-side).
     pub font_family: Option<String>,
     /// Inherited SVG font-weight.
     pub font_bold: Option<bool>,
@@ -1250,7 +1251,10 @@ fn parse_svg_font_family_value(val: &str) -> Option<String> {
     if val.is_empty() {
         None
     } else {
-        Some(resolve_svg_font_family(val))
+        // Keep the raw family stack: the renderer resolves it against
+        // add_font-registered custom fonts first, then base-14 families
+        // (see svg_to_pdf::resolve_svg_text_font / resolve_svg_font_family).
+        Some(val.to_string())
     }
 }
 
@@ -1370,7 +1374,7 @@ fn parse_fill_raw(el: &ElementNode) -> Option<String> {
 }
 
 /// Map a CSS font-family value to a PDF base-font family name.
-fn resolve_svg_font_family(css_family: &str) -> String {
+pub(crate) fn resolve_svg_font_family(css_family: &str) -> String {
     let lower = css_family.to_ascii_lowercase();
     if lower.contains("times") || lower == "serif" {
         "Times-Roman".to_string()
@@ -4623,26 +4627,29 @@ mod tests {
     // ── font attribute parsing ─────────────────────────────────────────
 
     #[test]
-    fn parse_svg_font_family_times() {
+    fn parse_svg_font_family_keeps_raw_value_times() {
         let el = make_el("text", vec![("font-family", "Times New Roman")]);
         let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![el]);
         let tree = parse_svg_from_element(&svg).unwrap();
         match &tree.children[0] {
             SvgNode::Text { font_family, .. } => {
-                assert_eq!(font_family.as_deref(), Some("Times-Roman"));
+                // Raw value preserved; base-14 mapping happens render-side.
+                assert_eq!(font_family.as_deref(), Some("Times New Roman"));
+                assert_eq!(resolve_svg_font_family("Times New Roman"), "Times-Roman");
             }
             other => panic!("expected Text, got {other:?}"),
         }
     }
 
     #[test]
-    fn parse_svg_font_family_courier() {
+    fn parse_svg_font_family_keeps_raw_value_courier() {
         let el = make_el("text", vec![("font-family", "Courier New")]);
         let svg = make_svg_el(vec![("width", "100"), ("height", "100")], vec![el]);
         let tree = parse_svg_from_element(&svg).unwrap();
         match &tree.children[0] {
             SvgNode::Text { font_family, .. } => {
-                assert_eq!(font_family.as_deref(), Some("Courier"));
+                assert_eq!(font_family.as_deref(), Some("Courier New"));
+                assert_eq!(resolve_svg_font_family("Courier New"), "Courier");
             }
             other => panic!("expected Text, got {other:?}"),
         }

--- a/src/parser/ttf.rs
+++ b/src/parser/ttf.rs
@@ -4,6 +4,7 @@
 //! widths, units per em, cmap, bounding box, and vertical metrics.
 
 use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
 
 /// Parsed TrueType font data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -150,6 +151,49 @@ struct TableRecord {
     offset: u32,
     #[allow(dead_code)]
     length: u32,
+}
+
+/// Process-global cache of parsed fonts keyed by a fast hash of the raw TTF
+/// bytes. Registering the same font (via `add_font`, `@font-face`, or a bundled
+/// asset) re-parses megabytes of TTF data on every `convert()` call otherwise;
+/// caching the parse makes the second and later calls in a process near-free.
+/// Cloning the cached `TtfFont` shares the Arc'd byte data and only copies the
+/// small cmap / glyph-width tables.
+static PARSED_FONT_CACHE: OnceLock<RwLock<HashMap<u64, TtfFont>>> = OnceLock::new();
+
+fn parsed_font_cache() -> &'static RwLock<HashMap<u64, TtfFont>> {
+    PARSED_FONT_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// FNV-1a 64-bit hash over the whole byte slice — fast, dependency-free, and
+/// collision-safe enough for the handful of distinct fonts a process registers.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Parse a TTF reusing a process-global cache keyed by the byte content.
+/// Returns `None` on parse failure (errors are not cached). The stored font's
+/// data length is checked on a hash hit to guard against the (astronomically
+/// unlikely) FNV collision between two same-length blobs.
+pub(crate) fn parse_ttf_cached(data: &[u8]) -> Option<TtfFont> {
+    let key = fnv1a_64(data);
+    if let Ok(cache) = parsed_font_cache().read() {
+        if let Some(font) = cache.get(&key) {
+            if font.data.len() == data.len() {
+                return Some(font.clone());
+            }
+        }
+    }
+    let font = parse_ttf(data.to_vec()).ok()?;
+    if let Ok(mut cache) = parsed_font_cache().write() {
+        cache.entry(key).or_insert_with(|| font.clone());
+    }
+    Some(font)
 }
 
 /// Parse a TrueType font from raw TTF data.

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1,6 +1,6 @@
 use crate::error::IronpressError;
 use crate::layout::engine::{
-    ImageFormat, LayoutElement, Page, PngMetadata, TableCell, TextLine, TextRun,
+    ImageFormat, LayoutElement, Page, PngMetadata, RasterImageAsset, TableCell, TextLine, TextRun,
     layout_element_paint_order, table_cell_box_height, table_cell_content_height,
 };
 use crate::parser::ttf::TtfFont;
@@ -2524,13 +2524,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     let img_x = margin.left;
                     // PDF y-axis is bottom-up; y_pos is top of margin, image draws from bottom-left
                     let img_y = page_size.height - margin.top - y_pos - height;
-                    if let Some(img_obj_id) = pdf_writer.add_layout_image_object(
-                        &image.data,
-                        image.source_width,
-                        image.source_height,
-                        image.format,
-                        image.png_metadata.as_ref(),
-                    ) {
+                    if let Some(img_obj_id) = pdf_writer.add_layout_image_object(image) {
                         let img_name = format!("Im{img_obj_id}");
                         content.push_str(&format!(
                             "q\n{w} 0 0 {h} {x} {y} cm\n/{name} Do\nQ\n",
@@ -5270,26 +5264,26 @@ impl PdfWriter {
     }
 
     /// Add a layout `<img>` image XObject, choosing the correct encoding per
-    /// format: a PNG is fully decoded into a DeviceRGB image (plus an alpha
-    /// `/SMask`) via `add_raw_png_image_object`; a JPEG is embedded as DCTDecode.
-    /// Returns `None` when a PNG cannot be decoded, so the caller skips the image
-    /// rather than emit a corrupt one. Requires `data` to be the raw image bytes.
-    fn add_layout_image_object(
-        &mut self,
-        data: &[u8],
-        source_width: u32,
-        source_height: u32,
-        format: ImageFormat,
-        png_metadata: Option<&PngMetadata>,
-    ) -> Option<usize> {
-        match format {
-            ImageFormat::Png => self.add_raw_png_image_object(data),
+    /// format: PNG layout assets already carry decoded color bytes plus optional
+    /// alpha data, while JPEG assets carry their original DCT stream.
+    fn add_layout_image_object(&mut self, image: &RasterImageAsset) -> Option<usize> {
+        match image.format {
+            ImageFormat::Png => {
+                let meta = image.png_metadata.as_ref()?;
+                self.add_decoded_png_image_object(
+                    &image.data,
+                    meta.alpha_data.as_deref(),
+                    image.source_width,
+                    image.source_height,
+                    meta.color_space.pdf_name(),
+                )
+            }
             ImageFormat::Jpeg => Some(self.add_image_object(
-                data,
-                source_width,
-                source_height,
-                format,
-                png_metadata,
+                &image.data,
+                image.source_width,
+                image.source_height,
+                image.format,
+                image.png_metadata.as_ref(),
             )),
         }
     }
@@ -5328,10 +5322,16 @@ impl PdfWriter {
         Some(id)
     }
 
-    pub(crate) fn add_raw_png_image_object(&mut self, raw_png: &[u8]) -> Option<usize> {
-        let decoded = decode_png_for_pdf(raw_png)?;
-        let color_stream = flate_compress(&decoded.color_data)?;
-        let alpha_stream = if let Some(alpha_data) = decoded.alpha_data.as_deref() {
+    fn add_decoded_png_image_object(
+        &mut self,
+        color_data: &[u8],
+        alpha_data: Option<&[u8]>,
+        width: u32,
+        height: u32,
+        color_space: &'static str,
+    ) -> Option<usize> {
+        let color_stream = flate_compress(color_data)?;
+        let alpha_stream = if let Some(alpha_data) = alpha_data {
             Some(flate_compress(alpha_data)?)
         } else {
             None
@@ -5341,8 +5341,6 @@ impl PdfWriter {
             let id = self.next_id();
             let header = format!(
                 "{id} 0 obj\n<< /Type /XObject /Subtype /Image /Width {width} /Height {height} /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter /FlateDecode /Length {len} >>\nstream\n",
-                width = decoded.width,
-                height = decoded.height,
                 len = stream.len(),
             );
             self.objects.push(header);
@@ -5353,9 +5351,6 @@ impl PdfWriter {
         let id = self.next_id();
         let mut header = format!(
             "{id} 0 obj\n<< /Type /XObject /Subtype /Image /Width {width} /Height {height} /ColorSpace {color_space} /BitsPerComponent 8 /Filter /FlateDecode /Length {len}",
-            width = decoded.width,
-            height = decoded.height,
-            color_space = decoded.color_space,
             len = color_stream.len(),
         );
         if let Some(alpha_id) = alpha_id {
@@ -5366,6 +5361,17 @@ impl PdfWriter {
         self.objects.push(header);
         self.binary_objects.insert(id, color_stream);
         Some(id)
+    }
+
+    pub(crate) fn add_raw_png_image_object(&mut self, raw_png: &[u8]) -> Option<usize> {
+        let decoded = decode_png_for_pdf(raw_png)?;
+        self.add_decoded_png_image_object(
+            &decoded.color_data,
+            decoded.alpha_data.as_deref(),
+            decoded.width,
+            decoded.height,
+            decoded.color_space,
+        )
     }
 
     pub(crate) fn add_raw_raster_image_object(&mut self, raw_image: &[u8]) -> Option<usize> {
@@ -7032,8 +7038,8 @@ mod tests {
     #[test]
     fn border_style_parsed_from_shorthand() {
         use crate::parser::dom::HtmlTag;
+        use crate::style::computed::BorderStyle;
         use crate::style::computed::ComputedStyle;
-        use crate::style::computed::{BorderStyle, compute_style_with_context};
         let parent = ComputedStyle::default();
         let style = crate::style::computed::compute_style(
             HtmlTag::Div,
@@ -7258,12 +7264,12 @@ mod tests {
             "PNG image should use FlateDecode filter"
         );
         assert!(
-            content.contains("/Predictor 15"),
-            "PNG image should have Predictor 15 in DecodeParms"
+            content.contains("/ColorSpace /DeviceRGB"),
+            "decoded RGB PNG should use DeviceRGB color space"
         );
         assert!(
-            content.contains("/Colors 3"),
-            "RGB PNG should have Colors 3"
+            !content.contains("/Predictor 15"),
+            "layout PNGs are decoded before embedding and should not use PNG predictor DecodeParms"
         );
         assert!(
             content.contains("Do"),
@@ -7282,7 +7288,7 @@ mod tests {
         let content = String::from_utf8_lossy(&pdf);
         assert!(content.contains("/Filter /FlateDecode"));
         assert!(content.contains("/ColorSpace /DeviceGray"));
-        assert!(content.contains("/Colors 1"));
+        assert!(!content.contains("/Predictor 15"));
     }
 
     /// Build a minimal valid PNG (1x1 RGB, 8-bit).
@@ -7292,33 +7298,32 @@ mod tests {
 
     fn build_test_png_with_color_type(color_type: u8) -> Vec<u8> {
         let mut png = Vec::new();
-        // PNG signature
-        png.extend_from_slice(&[137, 80, 78, 71, 13, 10, 26, 10]);
-        // IHDR chunk (13 bytes data)
-        let mut ihdr = Vec::new();
-        ihdr.extend_from_slice(&1u32.to_be_bytes()); // width
-        ihdr.extend_from_slice(&1u32.to_be_bytes()); // height
-        ihdr.push(8); // bit depth
-        ihdr.push(color_type);
-        ihdr.push(0); // compression
-        ihdr.push(0); // filter
-        ihdr.push(0); // interlace
-        append_png_chunk(&mut png, b"IHDR", &ihdr);
-        // IDAT chunk with dummy zlib-compressed data
-        let idat = [
-            0x78, 0x01, 0x62, 0x60, 0x60, 0x60, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01,
-        ];
-        append_png_chunk(&mut png, b"IDAT", &idat);
-        // IEND
-        append_png_chunk(&mut png, b"IEND", &[]);
+        match color_type {
+            0 => image::DynamicImage::ImageLuma8(image::ImageBuffer::from_pixel(
+                1,
+                1,
+                image::Luma([128]),
+            )),
+            2 => image::DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+                1,
+                1,
+                image::Rgb([255, 0, 0]),
+            )),
+            4 => image::DynamicImage::ImageLumaA8(image::ImageBuffer::from_pixel(
+                1,
+                1,
+                image::LumaA([128, 200]),
+            )),
+            6 => image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+                1,
+                1,
+                image::Rgba([255, 0, 0, 200]),
+            )),
+            _ => panic!("unsupported test PNG color type {color_type}"),
+        }
+        .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+        .unwrap();
         png
-    }
-
-    fn append_png_chunk(buf: &mut Vec<u8>, chunk_type: &[u8; 4], data: &[u8]) {
-        buf.extend_from_slice(&(data.len() as u32).to_be_bytes());
-        buf.extend_from_slice(chunk_type);
-        buf.extend_from_slice(data);
-        buf.extend_from_slice(&[0, 0, 0, 0]); // CRC placeholder
     }
 
     fn simple_base64_encode_test(data: &[u8]) -> String {
@@ -8618,12 +8623,12 @@ mod tests {
         let pdf_str = String::from_utf8_lossy(&pdf);
 
         assert!(
-            pdf_str.contains("BI\n"),
-            "Expected nested table-cell background block to emit an inline image"
+            pdf_str.contains("/Subtype /Image"),
+            "Expected nested table-cell background block to emit an image XObject"
         );
         assert!(
-            pdf_str.contains("EI\n"),
-            "Expected nested table-cell background block to terminate the inline image"
+            pdf_str.contains(" Do\n"),
+            "Expected nested table-cell background block to draw the image XObject"
         );
     }
 
@@ -11579,7 +11584,9 @@ mod tests {
             .iter()
             .find(|r| r.border_bottom.is_some())
             .expect("fill-in underline run with border_bottom should exist");
-        let bw = underline.box_width.expect("underline run should carry box_width");
+        let bw = underline
+            .box_width
+            .expect("underline run should carry box_width");
         assert!(
             (bw - 141.73).abs() < 1.0,
             "underline box_width should be ~50mm (141.73pt), got {bw}"
@@ -11603,6 +11610,24 @@ mod tests {
         // the inline box is emitted alongside sibling text, not in place of it.
         let has_label = runs.iter().any(|r| r.text.contains("NPO"));
         assert!(has_label, "sibling label text should still be collected");
+    }
+
+    #[test]
+    fn inline_block_with_only_unsupported_side_borders_is_not_atomic_box() {
+        let html = "<table><tr><td>A<span style=\"display:inline-block;border-left:1pt solid red;\"></span>B</td></tr></table>";
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let runs = collect_table_cell_runs(&pages);
+
+        assert!(
+            !runs.iter().any(|r| {
+                r.text == " "
+                    && r.box_width.is_none()
+                    && r.box_height.is_none()
+                    && r.border_bottom.is_none()
+            }),
+            "side-only borders are not preserved by atomic table-cell runs and should not create placeholder box runs"
+        );
     }
 
     #[test]

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -2506,26 +2506,27 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                     let img_x = margin.left;
                     // PDF y-axis is bottom-up; y_pos is top of margin, image draws from bottom-left
                     let img_y = page_size.height - margin.top - y_pos - height;
-                    let img_obj_id = pdf_writer.add_image_object(
+                    if let Some(img_obj_id) = pdf_writer.add_layout_image_object(
                         &image.data,
                         image.source_width,
                         image.source_height,
                         image.format,
                         image.png_metadata.as_ref(),
-                    );
-                    let img_name = format!("Im{img_obj_id}");
-                    content.push_str(&format!(
-                        "q\n{w} 0 0 {h} {x} {y} cm\n/{name} Do\nQ\n",
-                        w = width,
-                        h = height,
-                        x = img_x,
-                        y = img_y,
-                        name = img_name,
-                    ));
-                    page_images.push(ImageRef {
-                        name: img_name,
-                        obj_id: img_obj_id,
-                    });
+                    ) {
+                        let img_name = format!("Im{img_obj_id}");
+                        content.push_str(&format!(
+                            "q\n{w} 0 0 {h} {x} {y} cm\n/{name} Do\nQ\n",
+                            w = width,
+                            h = height,
+                            x = img_x,
+                            y = img_y,
+                            name = img_name,
+                        ));
+                        page_images.push(ImageRef {
+                            name: img_name,
+                            obj_id: img_obj_id,
+                        });
+                    }
                 }
                 LayoutElement::Svg {
                     tree,
@@ -5217,6 +5218,31 @@ impl PdfWriter {
         self.objects.push(header);
         self.binary_objects.insert(id, data.to_vec());
         id
+    }
+
+    /// Add a layout `<img>` image XObject, choosing the correct encoding per
+    /// format: a PNG is fully decoded into a DeviceRGB image (plus an alpha
+    /// `/SMask`) via `add_raw_png_image_object`; a JPEG is embedded as DCTDecode.
+    /// Returns `None` when a PNG cannot be decoded, so the caller skips the image
+    /// rather than emit a corrupt one. Requires `data` to be the raw image bytes.
+    fn add_layout_image_object(
+        &mut self,
+        data: &[u8],
+        source_width: u32,
+        source_height: u32,
+        format: ImageFormat,
+        png_metadata: Option<&PngMetadata>,
+    ) -> Option<usize> {
+        match format {
+            ImageFormat::Png => self.add_raw_png_image_object(data),
+            ImageFormat::Jpeg => Some(self.add_image_object(
+                data,
+                source_width,
+                source_height,
+                format,
+                png_metadata,
+            )),
+        }
     }
 
     fn add_icc_profile_object(&mut self, icc_profile: &[u8]) -> Option<usize> {

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -1,7 +1,7 @@
 use crate::error::IronpressError;
 use crate::layout::engine::{
     ImageFormat, LayoutElement, Page, PngMetadata, TableCell, TextLine, TextRun,
-    layout_element_paint_order, table_cell_content_height,
+    layout_element_paint_order, table_cell_box_height, table_cell_content_height,
 };
 use crate::parser::ttf::TtfFont;
 use crate::render::background::{
@@ -7708,6 +7708,7 @@ mod tests {
             border: LayoutBorder::default(),
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Baseline,
+            min_height: 0.0,
         };
         let mut content = String::new();
         let fonts = HashMap::new();
@@ -9225,6 +9226,7 @@ mod tests {
             border: LayoutBorder::default(),
             text_align: TextAlign::Center,
             vertical_align: VerticalAlign::Middle,
+            min_height: 0.0,
         };
         let mut content = String::new();
         let fonts = HashMap::new();
@@ -10215,6 +10217,7 @@ mod tests {
             border: LayoutBorder::default(),
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
         let cell_visible = TableCell {
             lines: vec![TextLine {
@@ -10233,6 +10236,7 @@ mod tests {
             border: LayoutBorder::default(),
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
         let element = LayoutElement::TableRow {
             cells: vec![cell_skip, cell_visible],
@@ -10316,6 +10320,7 @@ mod tests {
             border: LayoutBorder::default(),
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
         let element = LayoutElement::TableRow {
             cells: vec![cell],
@@ -10421,6 +10426,7 @@ mod tests {
             border,
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
         let element = LayoutElement::TableRow {
             cells: vec![cell],
@@ -10513,6 +10519,7 @@ mod tests {
             border: crate::layout::engine::LayoutBorder::default(),
             text_align: TextAlign::Right,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
         let mut content_right = String::new();
         render_cell_text(
@@ -10544,6 +10551,7 @@ mod tests {
             border: crate::layout::engine::LayoutBorder::default(),
             text_align: TextAlign::Center,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
         let mut content_center = String::new();
         render_cell_text(
@@ -10621,6 +10629,7 @@ mod tests {
             border: crate::layout::engine::LayoutBorder::default(),
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
 
         let mut content = String::new();
@@ -10685,6 +10694,7 @@ mod tests {
             border: crate::layout::engine::LayoutBorder::default(),
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
 
         let mut content = String::new();
@@ -10748,6 +10758,7 @@ mod tests {
             border: crate::layout::engine::LayoutBorder::default(),
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Top,
+            min_height: 0.0,
         };
 
         let mut content = String::new();

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -2746,6 +2746,10 @@ fn font_name_for_run(run: &TextRun) -> &str {
 }
 
 fn estimate_run_width(run: &TextRun) -> f32 {
+    // Atomic inline-block boxes reserve their explicit width regardless of text.
+    if let Some(box_width) = run.box_width {
+        return box_width;
+    }
     crate::fonts::str_width(&run.text, run.font_size, &run.font_family, run.bold)
 }
 
@@ -2766,6 +2770,10 @@ fn resolve_font_name(
 
 /// Estimate run width using TTF metrics for custom fonts, falling back to fixed estimation.
 fn estimate_run_width_with_fonts(run: &TextRun, custom_fonts: &HashMap<String, TtfFont>) -> f32 {
+    // Atomic inline-block boxes reserve their explicit width regardless of text.
+    if let Some(box_width) = run.box_width {
+        return box_width;
+    }
     if let Some(width) = crate::text::measure_text_width(
         &run.text,
         run.font_size,
@@ -4306,6 +4314,15 @@ fn merge_runs(runs: &[TextRun]) -> Vec<TextRun> {
                 && prev.background_color == run.background_color
                 && prev.padding == run.padding
                 && prev.border_radius == run.border_radius
+                // Atomic inline-block boxes (fill-in underlines / checkbox
+                // squares) are indivisible: never fold them into a neighbour, or
+                // the box width/border would be applied to the merged text.
+                && prev.box_width.is_none()
+                && prev.box_height.is_none()
+                && prev.border_bottom.is_none()
+                && run.box_width.is_none()
+                && run.box_height.is_none()
+                && run.border_bottom.is_none()
                 // Don't merge across an RTL <-> LTR boundary: the bidi pass
                 // split these into separate runs in visual order, and merging
                 // would give the shaper a mixed-script buffer whose guessed
@@ -6091,6 +6108,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         }
     }
 
@@ -7695,6 +7715,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let non_empty_run = TextRun {
             text: "Hello".to_string(),
@@ -7710,6 +7733,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let cell = TableCell {
             lines: vec![
@@ -7794,6 +7820,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         assert_eq!(font_name_for_run(&run_bi), "Helvetica-BoldOblique");
 
@@ -7811,6 +7840,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         assert_eq!(font_name_for_run(&run_b), "Helvetica-Bold");
 
@@ -7828,6 +7860,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         assert_eq!(font_name_for_run(&run_i), "Helvetica-Oblique");
     }
@@ -9234,6 +9269,9 @@ mod tests {
             background_color: Some((1.0, 0.0, 0.0, 1.0)),
             padding: (4.0, 2.0),
             border_radius: 3.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let cell = TableCell {
             lines: vec![TextLine {
@@ -9290,6 +9328,9 @@ mod tests {
             background_color: Some((1.0, 1.0, 0.0, 1.0)),
             padding: (2.0, 1.0),
             border_radius: 4.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let run_b = TextRun {
             text: "World".to_string(),
@@ -9305,6 +9346,9 @@ mod tests {
             background_color: Some((1.0, 1.0, 0.0, 1.0)),
             padding: (2.0, 1.0),
             border_radius: 8.0, // Different border_radius
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let merged = merge_runs(&[run_a.clone(), run_b.clone()]);
         // Different border_radius should prevent merging
@@ -10220,6 +10264,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let run_visible = TextRun {
             text: "Visible".to_string(),
@@ -10328,6 +10375,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let cell = TableCell {
             lines: vec![TextLine {
@@ -10413,6 +10463,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let mut border = LayoutBorder::default();
         border.top = LayoutBorderSide {
@@ -10525,6 +10578,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
 
         // Test right-align
@@ -10615,6 +10671,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let strike_run = TextRun {
             text: "Strike".to_string(),
@@ -10630,6 +10689,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
 
         let cell = crate::layout::engine::TableCell {
@@ -10701,6 +10763,9 @@ mod tests {
             background_color: Some((0.2, 0.4, 0.8, 1.0)),
             padding: (3.0, 2.0),
             border_radius: 4.0, // Triggers rounded rect for inline background
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
 
         let cell = crate::layout::engine::TableCell {
@@ -10765,6 +10830,9 @@ mod tests {
             background_color: Some((1.0, 1.0, 0.0, 1.0)), // yellow
             padding: (2.0, 1.0),
             border_radius: 0.0, // No rounding — should use rectangle
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
 
         let cell = crate::layout::engine::TableCell {
@@ -11438,5 +11506,114 @@ mod tests {
             "render_pdf and render_pdf_to_writer should produce identical output"
         );
         assert_eq!(pdf_bytes, writer_buf);
+    }
+
+    /// Collect every `TextRun` from all table cells across all pages.
+    fn collect_table_cell_runs(pages: &[crate::layout::engine::Page]) -> Vec<TextRun> {
+        let mut runs = Vec::new();
+        for page in pages {
+            for (_, element) in &page.elements {
+                if let LayoutElement::TableRow { cells, .. } = element {
+                    for cell in cells {
+                        for line in &cell.lines {
+                            runs.extend(line.runs.iter().cloned());
+                        }
+                    }
+                }
+            }
+        }
+        runs
+    }
+
+    #[test]
+    fn inline_block_box_in_table_cell_carries_box_fields() {
+        // A fill-in underline (border-bottom + explicit width) and a checkbox
+        // square (explicit width/height + background) inside a table cell must
+        // each produce ONE atomic TextRun carrying the box geometry, flowing
+        // inline with the sibling label text — not be flattened to plain runs.
+        let html = "<table><tr><td>\
+            NPO <span style=\"border-bottom:0.25mm solid #555;display:inline-block;width:50mm;\">&nbsp;</span> \
+            <span style=\"display:inline-block;width:3mm;height:3mm;background:#cfcfcf;\">.</span>\
+            </td></tr></table>";
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let runs = collect_table_cell_runs(&pages);
+
+        // 50mm = 141.73pt; 3mm = 8.50pt.
+        let underline = runs
+            .iter()
+            .find(|r| r.border_bottom.is_some())
+            .expect("fill-in underline run with border_bottom should exist");
+        let bw = underline.box_width.expect("underline run should carry box_width");
+        assert!(
+            (bw - 141.73).abs() < 1.0,
+            "underline box_width should be ~50mm (141.73pt), got {bw}"
+        );
+        let (line_w, _rgb) = underline.border_bottom.unwrap();
+        assert!(line_w > 0.0, "border_bottom width should be positive");
+
+        let checkbox = runs
+            .iter()
+            .find(|r| {
+                r.box_width.is_some_and(|w| (w - 8.50).abs() < 0.6)
+                    && r.box_height.is_some_and(|h| (h - 8.50).abs() < 0.6)
+            })
+            .expect("3mm x 3mm checkbox run should exist");
+        assert!(
+            checkbox.background_color.is_some(),
+            "checkbox run should carry its background fill"
+        );
+
+        // The plain "NPO" label text must still be present as its own run(s):
+        // the inline box is emitted alongside sibling text, not in place of it.
+        let has_label = runs.iter().any(|r| r.text.contains("NPO"));
+        assert!(has_label, "sibling label text should still be collected");
+    }
+
+    #[test]
+    fn merge_runs_never_merges_atomic_box_runs() {
+        // Two visually identical runs that would normally merge must NOT merge
+        // when either carries an atomic inline-block box field, or the box
+        // width/border would bleed onto the merged text.
+        let plain = TextRun {
+            text: "AB".to_string(),
+            font_size: 12.0,
+            bold: false,
+            italic: false,
+            underline: false,
+            line_through: false,
+            overline: false,
+            color: (0.0, 0.0, 0.0),
+            font_family: FontFamily::Helvetica,
+            link_url: None,
+            background_color: None,
+            padding: (0.0, 0.0),
+            border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
+        };
+        // Sanity: two plain identical runs DO merge.
+        assert_eq!(merge_runs(&[plain.clone(), plain.clone()]).len(), 1);
+
+        let mut boxed = plain.clone();
+        boxed.box_width = Some(40.0);
+        // A box run next to a plain run stays separate (both orders).
+        assert_eq!(
+            merge_runs(&[plain.clone(), boxed.clone()]).len(),
+            2,
+            "plain followed by box run should not merge"
+        );
+        assert_eq!(
+            merge_runs(&[boxed.clone(), plain.clone()]).len(),
+            2,
+            "box run followed by plain should not merge"
+        );
+        // Two box runs never merge either.
+        assert_eq!(
+            merge_runs(&[boxed.clone(), boxed]).len(),
+            2,
+            "two box runs should not merge"
+        );
     }
 }

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -2267,6 +2267,9 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                             &mut bg_alpha_counter,
                                             &mut page_shadings,
                                             &mut shading_counter,
+                                            &mut pdf_writer,
+                                            &mut page_images,
+                                            &mut annotations,
                                             *cont_pl + cont_border.left.width,
                                             *cont_pt + cont_border.top.width,
                                         );
@@ -2506,6 +2509,9 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                         &mut bg_alpha_counter,
                         &mut page_shadings,
                         &mut shading_counter,
+                        &mut pdf_writer,
+                        &mut page_images,
+                        &mut annotations,
                         *c_pl + border.left.width,
                         *c_pt + border.top.width,
                     );
@@ -2943,6 +2949,9 @@ fn render_container_children(
     bg_alpha_counter: &mut usize,
     page_shadings: &mut Vec<ShadingEntry>,
     shading_counter: &mut usize,
+    pdf_writer: &mut PdfWriter,
+    page_images: &mut Vec<ImageRef>,
+    annotations: &mut Vec<LinkAnnotation>,
     abs_pad_left: f32,
     abs_pad_top: f32,
 ) {
@@ -2979,6 +2988,11 @@ fn render_container_children(
                 bg_alpha_counter,
                 custom_fonts,
                 prepared_custom_fonts,
+                pdf_writer,
+                page_images,
+                page_shadings,
+                shading_counter,
+                annotations,
             );
             y = cursor_y;
         }
@@ -3463,6 +3477,9 @@ fn render_container_children(
                     bg_alpha_counter,
                     page_shadings,
                     shading_counter,
+                    pdf_writer,
+                    page_images,
+                    annotations,
                     *padding_left + border.left.width,
                     *padding_top + border.top.width,
                 );
@@ -3722,6 +3739,9 @@ fn render_container_children(
                             bg_alpha_counter,
                             page_shadings,
                             shading_counter,
+                            pdf_writer,
+                            page_images,
+                            annotations,
                             0.0, // flex cells don't have separate padding for abs children
                             0.0,
                         );
@@ -3766,6 +3786,11 @@ fn render_container_children(
             bg_alpha_counter,
             custom_fonts,
             prepared_custom_fonts,
+            pdf_writer,
+            page_images,
+            page_shadings,
+            shading_counter,
+            annotations,
         );
     }
 }
@@ -3781,6 +3806,11 @@ fn render_nested_table_rows(
     bg_alpha_counter: &mut usize,
     custom_fonts: &HashMap<String, TtfFont>,
     prepared_custom_fonts: &PreparedCustomFonts,
+    pdf_writer: &mut PdfWriter,
+    page_images: &mut Vec<ImageRef>,
+    page_shadings: &mut Vec<ShadingEntry>,
+    shading_counter: &mut usize,
+    annotations: &mut Vec<LinkAnnotation>,
 ) {
     for element in elements {
         match element {
@@ -3867,73 +3897,36 @@ fn render_nested_table_rows(
                         }
                     }
 
-                    // Compute cell content top (simplified vertical alignment)
-                    let content_top = row_y - cell.padding_top;
-                    let cell_inner_w = cell_w - cell.padding_left - cell.padding_right;
-                    let mut text_y = content_top;
-                    for line in &cell.lines {
-                        let metrics = line_box_metrics(line, custom_fonts);
-                        text_y -= metrics.half_leading + metrics.ascender;
-                        let text_content: String =
-                            line.runs.iter().map(|run| run.text.as_str()).collect();
-                        if text_content.is_empty() {
-                            continue;
-                        }
-                        let merged = merge_runs(&line.runs);
-                        let line_width: f32 = merged
-                            .iter()
-                            .map(|run| estimate_run_width_with_fonts(run, custom_fonts))
-                            .sum();
-                        let text_x = match cell.text_align {
-                            TextAlign::Right => {
-                                cell_x + cell.padding_left + (cell_inner_w - line_width).max(0.0)
-                            }
-                            TextAlign::Center => {
-                                cell_x
-                                    + cell.padding_left
-                                    + ((cell_inner_w - line_width) / 2.0).max(0.0)
-                            }
-                            _ => cell_x + cell.padding_left,
-                        };
-                        let mut lx = text_x;
-                        for run in &merged {
-                            if run.text.is_empty() {
-                                continue;
-                            }
-                            // Inline background (for status badges etc.)
-                            if let Some((br, bg_c, bb, _ba)) = run.background_color {
-                                let (pad_h, pad_v) = run.padding;
-                                let run_w = estimate_run_width_with_fonts(run, custom_fonts);
-                                let rx = lx - pad_h;
-                                let ry = text_y - 2.0 - pad_v;
-                                let rw2 = run_w + pad_h * 2.0;
-                                let rh = run.font_size + 2.0 + pad_v * 2.0;
-                                content.push_str(&format!("{br} {bg_c} {bb} rg\n"));
-                                if run.border_radius > 0.0 {
-                                    content.push_str(&rounded_rect_path(
-                                        rx,
-                                        ry,
-                                        rw2,
-                                        rh,
-                                        run.border_radius,
-                                    ));
-                                    content.push_str("\nf\n");
-                                } else {
-                                    content.push_str(&format!("{rx} {ry} {rw2} {rh} re\nf\n"));
-                                }
-                            }
-                            let rw = render_run_text(
-                                content,
-                                run,
-                                lx,
-                                text_y,
-                                custom_fonts,
-                                prepared_custom_fonts,
-                            );
-                            lx += rw;
-                        }
-                        text_y -= metrics.descender + metrics.half_leading;
-                    }
+                    // Delegate cell content to the main-path painter so text,
+                    // vertical alignment, and nested content (tables, SVG,
+                    // images) inside Container-hosted rows render exactly like
+                    // page-level table cells. The text-only loop this replaces
+                    // dropped cell.nested_rows entirely: an avoid-wrapped table
+                    // whose cells hold nested tables reserved its space but
+                    // painted blank (gwd #4604, anaesthesia page 2).
+                    let mut cell_ctx = PageRenderContext::new(
+                        pdf_writer,
+                        page_images,
+                        custom_fonts,
+                        prepared_custom_fonts,
+                        page_shadings,
+                        shading_counter,
+                        page_ext_gstates,
+                        bg_alpha_counter,
+                        annotations,
+                    );
+                    render_cell_content(
+                        content,
+                        cell,
+                        TableCellRenderBox::new(
+                            cell_x,
+                            row_y,
+                            cell_w,
+                            row_height,
+                            NestedLayoutFrame::new(cell_x, row_y, origin_x, row_y, cell_w),
+                        ),
+                        &mut cell_ctx,
+                    );
 
                     col_pos += cell.colspan;
                 }
@@ -11437,6 +11430,56 @@ mod tests {
             content.contains("Inside container"),
             "Container children text should be rendered"
         );
+    }
+
+    /// gwd #4604 regression — a `page-break-inside: avoid` block wraps its
+    /// content in a Container; tables inside it must still paint their cells'
+    /// nested content. The old Container-path cell painter drew only direct
+    /// cell text and dropped `nested_rows`, so a nested table inside a cell
+    /// reserved its space but painted nothing.
+    #[test]
+    fn render_avoid_container_paints_nested_table_in_cell() {
+        let html = r#"
+            <div style="page-break-inside: avoid;">
+                <table><tr><td>
+                    OUTER-TEXT
+                    <table><tr><td>NESTED-TEXT</td></tr></table>
+                </td></tr></table>
+            </div>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("OUTER-TEXT"),
+            "direct cell text must render inside an avoid Container"
+        );
+        assert!(
+            content.contains("NESTED-TEXT"),
+            "nested table content inside an avoid Container must render"
+        );
+    }
+
+    /// Same shape as the anaesthesia page-2 airway/grid section: a fixed-layout
+    /// outer table whose two cells each hold nested tables. Every marker must
+    /// survive into the page content stream.
+    #[test]
+    fn render_avoid_container_paints_two_column_nested_tables() {
+        let html = r#"
+            <div style="page-break-inside: avoid;">
+                <table style="width:100%;table-layout:fixed;"><tr>
+                    <td style="width:9%;"><table><tr><td>COL-A</td></tr></table></td>
+                    <td style="width:91%;"><table><tr><td>COL-B</td></tr></table></td>
+                </tr></table>
+            </div>
+        "#;
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(content.contains("COL-A"), "left column nested table must render");
+        assert!(content.contains("COL-B"), "right column nested table must render");
     }
 
     #[test]

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -534,6 +534,10 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             &mut page_shadings,
                             &mut shading_counter,
                             Some(&mut page_ext_gstates),
+                            Some(crate::render::svg_to_pdf::SvgFontContext {
+                                custom_fonts,
+                                prepared: &prepared_custom_fonts,
+                            }),
                             BackgroundPaintContext::new(
                                 SvgViewportBox::new(ref_x, ref_y, ref_w, ref_h),
                                 SvgViewportBox::new(
@@ -1349,6 +1353,10 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                             &mut page_shadings,
                             &mut shading_counter,
                             Some(&mut page_ext_gstates),
+                            Some(crate::render::svg_to_pdf::SvgFontContext {
+                                custom_fonts,
+                                prepared: &prepared_custom_fonts,
+                            }),
                             BackgroundPaintContext::new(
                                 SvgViewportBox::new(ref_x, ref_y, ref_w, ref_h),
                                 SvgViewportBox::new(
@@ -1726,6 +1734,10 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                 &mut page_shadings,
                                 &mut shading_counter,
                                 Some(&mut page_ext_gstates),
+                                Some(crate::render::svg_to_pdf::SvgFontContext {
+                                    custom_fonts,
+                                    prepared: &prepared_custom_fonts,
+                                }),
                                 BackgroundPaintContext::new(
                                     SvgViewportBox::new(ref_x, ref_y, ref_w, ref_h),
                                     SvgViewportBox::new(bg_x, bg_y, cell.width, cell_render_h),
@@ -2095,6 +2107,12 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                                     shading_counter: &mut shading_counter,
                                                     ext_gstates: Some(&mut page_ext_gstates),
                                                     image_sink: Some(&mut image_sink),
+                                                    fonts: Some(
+                                                        crate::render::svg_to_pdf::SvgFontContext {
+                                                            custom_fonts,
+                                                            prepared: &prepared_custom_fonts,
+                                                        },
+                                                    ),
                                                 };
                                             crate::render::svg_to_pdf::render_svg_tree_with_resources(
                                                 tree,
@@ -2570,6 +2588,10 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
                                 shading_counter: &mut shading_counter,
                                 ext_gstates: Some(&mut page_ext_gstates),
                                 image_sink: Some(&mut image_sink),
+                                fonts: Some(crate::render::svg_to_pdf::SvgFontContext {
+                                    custom_fonts,
+                                    prepared: &prepared_custom_fonts,
+                                }),
                             };
                             crate::render::svg_to_pdf::render_svg_tree_with_resources(
                                 tree,
@@ -3497,6 +3519,10 @@ fn render_container_children(
                             shading_counter: &mut 0,
                             ext_gstates: Some(page_ext_gstates),
                             image_sink: None,
+                            fonts: Some(crate::render::svg_to_pdf::SvgFontContext {
+                                custom_fonts,
+                                prepared: prepared_custom_fonts,
+                            }),
                         };
                         crate::render::svg_to_pdf::render_svg_tree_with_resources(
                             tree, content, &mut res,
@@ -3509,6 +3535,10 @@ fn render_container_children(
                         shading_counter: &mut 0,
                         ext_gstates: Some(page_ext_gstates),
                         image_sink: None,
+                        fonts: Some(crate::render::svg_to_pdf::SvgFontContext {
+                            custom_fonts,
+                            prepared: prepared_custom_fonts,
+                        }),
                     };
                     crate::render::svg_to_pdf::render_svg_tree_with_resources(
                         tree, content, &mut res,
@@ -4270,7 +4300,7 @@ fn estimate_line_width_with_fonts(line: &TextLine, custom_fonts: &HashMap<String
 }
 
 /// Sanitize a font name for use as a PDF name object (remove spaces, special chars).
-fn sanitize_pdf_name(name: &str) -> String {
+pub(crate) fn sanitize_pdf_name(name: &str) -> String {
     name.chars()
         .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
         .collect()
@@ -4444,6 +4474,7 @@ fn render_svg_background(
     shadings: &mut Vec<ShadingEntry>,
     shading_counter: &mut usize,
     mut ext_gstates: Option<&mut Vec<(String, f32)>>,
+    fonts: Option<crate::render::svg_to_pdf::SvgFontContext<'_>>,
     paint: BackgroundPaintContext,
 ) {
     // SVG image resources frequently omit explicit width/height and only provide
@@ -4646,6 +4677,7 @@ fn render_svg_background(
                         shading_counter,
                         ext_gstates: ext_gstates.as_deref_mut(),
                         image_sink: Some(&mut image_sink),
+                        fonts,
                     };
                     crate::render::svg_to_pdf::render_svg_tree_with_resources(
                         tree,
@@ -8257,6 +8289,7 @@ mod tests {
             &mut shadings,
             &mut shading_counter,
             None,
+            None,
             BackgroundPaintContext::new(
                 SvgViewportBox::new(0.0, 0.0, 200.0, 100.0),
                 SvgViewportBox::new(0.0, 0.0, 200.0, 100.0),
@@ -8320,6 +8353,7 @@ mod tests {
             &mut shadings,
             &mut shading_counter,
             None,
+            None,
             BackgroundPaintContext::new(
                 SvgViewportBox::new(0.0, 0.0, 200.0, 100.0),
                 SvgViewportBox::new(0.0, 0.0, 200.0, 100.0),
@@ -8378,6 +8412,7 @@ mod tests {
             &mut page_images,
             &mut shadings,
             &mut shading_counter,
+            None,
             None,
             BackgroundPaintContext::new(
                 SvgViewportBox::new(20.0, 10.0, 160.0, 80.0),

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -200,7 +200,12 @@ pub(super) fn render_cell_content(
             &cell.nested_rows,
             NestedLayoutFrame::new(
                 placement.cell_x + cell.padding_left,
-                content_top - text_h - cell.padding_bottom,
+                // GFI-298: nested content sits directly below any direct cell text
+                // (content_top is already inset by padding_top + the vertical-align
+                // offset). Subtracting padding_bottom here double-counted the bottom
+                // padding, shoving nested content down by padding_bottom — which left
+                // the food-measurement card badge+text glued low instead of centered.
+                content_top - text_h,
                 placement.nested_frame.initial_origin_x,
                 placement.nested_frame.initial_top_y,
                 (placement.col_width - cell.padding_left - cell.padding_right).max(0.0),

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -671,6 +671,81 @@ pub(super) fn render_nested_layout_elements(
                     ctx,
                 );
             }
+            LayoutElement::Image {
+                image,
+                width,
+                height,
+                ..
+            } => {
+                let img_x = planned_element.origin_x;
+                let img_y = planned_element.top_y - height;
+                let img_obj_id = ctx.pdf_writer.add_image_object(
+                    &image.data,
+                    image.source_width,
+                    image.source_height,
+                    image.format,
+                    image.png_metadata.as_ref(),
+                );
+                let img_name = format!("Im{img_obj_id}");
+                content.push_str(&format!(
+                    "q\n{width} 0 0 {height} {img_x} {img_y} cm\n/{img_name} Do\nQ\n"
+                ));
+                ctx.page_images.push(ImageRef {
+                    name: img_name,
+                    obj_id: img_obj_id,
+                });
+            }
+            LayoutElement::Svg {
+                tree,
+                width,
+                height,
+                ..
+            } => {
+                let svg_x = planned_element.origin_x;
+                // PDF y-axis is bottom-up, SVG is top-down; flip about the top edge.
+                let svg_top = planned_element.top_y;
+                content.push_str("q\n");
+                content.push_str(&format!("1 0 0 -1 {svg_x} {svg_top} cm\n"));
+                if let Some(placement) = crate::render::svg_geometry::compute_svg_placement(
+                    tree,
+                    crate::render::svg_geometry::SvgPlacementRequest::from_rect(
+                        0.0,
+                        0.0,
+                        *width,
+                        *height,
+                        tree.preserve_aspect_ratio,
+                    ),
+                ) {
+                    content.push_str("q\n");
+                    content.push_str(&placement.viewport.clip_path());
+                    content.push_str(&format!(
+                        "{sx} 0 0 {sy} {tx} {ty} cm\n",
+                        sx = placement.scale_x,
+                        sy = placement.scale_y,
+                        tx = placement.translate_x,
+                        ty = placement.translate_y,
+                    ));
+                    {
+                        let mut image_sink = SvgPageImageSink {
+                            pdf_writer: ctx.pdf_writer,
+                            page_images: ctx.page_images,
+                        };
+                        let mut resources = crate::render::svg_to_pdf::SvgPdfResources {
+                            shadings: ctx.shadings,
+                            shading_counter: ctx.shading_counter,
+                            ext_gstates: Some(ctx.page_ext_gstates),
+                            image_sink: Some(&mut image_sink),
+                        };
+                        crate::render::svg_to_pdf::render_svg_tree_with_resources(
+                            tree,
+                            content,
+                            &mut resources,
+                        );
+                    }
+                    content.push_str("Q\n");
+                }
+                content.push_str("Q\n");
+            }
             _ => {}
         }
     }
@@ -773,6 +848,31 @@ pub(super) fn plan_nested_layout_elements(
                         )
                         - *margin_bottom;
                 }
+            }
+            LayoutElement::Svg {
+                height,
+                flow_extra_bottom,
+                margin_top,
+                margin_bottom,
+                ..
+            }
+            | LayoutElement::Image {
+                height,
+                flow_extra_bottom,
+                margin_top,
+                margin_bottom,
+                ..
+            } => {
+                cursor_y -= *margin_top;
+                planned.push(PlannedNestedElement {
+                    element,
+                    source_index: element_idx,
+                    origin_x: frame.origin_x,
+                    top_y: cursor_y,
+                    available_width: frame.available_width,
+                    blur_canvas_box: None,
+                });
+                cursor_y -= *height + *flow_extra_bottom + *margin_bottom;
             }
             _ => {}
         }

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -685,21 +685,22 @@ pub(super) fn render_nested_layout_elements(
             } => {
                 let img_x = planned_element.origin_x;
                 let img_y = planned_element.top_y - height;
-                let img_obj_id = ctx.pdf_writer.add_image_object(
+                if let Some(img_obj_id) = ctx.pdf_writer.add_layout_image_object(
                     &image.data,
                     image.source_width,
                     image.source_height,
                     image.format,
                     image.png_metadata.as_ref(),
-                );
-                let img_name = format!("Im{img_obj_id}");
-                content.push_str(&format!(
-                    "q\n{width} 0 0 {height} {img_x} {img_y} cm\n/{img_name} Do\nQ\n"
-                ));
-                ctx.page_images.push(ImageRef {
-                    name: img_name,
-                    obj_id: img_obj_id,
-                });
+                ) {
+                    let img_name = format!("Im{img_obj_id}");
+                    content.push_str(&format!(
+                        "q\n{width} 0 0 {height} {img_x} {img_y} cm\n/{img_name} Do\nQ\n"
+                    ));
+                    ctx.page_images.push(ImageRef {
+                        name: img_name,
+                        obj_id: img_obj_id,
+                    });
+                }
             }
             LayoutElement::Svg {
                 tree,

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -252,7 +252,53 @@ pub(super) fn render_cell_text(
             let (r, g, b) = run.color;
             let run_width = estimate_run_width_with_fonts(run, ctx.custom_fonts);
 
-            if let Some((background_r, background_g, background_b, _background_a)) =
+            // Atomic inline-block box (form fill-in underline / checkbox square):
+            // paint the background as a box_width x box_height rectangle centred
+            // on the text line (approximating vertical-align: middle) and stroke
+            // the bottom border, instead of the text-sized background rect.
+            let is_box =
+                run.box_width.is_some() || run.box_height.is_some() || run.border_bottom.is_some();
+            if is_box {
+                let box_w = run.box_width.unwrap_or(run_width);
+                // Vertical centre of the text line, ~0.3em above the baseline.
+                let mid_y = text_y + run.font_size * 0.3;
+                if let Some(box_h) = run.box_height {
+                    let box_bottom = mid_y - box_h / 2.0;
+                    if let Some((bg_r, bg_g, bg_b, _bg_a)) = run.background_color {
+                        content.push_str(&format!("{bg_r} {bg_g} {bg_b} rg\n"));
+                        if run.border_radius > 0.0 {
+                            content.push_str(&rounded_rect_path(
+                                x,
+                                box_bottom,
+                                box_w,
+                                box_h,
+                                run.border_radius,
+                            ));
+                            content.push_str("\nf\n");
+                        } else {
+                            content.push_str(&format!("{x} {box_bottom} {box_w} {box_h} re\nf\n"));
+                        }
+                    }
+                } else if let Some((bg_r, bg_g, bg_b, _bg_a)) = run.background_color {
+                    // No explicit height: fall back to a text-height background.
+                    let ry = text_y - 2.0;
+                    let rh = run.font_size + 2.0;
+                    content.push_str(&format!("{bg_r} {bg_g} {bg_b} rg\n"));
+                    content.push_str(&format!("{x} {ry} {box_w} {rh} re\nf\n"));
+                }
+                if let Some((bw, (br, bg2, bb))) = run.border_bottom {
+                    // Bottom border line: at the box bottom when a height is set,
+                    // otherwise just below the text baseline (a writing line).
+                    let line_y = match run.box_height {
+                        Some(box_h) => mid_y - box_h / 2.0,
+                        None => text_y - run.font_size * 0.18,
+                    };
+                    let x2 = x + box_w;
+                    content.push_str(&format!(
+                        "{br} {bg2} {bb} RG\n{bw} w\n{x} {line_y} m {x2} {line_y} l\nS\n",
+                    ));
+                }
+            } else if let Some((background_r, background_g, background_b, _background_a)) =
                 run.background_color
             {
                 let (pad_h, pad_v) = run.padding;

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+// Atomic inline-block boxes are positioned against the same text baseline as
+// surrounding runs. These ratios preserve the existing visual placement while
+// making the baseline heuristics easy to tune if font metrics vary.
+const INLINE_BOX_MIDDLE_BASELINE_OFFSET_EM: f32 = 0.3;
+const INLINE_BOX_BORDER_BASELINE_OFFSET_EM: f32 = 0.18;
+const INLINE_BACKGROUND_BASELINE_PADDING_PT: f32 = 2.0;
+
 pub(super) struct TextRenderContext<'a> {
     custom_fonts: &'a HashMap<String, TtfFont>,
     prepared_custom_fonts: &'a PreparedCustomFonts,
@@ -260,8 +267,7 @@ pub(super) fn render_cell_text(
                 run.box_width.is_some() || run.box_height.is_some() || run.border_bottom.is_some();
             if is_box {
                 let box_w = run.box_width.unwrap_or(run_width);
-                // Vertical centre of the text line, ~0.3em above the baseline.
-                let mid_y = text_y + run.font_size * 0.3;
+                let mid_y = text_y + run.font_size * INLINE_BOX_MIDDLE_BASELINE_OFFSET_EM;
                 if let Some(box_h) = run.box_height {
                     let box_bottom = mid_y - box_h / 2.0;
                     if let Some((bg_r, bg_g, bg_b, _bg_a)) = run.background_color {
@@ -281,8 +287,8 @@ pub(super) fn render_cell_text(
                     }
                 } else if let Some((bg_r, bg_g, bg_b, _bg_a)) = run.background_color {
                     // No explicit height: fall back to a text-height background.
-                    let ry = text_y - 2.0;
-                    let rh = run.font_size + 2.0;
+                    let ry = text_y - INLINE_BACKGROUND_BASELINE_PADDING_PT;
+                    let rh = run.font_size + INLINE_BACKGROUND_BASELINE_PADDING_PT;
                     content.push_str(&format!("{bg_r} {bg_g} {bg_b} rg\n"));
                     content.push_str(&format!("{x} {ry} {box_w} {rh} re\nf\n"));
                 }
@@ -291,7 +297,7 @@ pub(super) fn render_cell_text(
                     // otherwise just below the text baseline (a writing line).
                     let line_y = match run.box_height {
                         Some(box_h) => mid_y - box_h / 2.0,
-                        None => text_y - run.font_size * 0.18,
+                        None => text_y - run.font_size * INLINE_BOX_BORDER_BASELINE_OFFSET_EM,
                     };
                     let x2 = x + box_w;
                     content.push_str(&format!(
@@ -303,9 +309,9 @@ pub(super) fn render_cell_text(
             {
                 let (pad_h, pad_v) = run.padding;
                 let rx = x - pad_h;
-                let ry = text_y - 2.0 - pad_v;
+                let ry = text_y - INLINE_BACKGROUND_BASELINE_PADDING_PT - pad_v;
                 let rw2 = run_width + pad_h * 2.0;
-                let rh = run.font_size + 2.0 + pad_v * 2.0;
+                let rh = run.font_size + INLINE_BACKGROUND_BASELINE_PADDING_PT + pad_v * 2.0;
                 content.push_str(&format!(
                     "{background_r} {background_g} {background_b} rg\n"
                 ));
@@ -735,13 +741,7 @@ pub(super) fn render_nested_layout_elements(
             } => {
                 let img_x = planned_element.origin_x;
                 let img_y = planned_element.top_y - height;
-                if let Some(img_obj_id) = ctx.pdf_writer.add_layout_image_object(
-                    &image.data,
-                    image.source_width,
-                    image.source_height,
-                    image.format,
-                    image.png_metadata.as_ref(),
-                ) {
+                if let Some(img_obj_id) = ctx.pdf_writer.add_layout_image_object(image) {
                     let img_name = format!("Im{img_obj_id}");
                     content.push_str(&format!(
                         "q\n{width} 0 0 {height} {img_x} {img_y} cm\n/{img_name} Do\nQ\n"

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -148,10 +148,15 @@ pub(super) struct NestedTextBlock<'a> {
 }
 
 /// Compute the height of a table row from its cells.
+///
+/// Uses each cell's box height so a CSS `height` on a row/cell expands the row
+/// beyond its natural content. `vertical-align` placement (below) compares the
+/// content-only height against this row height to position content within the
+/// expanded box.
 pub(super) fn compute_row_height(cells: &[TableCell]) -> f32 {
     cells
         .iter()
-        .map(table_cell_content_height)
+        .map(table_cell_box_height)
         .fold(0.0f32, f32::max)
 }
 
@@ -484,6 +489,7 @@ pub(super) fn render_nested_text_block(
             border: crate::layout::engine::LayoutBorder::default(),
             text_align: block.text_align,
             vertical_align: VerticalAlign::Baseline,
+            min_height: 0.0,
         };
         render_cell_text(
             content,

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -459,6 +459,10 @@ pub(super) fn render_nested_text_block(
             ctx.shadings,
             ctx.shading_counter,
             Some(ctx.page_ext_gstates),
+            Some(crate::render::svg_to_pdf::SvgFontContext {
+                custom_fonts: ctx.text.custom_fonts,
+                prepared: ctx.text.prepared_custom_fonts,
+            }),
             BackgroundPaintContext::new(
                 SvgViewportBox::new(ref_x, ref_y, ref_w, ref_h),
                 SvgViewportBox::new(
@@ -788,6 +792,10 @@ pub(super) fn render_nested_layout_elements(
                             shading_counter: ctx.shading_counter,
                             ext_gstates: Some(ctx.page_ext_gstates),
                             image_sink: Some(&mut image_sink),
+                            fonts: Some(crate::render::svg_to_pdf::SvgFontContext {
+                                custom_fonts: ctx.text.custom_fonts,
+                                prepared: ctx.text.prepared_custom_fonts,
+                            }),
                         };
                         crate::render::svg_to_pdf::render_svg_tree_with_resources(
                             tree,

--- a/src/render/pdf_fonts.rs
+++ b/src/render/pdf_fonts.rs
@@ -171,8 +171,13 @@ fn collect_font_usage_from_element(
     usage: &mut BTreeMap<String, FontUsage>,
 ) {
     match element {
-        LayoutElement::TextBlock { lines, .. } => {
-            collect_font_usage_from_lines(lines, custom_fonts, usage)
+        LayoutElement::TextBlock {
+            lines,
+            background_svg,
+            ..
+        } => {
+            collect_font_usage_from_lines(lines, custom_fonts, usage);
+            collect_font_usage_from_svg(background_svg.as_ref(), custom_fonts, usage);
         }
         LayoutElement::TableRow { cells, .. } | LayoutElement::GridRow { cells, .. } => {
             for cell in cells {
@@ -182,21 +187,57 @@ fn collect_font_usage_from_element(
                 }
             }
         }
-        LayoutElement::FlexRow { cells, .. } => {
+        LayoutElement::FlexRow {
+            cells,
+            background_svg,
+            ..
+        } => {
             for cell in cells {
                 collect_font_usage_from_lines(&cell.lines, custom_fonts, usage);
+                collect_font_usage_from_svg(cell.background_svg.as_ref(), custom_fonts, usage);
                 for nested in &cell.nested_elements {
                     collect_font_usage_from_element(nested, custom_fonts, usage);
                 }
             }
+            collect_font_usage_from_svg(background_svg.as_ref(), custom_fonts, usage);
         }
-        LayoutElement::Container { children, .. } => {
+        LayoutElement::Container {
+            children,
+            background_svg,
+            ..
+        } => {
             for child in children {
                 collect_font_usage_from_element(child, custom_fonts, usage);
             }
+            collect_font_usage_from_svg(background_svg.as_ref(), custom_fonts, usage);
+        }
+        LayoutElement::Svg { tree, .. } => {
+            collect_font_usage_from_svg(Some(tree), custom_fonts, usage);
         }
         _ => {}
     }
+}
+
+/// Collect custom-font glyph usage from SVG `<text>` nodes so that fonts used
+/// only inside SVGs are still subset, embedded, and registered.
+fn collect_font_usage_from_svg(
+    tree: Option<&crate::parser::svg::SvgTree>,
+    custom_fonts: &HashMap<String, TtfFont>,
+    usage: &mut BTreeMap<String, FontUsage>,
+) {
+    let Some(tree) = tree else {
+        return;
+    };
+    crate::render::svg_to_pdf::collect_svg_text_font_usage(
+        tree,
+        custom_fonts,
+        &mut |font_name, shaped| {
+            let font_usage = usage.entry(font_name.to_string()).or_default();
+            for glyph in shaped.glyphs {
+                font_usage.record_glyph(glyph.glyph_id, glyph.unicode);
+            }
+        },
+    );
 }
 
 fn collect_font_usage_from_lines(

--- a/src/render/pdf_fonts.rs
+++ b/src/render/pdf_fonts.rs
@@ -430,6 +430,7 @@ mod tests {
             border: LayoutBorder::default(),
             text_align: TextAlign::Left,
             vertical_align: VerticalAlign::Middle,
+            min_height: 0.0,
         }
     }
 

--- a/src/render/pdf_fonts.rs
+++ b/src/render/pdf_fonts.rs
@@ -990,6 +990,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let line = TextLine {
             runs: vec![run],

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -4,16 +4,29 @@ use crate::parser::svg::{
     PathCommand, SvgClipPathUnits, SvgGradientUnits, SvgLinearGradient, SvgNode, SvgPaint,
     SvgRadialGradient, SvgStyle, SvgTextAnchor, SvgTextContext, SvgTransform, SvgTree,
 };
-use crate::render::pdf::encode_pdf_text;
+use crate::parser::ttf::TtfFont;
+use crate::render::pdf::{encode_pdf_text, sanitize_pdf_name};
+use crate::render::pdf_fonts::{PreparedCustomFont, PreparedCustomFonts};
 use crate::render::shading::{ShadingEntry, push_axial_shading, push_radial_shading};
 use crate::render::svg_geometry::{
     SvgPlacementRequest, SvgViewportBox, compute_raster_placement, compute_svg_placement,
 };
 use crate::style::computed::{FontFamily, parse_font_stack};
+use std::collections::HashMap;
 use std::fmt::Write as _;
 
 pub(crate) trait SvgImageObjectSink {
     fn register_raster(&mut self, raw_image: &[u8]) -> Option<String>;
+}
+
+/// Custom fonts registered via `add_font`, made visible to SVG `<text>` rendering.
+///
+/// `prepared` carries the subset glyph remapping produced by
+/// `prepare_custom_fonts`; content streams must emit remapped glyph IDs.
+#[derive(Clone, Copy)]
+pub(crate) struct SvgFontContext<'a> {
+    pub custom_fonts: &'a HashMap<String, TtfFont>,
+    pub prepared: &'a PreparedCustomFonts,
 }
 
 pub(crate) struct SvgPdfResources<'a> {
@@ -21,6 +34,7 @@ pub(crate) struct SvgPdfResources<'a> {
     pub shading_counter: &'a mut usize,
     pub ext_gstates: Option<&'a mut Vec<(String, f32)>>,
     pub image_sink: Option<&'a mut dyn SvgImageObjectSink>,
+    pub fonts: Option<SvgFontContext<'a>>,
 }
 
 impl<'a> SvgPdfResources<'a> {
@@ -30,6 +44,7 @@ impl<'a> SvgPdfResources<'a> {
             shading_counter,
             ext_gstates: None,
             image_sink: None,
+            fonts: None,
         }
     }
 
@@ -476,6 +491,23 @@ fn render_node(
                 *font_italic,
                 text_ctx,
             );
+            // Prefer an add_font-registered face when the font stack names one;
+            // shaping must succeed for the custom path (glyph IDs + advances).
+            let font_ctx = resources.fonts;
+            let custom = font_ctx.and_then(|fonts| {
+                let (name, ttf) = resolve_svg_custom_font(
+                    style.font_family.as_deref(),
+                    style.font_bold,
+                    style.font_italic,
+                    font_family.as_deref(),
+                    *font_bold,
+                    *font_italic,
+                    text_ctx,
+                    fonts.custom_fonts,
+                )?;
+                let shaped = crate::text::shape_text_with_font(content, size, ttf)?;
+                Some((sanitize_pdf_name(name), ttf, shaped, fonts.prepared.get(name)))
+            });
             if let Some(clip_id) = clip_path.as_deref() {
                 out.push_str("q\n");
                 let (shadings, shading_counter) = resources.shading_state();
@@ -511,8 +543,13 @@ fn render_node(
             let text_x = match text_anchor {
                 SvgTextAnchor::Start => *x,
                 SvgTextAnchor::Middle | SvgTextAnchor::End => {
-                    let (ff, is_bold) = font_metrics_font(&font);
-                    let text_w = crate::fonts::str_width(content, size, &ff, is_bold);
+                    let text_w = match &custom {
+                        Some((_, _, shaped, _)) => shaped.width,
+                        None => {
+                            let (ff, is_bold) = font_metrics_font(&font);
+                            crate::fonts::str_width(content, size, &ff, is_bold)
+                        }
+                    };
                     if *text_anchor == SvgTextAnchor::Middle {
                         x - text_w * 0.5
                     } else {
@@ -521,8 +558,11 @@ fn render_node(
                 }
             };
 
+            let font_label = custom
+                .as_ref()
+                .map_or(font.as_str(), |(resource_name, ..)| resource_name.as_str());
             out.push_str("BT\n");
-            out.push_str(&format!("/{font} {size} Tf\n"));
+            out.push_str(&format!("/{font_label} {size} Tf\n"));
             out.push_str(&format!("{text_render_mode} Tr\n"));
             if let Some((r, g, b)) = fill {
                 out.push_str(&format!("{r} {g} {b} rg\n"));
@@ -532,8 +572,15 @@ fn render_node(
                 out.push_str(&format!("{} w\n", style.stroke_width));
             }
             out.push_str(&format!("1 0 0 -1 {text_x} {y} Tm\n"));
-            let encoded = encode_pdf_text(content);
-            out.push_str(&format!("({encoded}) Tj\n"));
+            match &custom {
+                Some((_, ttf, shaped, prepared)) => {
+                    emit_shaped_glyphs_tj(shaped, ttf, *prepared, size, out);
+                }
+                None => {
+                    let encoded = encode_pdf_text(content);
+                    out.push_str(&format!("({encoded}) Tj\n"));
+                }
+            }
             out.push_str("ET\n");
             if opacity_wrapped {
                 out.push_str("Q\n");
@@ -1194,7 +1241,10 @@ fn resolve_svg_text_font(
         .unwrap_or(text_ctx.font_italic);
 
     if let Some(base) = font_family.or(inherited_font_family) {
-        crate::fonts::pdf_font_name(base, bold, italic).to_string()
+        // `base` is the raw CSS family stack; map it to a base-14 family the
+        // same way the parser used to before resolution moved render-side.
+        let base = crate::parser::svg::resolve_svg_font_family(base);
+        crate::fonts::pdf_font_name(&base, bold, italic).to_string()
     } else if font_bold.is_some()
         || font_italic.is_some()
         || inherited_font_bold.is_some()
@@ -1215,6 +1265,156 @@ fn base_family_from_pdf_name(name: &str) -> &str {
         "Courier"
     } else {
         "Helvetica"
+    }
+}
+
+/// Emit a shaped glyph run as a TJ array with subset-remapped glyph IDs.
+///
+/// Kerning adjustments from shaping are carried as TJ advance adjustments
+/// (thousandths of text space), mirroring the HTML text path.
+fn emit_shaped_glyphs_tj(
+    shaped: &crate::text::ShapedRun,
+    ttf: &TtfFont,
+    prepared: Option<&PreparedCustomFont>,
+    font_size: f32,
+    out: &mut String,
+) {
+    out.push('[');
+    let mut first = true;
+    for glyph in &shaped.glyphs {
+        if !first {
+            out.push(' ');
+        }
+        first = false;
+        let glyph_id = prepared.map_or(glyph.glyph_id, |p| p.pdf_glyph_id(glyph.glyph_id));
+        let _ = write!(out, "<{glyph_id:04X}>");
+        let nominal_advance = ttf.glyph_width_scaled(glyph.glyph_id, font_size);
+        let advance_adjustment = glyph.x_advance - nominal_advance;
+        if advance_adjustment.abs() > 0.001 {
+            let tj = -(advance_adjustment * 1000.0 / font_size.max(f32::EPSILON));
+            let _ = write!(out, " {tj:.2}");
+        }
+    }
+    out.push_str("] TJ\n");
+}
+
+/// Resolve an SVG `<text>` element's font stack against `add_font`-registered
+/// custom fonts, honoring CSS fallback order.
+///
+/// Returns the registered font's key and face when the first resolvable family
+/// in the stack is a registered custom font. Returns `None` when the stack is
+/// absent, when a standard (base-14) family resolves first, or when no listed
+/// custom family is registered — callers then fall back to the base-14 path.
+fn resolve_svg_custom_font<'a>(
+    inherited_font_family: Option<&str>,
+    inherited_font_bold: Option<bool>,
+    inherited_font_italic: Option<bool>,
+    font_family: Option<&str>,
+    font_bold: Option<bool>,
+    font_italic: Option<bool>,
+    text_ctx: &SvgTextContext,
+    custom_fonts: &'a HashMap<String, TtfFont>,
+) -> Option<(&'a str, &'a TtfFont)> {
+    let bold = font_bold
+        .or(inherited_font_bold)
+        .unwrap_or(text_ctx.font_bold);
+    let italic = font_italic
+        .or(inherited_font_italic)
+        .unwrap_or(text_ctx.font_italic);
+    let stack_raw = font_family.or(inherited_font_family)?;
+    for family in parse_font_stack(stack_raw).families() {
+        match family {
+            FontFamily::Custom(name) => {
+                if let Some(hit) =
+                    crate::system_fonts::find_font(custom_fonts, name, bold, italic)
+                {
+                    return Some(hit);
+                }
+                // Unregistered custom name: try the next family in the stack.
+            }
+            // A standard family resolves immediately — base-14 wins from here.
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// Walk an SVG tree and report every `<text>` node that resolves to a custom
+/// font, shaped with that font. Used by `prepare_custom_fonts` so SVG glyphs
+/// are included in font subsets before page content is rendered.
+///
+/// Style inheritance mirrors `render_node` so collection and emission always
+/// agree on which font a text node uses.
+pub(crate) fn collect_svg_text_font_usage(
+    tree: &SvgTree,
+    custom_fonts: &HashMap<String, TtfFont>,
+    record: &mut dyn FnMut(&str, crate::text::ShapedRun),
+) {
+    let root_style = ResolvedStyle {
+        color: tree.text_ctx.color,
+        fill: SvgPaint::Color((0.0, 0.0, 0.0)),
+        stroke: SvgPaint::None,
+        clip_path: None,
+        stroke_width: 1.0,
+        font_family: None,
+        font_bold: None,
+        font_italic: None,
+        opacity: 1.0,
+    };
+    for node in &tree.children {
+        collect_text_usage_node(node, &root_style, &tree.text_ctx, custom_fonts, record);
+    }
+}
+
+fn collect_text_usage_node(
+    node: &SvgNode,
+    inherited: &ResolvedStyle,
+    text_ctx: &SvgTextContext,
+    custom_fonts: &HashMap<String, TtfFont>,
+    record: &mut dyn FnMut(&str, crate::text::ShapedRun),
+) {
+    match node {
+        SvgNode::Group {
+            children, style, ..
+        } => {
+            let resolved = resolve_style(inherited.clone(), style);
+            for child in children {
+                collect_text_usage_node(child, &resolved, text_ctx, custom_fonts, record);
+            }
+        }
+        SvgNode::Text {
+            font_size,
+            font_size_attr,
+            font_family,
+            font_bold,
+            font_italic,
+            content,
+            style,
+            ..
+        } => {
+            let style = resolve_style(inherited.clone(), style);
+            let size = font_size_attr
+                .as_deref()
+                .and_then(|raw| resolve_svg_font_size(raw, text_ctx.font_size))
+                .or(*font_size)
+                .unwrap_or(text_ctx.font_size);
+            let Some((name, ttf)) = resolve_svg_custom_font(
+                style.font_family.as_deref(),
+                style.font_bold,
+                style.font_italic,
+                font_family.as_deref(),
+                *font_bold,
+                *font_italic,
+                text_ctx,
+                custom_fonts,
+            ) else {
+                return;
+            };
+            if let Some(shaped) = crate::text::shape_text_with_font(content, size, ttf) {
+                record(name, shaped);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -2765,6 +2965,7 @@ mod tests {
             shading_counter: &mut shading_counter,
             ext_gstates: None,
             image_sink: Some(&mut image_sink),
+            fonts: None,
         };
 
         render_svg_tree_with_resources(&tree, &mut out, &mut resources);

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -466,6 +466,7 @@ fn render_node(
             font_family,
             font_bold,
             font_italic,
+            letter_spacing,
             text_anchor,
             content,
             style,
@@ -539,15 +540,25 @@ fn render_node(
                 (false, false) => 3,
             };
 
+            // letter-spacing adds a constant advance between glyphs; it is
+            // painted via the Tc operator and included in anchor width math.
+            let letter_spacing = letter_spacing.unwrap_or(0.0);
+            let spacing_gaps = |glyph_count: usize| -> f32 {
+                letter_spacing * glyph_count.saturating_sub(1) as f32
+            };
+
             // Adjust x for text-anchor
             let text_x = match text_anchor {
                 SvgTextAnchor::Start => *x,
                 SvgTextAnchor::Middle | SvgTextAnchor::End => {
                     let text_w = match &custom {
-                        Some((_, _, shaped, _)) => shaped.width,
+                        Some((_, _, shaped, _)) => {
+                            shaped.width + spacing_gaps(shaped.glyphs.len())
+                        }
                         None => {
                             let (ff, is_bold) = font_metrics_font(&font);
                             crate::fonts::str_width(content, size, &ff, is_bold)
+                                + spacing_gaps(content.chars().count())
                         }
                     };
                     if *text_anchor == SvgTextAnchor::Middle {
@@ -563,6 +574,9 @@ fn render_node(
                 .map_or(font.as_str(), |(resource_name, ..)| resource_name.as_str());
             out.push_str("BT\n");
             out.push_str(&format!("/{font_label} {size} Tf\n"));
+            if letter_spacing != 0.0 {
+                out.push_str(&format!("{letter_spacing} Tc\n"));
+            }
             out.push_str(&format!("{text_render_mode} Tr\n"));
             if let Some((r, g, b)) = fill {
                 out.push_str(&format!("{r} {g} {b} rg\n"));
@@ -580,6 +594,11 @@ fn render_node(
                     let encoded = encode_pdf_text(content);
                     out.push_str(&format!("({encoded}) Tj\n"));
                 }
+            }
+            if letter_spacing != 0.0 {
+                // Character spacing survives ET; reset so later text on the
+                // same content stream is unaffected.
+                out.push_str("0 Tc\n");
             }
             out.push_str("ET\n");
             if opacity_wrapped {
@@ -2067,6 +2086,7 @@ mod tests {
             font_family: Some("Helvetica".to_string()),
             font_bold: Some(false),
             font_italic: Some(false),
+            letter_spacing: None,
             text_anchor: SvgTextAnchor::Start,
             content: text.to_string(),
             style: SvgStyle {
@@ -3153,6 +3173,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3206,6 +3227,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3263,6 +3285,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle::default(),
@@ -3301,6 +3324,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3349,6 +3373,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3403,6 +3428,7 @@ mod tests {
                     font_family: None,
                     font_bold: None,
                     font_italic: None,
+                    letter_spacing: None,
                     text_anchor: SvgTextAnchor::Start,
                     content: "Hello".to_string(),
                     style: SvgStyle {
@@ -3442,6 +3468,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3493,6 +3520,7 @@ mod tests {
                     font_family: None,
                     font_bold: None,
                     font_italic: None,
+                    letter_spacing: None,
                     text_anchor: SvgTextAnchor::Start,
                     content: "Hello".to_string(),
                     style: SvgStyle {
@@ -3532,6 +3560,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle::default(),

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -3306,29 +3306,8 @@ fn parse_border_shorthand(k: &str) -> (f32, Option<Color>, BorderStyle) {
     let mut width = 0.0f32;
     let mut border_style = BorderStyle::Solid;
     for part in &parts {
-        if let Some(n) = part.strip_suffix("px") {
-            if let Ok(v) = n.parse::<f32>() {
-                width = v * 0.75; // px to pt
-            }
-        } else if let Some(n) = part.strip_suffix("pt") {
-            if let Ok(v) = n.parse::<f32>() {
-                width = v;
-            }
-        } else if let Some(n) = part.strip_suffix("mm") {
-            // Absolute physical units resolve straight to points (1in = 72pt).
-            // Without these, `mm`/`cm`/`in` border widths silently became
-            // 0-width and the border vanished — print/A4 layouts use mm grids.
-            if let Ok(v) = n.parse::<f32>() {
-                width = v * 72.0 / 25.4;
-            }
-        } else if let Some(n) = part.strip_suffix("cm") {
-            if let Ok(v) = n.parse::<f32>() {
-                width = v * 72.0 / 2.54;
-            }
-        } else if let Some(n) = part.strip_suffix("in") {
-            if let Ok(v) = n.parse::<f32>() {
-                width = v * 72.0;
-            }
+        if let Some(points) = crate::parser::css::absolute_length_unit_to_points(part) {
+            width = points;
         } else {
             match *part {
                 "dashed" => border_style = BorderStyle::Dashed,
@@ -3878,6 +3857,22 @@ mod tests {
         assert_eq!(c.r, 0);
         assert_eq!(c.g, 128);
         assert_eq!(c.b, 0);
+    }
+
+    #[test]
+    fn border_shorthand_physical_units_match_parse_length() {
+        let parent = ComputedStyle::default();
+        for (css, expected) in [
+            ("border: 25.4mm solid black", 72.0),
+            ("border: 2.54cm solid black", 72.0),
+            ("border: 1in solid black", 72.0),
+        ] {
+            let style = compute_style(HtmlTag::Div, Some(css), &parent);
+            assert!(
+                (style.border.top.width - expected).abs() < 0.01,
+                "{css} should resolve to {expected}pt"
+            );
+        }
     }
 
     #[test]

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -594,6 +594,10 @@ pub struct ComputedStyle {
     pub line_height: f32,
     pub page_break_before: bool,
     pub page_break_after: bool,
+    /// `page-break-inside: avoid` / `break-inside: avoid` — the block must not
+    /// be split by a page break: when it doesn't fit in the remaining page
+    /// space it moves to the next page as a whole.
+    pub page_break_inside_avoid: bool,
     pub border: BorderSides,
     pub display: Display,
     pub width: Option<f32>,
@@ -696,6 +700,7 @@ impl Default for ComputedStyle {
             line_height: f32::NAN,
             page_break_before: false,
             page_break_after: false,
+            page_break_inside_avoid: false,
             border: BorderSides::default(),
             display: Display::Block,
             width: None,
@@ -934,6 +939,8 @@ pub fn compute_style_with_context(
     style.z_index = 0;
     style.row_gap = 0.0;
     style.blur_radius = 0.0;
+    // CSS break properties do not inherit.
+    style.page_break_inside_avoid = false;
     // custom_properties inherit from parent (already cloned)
 
     // Apply tag defaults
@@ -1775,6 +1782,13 @@ pub(crate) fn apply_style_map(style: &mut ComputedStyle, map: &StyleMap, parent:
     }
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "page-break-after") {
         style.page_break_after = k == "always";
+    }
+    if let Some(CssValue::Keyword(k)) = get_non_special(map, "page-break-inside") {
+        style.page_break_inside_avoid = k == "avoid";
+    }
+    // Modern alias: `break-inside: avoid | avoid-page` (CSS Fragmentation L3).
+    if let Some(CssValue::Keyword(k)) = get_non_special(map, "break-inside") {
+        style.page_break_inside_avoid = k == "avoid" || k == "avoid-page";
     }
 
     if let Some(CssValue::Keyword(k)) = get_non_special(map, "filter") {

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -3314,6 +3314,21 @@ fn parse_border_shorthand(k: &str) -> (f32, Option<Color>, BorderStyle) {
             if let Ok(v) = n.parse::<f32>() {
                 width = v;
             }
+        } else if let Some(n) = part.strip_suffix("mm") {
+            // Absolute physical units resolve straight to points (1in = 72pt).
+            // Without these, `mm`/`cm`/`in` border widths silently became
+            // 0-width and the border vanished — print/A4 layouts use mm grids.
+            if let Ok(v) = n.parse::<f32>() {
+                width = v * 72.0 / 25.4;
+            }
+        } else if let Some(n) = part.strip_suffix("cm") {
+            if let Ok(v) = n.parse::<f32>() {
+                width = v * 72.0 / 2.54;
+            }
+        } else if let Some(n) = part.strip_suffix("in") {
+            if let Ok(v) = n.parse::<f32>() {
+                width = v * 72.0;
+            }
         } else {
             match *part {
                 "dashed" => border_style = BorderStyle::Dashed,

--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -269,8 +269,7 @@ pub(crate) fn load_unicode_fallback_font(fonts: &mut HashMap<String, TtfFont>) {
 
     for family in UNICODE_FALLBACK_FAMILIES {
         let query = SystemFontQuery::new(family, FontVariant::new(false, false));
-        if let Some(font) = query_fontdb_font(db, &query).or_else(|| query_fontconfig_font(&query))
-        {
+        if let Some(font) = load_system_font_cached(db, &query) {
             fonts.insert(UNICODE_FALLBACK_KEY.to_string(), font);
             return;
         }
@@ -296,7 +295,7 @@ pub(crate) fn load_unicode_fallback_font(fonts: &mut HashMap<String, TtfFont>) {
 #[cfg(feature = "wasm")]
 fn load_bundled_cjk_font(fonts: &mut HashMap<String, TtfFont>) {
     static CJK_SUBSET_DATA: &[u8] = include_bytes!("../assets/NotoSansCJK-Subset.ttf");
-    if let Ok(font) = crate::parser::ttf::parse_ttf(CJK_SUBSET_DATA.to_vec()) {
+    if let Some(font) = crate::parser::ttf::parse_ttf_cached(CJK_SUBSET_DATA) {
         fonts.insert(UNICODE_FALLBACK_KEY.to_string(), font);
     }
 }
@@ -322,8 +321,7 @@ pub(crate) fn load_emoji_fallback_font(fonts: &mut HashMap<String, TtfFont>) {
     let db = system_fontdb();
     for family in EMOJI_FALLBACK_FAMILIES {
         let query = SystemFontQuery::new(family, FontVariant::new(false, false));
-        if let Some(font) = query_fontdb_font(db, &query).or_else(|| query_fontconfig_font(&query))
-        {
+        if let Some(font) = load_system_font_cached(db, &query) {
             fonts.insert(EMOJI_FALLBACK_KEY.to_string(), font);
             return;
         }
@@ -336,7 +334,7 @@ pub(crate) fn load_emoji_fallback_font(fonts: &mut HashMap<String, TtfFont>) {
 fn load_bundled_emoji_font(fonts: &mut HashMap<String, TtfFont>) {
     static NOTO_EMOJI_DATA: &[u8] = include_bytes!("../assets/NotoEmoji-Regular.ttf");
 
-    if let Ok(font) = crate::parser::ttf::parse_ttf(NOTO_EMOJI_DATA.to_vec()) {
+    if let Some(font) = crate::parser::ttf::parse_ttf_cached(NOTO_EMOJI_DATA) {
         fonts.insert(EMOJI_FALLBACK_KEY.to_string(), font);
     }
 }
@@ -436,6 +434,37 @@ fn system_fontdb() -> &'static fontdb::Database {
     })
 }
 
+/// Process-global cache of resolved system fonts keyed by variant key
+/// (family + bold/italic). Resolving a system font walks the (already cached)
+/// fontdb and parses the matched face; both steps are deterministic per
+/// process, so memoizing avoids re-querying and re-parsing ~12 system faces
+/// plus the CJK/emoji fallbacks on every render. `None` results are cached too
+/// (negative cache) so absent families aren't looked up repeatedly.
+static SYSTEM_FONT_RESOLUTION_CACHE: std::sync::OnceLock<
+    std::sync::RwLock<HashMap<String, Option<TtfFont>>>,
+> = std::sync::OnceLock::new();
+
+fn system_font_resolution_cache() -> &'static std::sync::RwLock<HashMap<String, Option<TtfFont>>> {
+    SYSTEM_FONT_RESOLUTION_CACHE.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+/// Memoized wrapper over [`load_system_font`]. The variant key fully determines
+/// resolution behavior (including the ui-sans-serif preference path), so the
+/// cached value is always identical to a fresh `load_system_font` call.
+fn load_system_font_cached(db: &fontdb::Database, query: &SystemFontQuery<'_>) -> Option<TtfFont> {
+    let key = query.variant_key();
+    if let Ok(cache) = system_font_resolution_cache().read() {
+        if let Some(cached) = cache.get(&key) {
+            return cached.clone();
+        }
+    }
+    let result = load_system_font(db, query);
+    if let Ok(mut cache) = system_font_resolution_cache().write() {
+        cache.entry(key).or_insert_with(|| result.clone());
+    }
+    result
+}
+
 fn parse_all_bundled_fonts() -> Vec<(String, TtfFont)> {
     let mut result = Vec::new();
     for bundled in LIBERATION_FONTS {
@@ -470,9 +499,7 @@ pub(crate) fn load_system_default_fonts(fonts: &mut HashMap<String, TtfFont>) {
             if fonts.contains_key(&key) {
                 continue;
             }
-            if let Some(font) =
-                query_fontdb_font(db, &query).or_else(|| query_fontconfig_font(&query))
-            {
+            if let Some(font) = load_system_font_cached(db, &query) {
                 fonts.insert(key, font);
             }
         }
@@ -559,7 +586,7 @@ fn load_family_variants(db: &fontdb::Database, family: &str, fonts: &mut HashMap
         match fonts.entry(query.variant_key()) {
             Entry::Occupied(_) => {}
             Entry::Vacant(slot) => {
-                let Some(font) = load_system_font(db, &query) else {
+                let Some(font) = load_system_font_cached(db, &query) else {
                     continue;
                 };
                 slot.insert(font);

--- a/src/text.rs
+++ b/src/text.rs
@@ -426,6 +426,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         assert!(shape_text_run(&run, &fonts).is_none());
     }
@@ -447,6 +450,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         assert!(shape_text_run(&run, &fonts).is_none());
     }
@@ -546,6 +552,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let result = shape_text_run(&run, &fonts);
         let shaped = result.expect("shape_text_run must return Some for a found font");
@@ -574,6 +583,9 @@ mod tests {
             background_color: None,
             padding: (0.0, 0.0),
             border_radius: 0.0,
+            box_width: None,
+            box_height: None,
+            border_bottom: None,
         };
         let shaped = shape_text_run(&run, &fonts).expect("empty text still returns Some");
         assert_eq!(shaped.width, 0.0);

--- a/src/text.rs
+++ b/src/text.rs
@@ -2,6 +2,7 @@ use crate::layout::engine::TextRun;
 use crate::parser::ttf::TtfFont;
 use crate::style::computed::FontFamily;
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, OnceLock, RwLock};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ShapedGlyph {
@@ -168,6 +169,54 @@ pub(crate) fn split_run_by_font_coverage(
     segments
 }
 
+/// A `rustybuzz::Face` kept for the whole process. Building a face parses the
+/// font's shaping tables; doing it on every shaped run (layout measures then
+/// paint re-shapes, thousands of times per document) is the dominant text cost.
+///
+/// SAFETY: the face is an immutable, read-only view — shaping borrows it by
+/// shared reference and never mutates it — so sharing `&SharedFace` across
+/// threads is sound. Its `'static` byte view is backed by a leaked Arc
+/// ref-count (see [`face_for_font`]) that pins the font buffer for the process.
+struct SharedFace(rustybuzz::Face<'static>);
+// SAFETY: see the type doc — read-only, bytes pinned for 'static.
+unsafe impl Send for SharedFace {}
+unsafe impl Sync for SharedFace {}
+
+/// Process-global cache of shaping faces keyed by the font's shared byte-buffer
+/// address (`Arc<Vec<u8>>` inner pointer). All clones of a cached font share one
+/// Arc, so the key is stable; the first shape of a font leaks one Arc ref-count
+/// to pin that buffer for the process, so the address is never reused and the
+/// `'static` face view stays valid. `None` is cached for un-parseable fonts.
+type FaceCache = HashMap<usize, Option<Arc<SharedFace>>>;
+static FACE_CACHE: OnceLock<RwLock<FaceCache>> = OnceLock::new();
+
+fn face_cache() -> &'static RwLock<FaceCache> {
+    FACE_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Return a cached shaping face for `font`, building (and caching) it on first
+/// use. Identical bytes to `rustybuzz::Face::from_slice(&font.data, 0)`, so
+/// shaping results are unchanged.
+fn face_for_font(font: &TtfFont) -> Option<Arc<SharedFace>> {
+    let key = Arc::as_ptr(&font.data) as usize;
+    if let Ok(cache) = face_cache().read() {
+        if let Some(entry) = cache.get(&key) {
+            return entry.clone();
+        }
+    }
+    // Miss: leak one Arc ref-count so the byte buffer lives for the whole
+    // process, then take a 'static view of it to build the face.
+    let arc = font.data.clone();
+    let buf: &Vec<u8> = &arc;
+    let bytes: &'static [u8] = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
+    std::mem::forget(arc);
+    let face = rustybuzz::Face::from_slice(bytes, 0).map(|f| Arc::new(SharedFace(f)));
+    if let Ok(mut cache) = face_cache().write() {
+        cache.entry(key).or_insert_with(|| face.clone());
+    }
+    face
+}
+
 pub(crate) fn shape_text_with_font(text: &str, font_size: f32, font: &TtfFont) -> Option<ShapedRun> {
     if text.is_empty() {
         return Some(ShapedRun {
@@ -176,7 +225,8 @@ pub(crate) fn shape_text_with_font(text: &str, font_size: f32, font: &TtfFont) -
         });
     }
 
-    let face = rustybuzz::Face::from_slice(&font.data, 0)?;
+    let shared = face_for_font(font)?;
+    let face = &shared.0;
     let units_per_em = (face.units_per_em() as f32).max(1.0);
     let scale = font_size / units_per_em;
 
@@ -184,7 +234,7 @@ pub(crate) fn shape_text_with_font(text: &str, font_size: f32, font: &TtfFont) -
     buffer.push_str(text);
     buffer.guess_segment_properties();
 
-    let shaped = rustybuzz::shape(&face, &[], buffer);
+    let shaped = rustybuzz::shape(face, &[], buffer);
     let infos = shaped.glyph_infos();
     let positions = shaped.glyph_positions();
     if infos.len() != positions.len() {

--- a/src/text.rs
+++ b/src/text.rs
@@ -168,7 +168,7 @@ pub(crate) fn split_run_by_font_coverage(
     segments
 }
 
-fn shape_text_with_font(text: &str, font_size: f32, font: &TtfFont) -> Option<ShapedRun> {
+pub(crate) fn shape_text_with_font(text: &str, font_size: f32, font: &TtfFont) -> Option<ShapedRun> {
     if text.is_empty() {
         return Some(ShapedRun {
             glyphs: Vec::new(),


### PR DESCRIPTION
This PR extends layout/rendering to better support form-like inline-block boxes within table text (explicit width/height and underline), improves table row height calculation to respect CSS height/min-height floors, and fixes several unit/image handling gaps for PDF output.

Changes:

- Add atomic inline-block “box” support on TextRun (width/height and bottom border) and render it as a rectangle + bottom rule in PDF.
- Respect CSS height/min-height for table rows/cells via min_height and table_cell_box_height, including distributing surplus to fill fixed-height tables.
- Improve CSS unit parsing for mm/cm/in, fix PNG embedding by storing full PNG bytes and decoding correctly for PDF, and handle positioned Container during pagination.

Verification:

- `cargo test --lib` (2191 passed, 0 failed, 3 ignored)
- `cargo clippy --lib` (passes with the existing `too_many_arguments` warning in `src/render/svg_to_pdf.rs`)

Notes:

- Full `cargo test` still hits a pre-existing stack overflow in `tests/proptest_properties.rs::nested_html_no_stack_overflow`, reproduced on the unmodified PR head.
- Strict all-target clippy remains blocked by pre-existing warnings outside this patch.