### PR TITLE
Fix <center> and unknown tags silently dropping their content

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2598,6 +2598,87 @@ mod tests {
         );
     }
 
+    fn collect_text(elements: &[LayoutElement]) -> String {
+        let mut out = String::new();
+        for el in elements {
+            match el {
+                LayoutElement::TextBlock { lines, .. } => {
+                    for l in lines {
+                        for r in &l.runs {
+                            out.push_str(&r.text);
+                        }
+                    }
+                }
+                LayoutElement::TableRow { cells, .. } => {
+                    for c in cells {
+                        for l in &c.lines {
+                            for r in &l.runs {
+                                out.push_str(&r.text);
+                            }
+                        }
+                        out.push_str(&collect_text(&c.nested_rows));
+                    }
+                }
+                _ => {}
+            }
+        }
+        out
+    }
+
+    fn page_text(pages: &[Page]) -> String {
+        pages
+            .iter()
+            .map(|p| {
+                let els: Vec<LayoutElement> = p.elements.iter().map(|(_, e)| e.clone()).collect();
+                collect_text(&els)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn layout_center_inside_table_cell_keeps_content() {
+        let html = "<table><tr><td><center><p>hello cell</p></center></td></tr></table>";
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let text = page_text(&pages);
+        assert!(
+            text.contains("hello cell"),
+            "content inside <center> in a <td> must not be dropped, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn layout_center_at_body_level_centers_text() {
+        let html = "<center><p>centered text</p></center>";
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let text = page_text(&pages);
+        assert!(
+            text.contains("centered text"),
+            "content inside <center> must render, got: {text:?}"
+        );
+        let centered = pages.iter().any(|p| {
+            p.elements.iter().any(|(_, e)| {
+                matches!(e, LayoutElement::TextBlock { text_align, lines, .. }
+                    if *text_align == TextAlign::Center
+                        && lines.iter().any(|l| l.runs.iter().any(|r| r.text.contains("centered"))))
+            })
+        });
+        assert!(centered, "<center> content must be center-aligned");
+    }
+
+    #[test]
+    fn layout_unknown_tag_content_not_dropped_in_table_cell() {
+        let html = "<table><tr><td><whatever><p>survives</p></whatever></td></tr></table>";
+        let nodes = parse_html(html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let text = page_text(&pages);
+        assert!(
+            text.contains("survives"),
+            "unknown-tag content in a <td> must not be dropped, got: {text:?}"
+        );
+    }
+
     #[test]
     fn base64_decode_basic() {
         // "Hello" in base64 is "SGVsbG8="

--- a/src/layout/helpers.rs
+++ b/src/layout/helpers.rs
@@ -215,6 +215,20 @@ pub(crate) fn recurses_as_layout_child(tag: HtmlTag) -> bool {
     tag.is_block() || tag == HtmlTag::Svg
 }
 
+/// True when the element itself, or anything in its subtree, requires
+/// element-level layout (block or svg). Inline wrappers (including unknown
+/// tags, which default to inline) must not hide block descendants from the
+/// table-cell recursion decision.
+pub(crate) fn subtree_recurses_as_layout_child(el: &crate::parser::dom::ElementNode) -> bool {
+    if recurses_as_layout_child(el.tag) {
+        return true;
+    }
+    el.children.iter().any(|c| match c {
+        crate::parser::dom::DomNode::Element(e) => subtree_recurses_as_layout_child(e),
+        _ => false,
+    })
+}
+
 pub(crate) fn collects_as_inline_text(tag: HtmlTag) -> bool {
     tag != HtmlTag::Svg && tag.is_inline()
 }

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use super::context::{LayoutContext, LayoutEnv, ParentBox, Viewport};
 use super::engine::{
     CounterState, LayoutBorder, LayoutElement, TextLine, TextRun, collects_as_inline_text,
-    flatten_element, has_background_paint, recurses_as_layout_child,
+    flatten_element, has_background_paint, subtree_recurses_as_layout_child,
 };
 use super::paginate::{estimate_element_height, table_row_content_width};
 use super::text::{
@@ -705,7 +705,7 @@ pub(crate) fn flatten_table(
                         let mut runs = Vec::new();
                         let mut nested_rows = Vec::new();
                         let recurse_descendants = cell_el.children.iter().any(
-                            |node| matches!(node, DomNode::Element(e) if recurses_as_layout_child(e.tag)),
+                            |node| matches!(node, DomNode::Element(e) if subtree_recurses_as_layout_child(e)),
                         );
                         let mut text_ancestors = cell_sizing_ctx.ancestors.clone();
                         text_ancestors.push(AncestorInfo {
@@ -966,10 +966,9 @@ pub(crate) fn flatten_table(
 
             let mut runs = Vec::new();
             let mut nested_rows = Vec::new();
-            let recurse_descendants = cell_el
-                .children
-                .iter()
-                .any(|node| matches!(node, DomNode::Element(e) if recurses_as_layout_child(e.tag)));
+            let recurse_descendants = cell_el.children.iter().any(
+                |node| matches!(node, DomNode::Element(e) if subtree_recurses_as_layout_child(e)),
+            );
             let mut text_ancestors = cell_selector_ctx.ancestors.clone();
             text_ancestors.push(AncestorInfo {
                 element: cell_el,

--- a/src/parser/dom.rs
+++ b/src/parser/dom.rs
@@ -72,6 +72,7 @@ pub enum HtmlTag {
     Audio,
     Progress,
     Meter,
+    Center,
     Unknown,
 }
 
@@ -147,6 +148,7 @@ impl HtmlTag {
             "audio" => Self::Audio,
             "progress" => Self::Progress,
             "meter" => Self::Meter,
+            "center" => Self::Center,
             _ => Self::Unknown,
         }
     }
@@ -193,6 +195,7 @@ impl HtmlTag {
                 | Self::Summary
                 | Self::Video
                 | Self::Textarea
+                | Self::Center
         )
     }
 
@@ -223,6 +226,10 @@ impl HtmlTag {
                 | Self::Audio
                 | Self::Progress
                 | Self::Meter
+                // Browsers treat unrecognized elements as inline; classifying
+                // them as neither block nor inline made layout drop their
+                // entire subtree (silent content loss).
+                | Self::Unknown
         )
     }
 }
@@ -350,6 +357,7 @@ impl ElementNode {
             HtmlTag::Audio => "audio",
             HtmlTag::Progress => "progress",
             HtmlTag::Meter => "meter",
+            HtmlTag::Center => "center",
             HtmlTag::Unknown => "unknown",
         }
     }

--- a/src/style/defaults.rs
+++ b/src/style/defaults.rs
@@ -108,6 +108,9 @@ pub fn default_style(tag: HtmlTag) -> StyleMap {
             style.set("padding-left", CssValue::Length(0.75));
             style.set("font-weight", CssValue::Keyword("bold".into()));
         }
+        HtmlTag::Center => {
+            style.set("text-align", CssValue::Keyword("center".into()));
+        }
         HtmlTag::Blockquote => {
             style.set("margin-top", CssValue::Length(8.0));
             style.set("margin-bottom", CssValue::Length(8.0));


### PR DESCRIPTION
## Problem

Real-world HTML (legacy email/voucher templates) commonly wraps table-cell content in `<center>`. `HtmlTag` has no `Center` variant, so `<center>` parses as `Unknown` — which is classified neither block nor inline — and table-cell collection drops the element **with its entire subtree**. A document whose content lives inside `<td><center>…</center></td>` produces a structurally valid, completely blank one-page PDF with exit code 0.

Minimal repro (renders blank on v1.4.3 and current main):

```html
<table><tr><td><center><p>hello</p></center></td></tr></table>
```

The same applies to any unrecognized tag wrapping content in a cell.

## Fix

- Add `HtmlTag::Center` as a block tag with a `text-align: center` UA default, per the HTML rendering spec for the legacy element.
- Classify `Unknown` tags as **inline**, matching browser behavior for unrecognized elements, so their children still lay out instead of being silently discarded.
- Make the table-cell recursion probe (`recurse_descendants`) look through inline wrappers for block descendants — previously a block child hidden inside an inline/unknown wrapper was invisible to the recurse decision and its content was dropped.

## Tests

Three new layout tests (center-in-cell content survives, body-level `<center>` centers, unknown-tag-in-cell content survives). Full suite: 2256 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)