### PR TITLE
Render images inside block containers and table cells

### DIFF
--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -15,6 +15,7 @@ use super::helpers::{
     collects_as_inline_text, has_background_paint, heading_level,
     patch_absolute_children_containing_block, pseudo_is_block_like, push_block_pseudo,
     recurses_as_layout_child, resolve_abs_containing_block, resolve_padding_box_height,
+    subtree_contains_img,
 };
 use super::inline::{
     element_has_css_display_block, element_is_inline_block, layout_inline_block_group,
@@ -483,7 +484,10 @@ pub(crate) fn layout_block_element(
                 matches!(c, DomNode::Element(e)
                     if (has_own_margins(e.tag)
                         || (e.tag.is_block() && !collects_as_inline_text(e.tag))
-                        || element_has_css_display_block(e, style, env.rules, child_ancestors))
+                        || element_has_css_display_block(e, style, env.rules, child_ancestors)
+                        // Image-bearing children must go through element
+                        // layout — text-run collection would drop the image.
+                        || subtree_contains_img(e))
                         && !element_is_inline_block(
                             e, style, env.rules, child_ancestors, 0, 0, &[]))
             });
@@ -651,7 +655,7 @@ pub(crate) fn layout_block_element(
                         );
                     }
                     DomNode::Element(child_el)
-                        if (child_el.tag.is_block()
+                        if ((child_el.tag.is_block()
                             || child_el.tag == HtmlTag::Svg
                             || element_has_css_display_block(
                                 child_el,
@@ -659,7 +663,8 @@ pub(crate) fn layout_block_element(
                                 env.rules,
                                 child_ancestors,
                             ))
-                            && !collects_as_inline_text(child_el.tag) =>
+                            && !collects_as_inline_text(child_el.tag))
+                            || subtree_contains_img(child_el) =>
                     {
                         // Flush inline runs before block child
                         flush_runs(
@@ -888,29 +893,99 @@ pub(crate) fn layout_block_element(
                                 child_ancestors,
                             ) =>
                     {
-                        collect_text_runs(
-                            std::slice::from_ref(child),
-                            style,
-                            &mut runs,
-                            None,
-                            env.rules,
-                            env.fonts,
-                            child_ancestors,
-                        );
+                        if subtree_contains_img(child_el) {
+                            // Text-run collection drops images; lay the
+                            // subtree out as elements instead.
+                            flush_runs(
+                                &mut runs,
+                                inner_width,
+                                style,
+                                available_width,
+                                block_w,
+                                effective_height,
+                                auto_offset_left,
+                                el,
+                                output,
+                                env.fonts,
+                            );
+                            flatten_element(
+                                child_el,
+                                style,
+                                &ctx.with_parent(
+                                    inner_width,
+                                    Some(available_height),
+                                    style.font_size,
+                                )
+                                .with_containing_block(None),
+                                output,
+                                None,
+                                child_ancestors,
+                                positioned_depth,
+                                0,
+                                0,
+                                &[],
+                                env,
+                            );
+                        } else {
+                            collect_text_runs(
+                                std::slice::from_ref(child),
+                                style,
+                                &mut runs,
+                                None,
+                                env.rules,
+                                env.fonts,
+                                child_ancestors,
+                            );
+                        }
                     }
                     _ => {} // Block children handled by needs_wrapper
                 }
             }
         } else {
-            collect_text_runs(
-                &el.children,
-                style,
-                &mut runs,
-                None,
-                env.rules,
-                env.fonts,
-                child_ancestors,
-            );
+            for child in &el.children {
+                if let DomNode::Element(child_el) = child
+                    && subtree_contains_img(child_el)
+                {
+                    // Text-run collection drops images; lay the subtree out
+                    // as elements instead.
+                    flush_runs(
+                        &mut runs,
+                        inner_width,
+                        style,
+                        available_width,
+                        block_w,
+                        effective_height,
+                        auto_offset_left,
+                        el,
+                        output,
+                        env.fonts,
+                    );
+                    flatten_element(
+                        child_el,
+                        style,
+                        &ctx.with_parent(inner_width, Some(available_height), style.font_size)
+                            .with_containing_block(None),
+                        output,
+                        None,
+                        child_ancestors,
+                        positioned_depth,
+                        0,
+                        0,
+                        &[],
+                        env,
+                    );
+                } else {
+                    collect_text_runs(
+                        std::slice::from_ref(child),
+                        style,
+                        &mut runs,
+                        None,
+                        env.rules,
+                        env.fonts,
+                        child_ancestors,
+                    );
+                }
+            }
         }
     }
     if !skip_inline_collection {

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2598,6 +2598,102 @@ mod tests {
         );
     }
 
+    /// Recursively count Image elements, descending into table cells.
+    fn count_images(elements: &[LayoutElement]) -> usize {
+        elements
+            .iter()
+            .map(|el| match el {
+                LayoutElement::Image { .. } => 1,
+                LayoutElement::TableRow { cells, .. } => cells
+                    .iter()
+                    .map(|c| count_images(&c.nested_rows))
+                    .sum::<usize>(),
+                _ => 0,
+            })
+            .sum()
+    }
+
+    fn page_images(pages: &[Page]) -> usize {
+        pages
+            .iter()
+            .map(|p| {
+                let els: Vec<LayoutElement> = p.elements.iter().map(|(_, e)| e.clone()).collect();
+                count_images(&els)
+            })
+            .sum()
+    }
+
+    #[test]
+    fn layout_image_inside_div_renders() {
+        let html =
+            format!(r#"<div><img src="{TEST_JPEG_DATA_URI}" width="100" height="80"></div>"#);
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(
+            page_images(&pages),
+            1,
+            "img inside <div> must produce an Image element"
+        );
+    }
+
+    #[test]
+    fn layout_image_inside_paragraph_renders() {
+        let html = format!(
+            r#"<p>before <img src="{TEST_JPEG_DATA_URI}" width="100" height="80"> after</p>"#
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(
+            page_images(&pages),
+            1,
+            "img inside <p> must produce an Image element"
+        );
+    }
+
+    #[test]
+    fn layout_image_inside_span_inside_div_renders() {
+        let html = format!(
+            r#"<div><span><img src="{TEST_JPEG_DATA_URI}" width="100" height="80"></span></div>"#
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(
+            page_images(&pages),
+            1,
+            "img inside <span> inside <div> must produce an Image element"
+        );
+    }
+
+    #[test]
+    fn layout_image_inside_table_cell_renders() {
+        let html = format!(
+            r#"<table><tr><td><img src="{TEST_JPEG_DATA_URI}" width="100" height="80"></td></tr></table>"#
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(
+            page_images(&pages),
+            1,
+            "img inside <td> must produce an Image element"
+        );
+    }
+
+    #[test]
+    fn layout_image_inside_styled_div_in_table_cell_renders() {
+        // Legacy template shape: table cell wrapping a styled div wrapping
+        // an image.
+        let html = format!(
+            r#"<table><tr><td style="text-align:center"><div><img src="{TEST_JPEG_DATA_URI}" width="100" height="80"></div></td></tr></table>"#
+        );
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        assert_eq!(
+            page_images(&pages),
+            1,
+            "img nested below <td> must produce an Image element"
+        );
+    }
+
     #[test]
     fn base64_decode_basic() {
         // "Hello" in base64 is "SGVsbG8="

--- a/src/layout/helpers.rs
+++ b/src/layout/helpers.rs
@@ -219,6 +219,19 @@ pub(crate) fn collects_as_inline_text(tag: HtmlTag) -> bool {
     tag != HtmlTag::Svg && tag.is_inline()
 }
 
+/// True when the element is an `<img>` or contains one anywhere in its
+/// subtree. Used to divert image-bearing children out of text-run
+/// collection (which only understands text) into element layout.
+pub(crate) fn subtree_contains_img(el: &crate::parser::dom::ElementNode) -> bool {
+    if el.tag == HtmlTag::Img {
+        return true;
+    }
+    el.children.iter().any(|c| match c {
+        crate::parser::dom::DomNode::Element(e) => subtree_contains_img(e),
+        _ => false,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Group 3 — List marker formatting
 // ---------------------------------------------------------------------------

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -1275,6 +1275,19 @@ fn collect_table_cell_content_inner(
                 if style.display == Display::None {
                     continue;
                 }
+                if el.tag == HtmlTag::Img {
+                    // Text-run collection has no image representation; emit
+                    // the image as a nested layout element within the cell.
+                    if let Some(img) = super::images::load_image_from_element(
+                        el,
+                        available_width,
+                        f32::INFINITY,
+                        &style,
+                    ) {
+                        nested_rows.push(img);
+                    }
+                    continue;
+                }
                 let url = if el.tag == HtmlTag::A {
                     el.attributes.get("href").map(|s| s.as_str()).or(link_url)
                 } else {

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -671,6 +671,36 @@ pub(super) fn render_nested_layout_elements(
                     ctx,
                 );
             }
+            LayoutElement::Image {
+                image,
+                width,
+                height,
+                ..
+            } => {
+                let img_x = planned_element.origin_x;
+                // PDF y-axis is bottom-up; top_y is the image top edge.
+                let img_y = planned_element.top_y - height;
+                let img_obj_id = ctx.pdf_writer.add_image_object(
+                    &image.data,
+                    image.source_width,
+                    image.source_height,
+                    image.format,
+                    image.png_metadata.as_ref(),
+                );
+                let img_name = format!("Im{img_obj_id}");
+                content.push_str(&format!(
+                    "q\n{w} 0 0 {h} {x} {y} cm\n/{name} Do\nQ\n",
+                    w = width,
+                    h = height,
+                    x = img_x,
+                    y = img_y,
+                    name = img_name,
+                ));
+                ctx.page_images.push(ImageRef {
+                    name: img_name,
+                    obj_id: img_obj_id,
+                });
+            }
             _ => {}
         }
     }
@@ -773,6 +803,25 @@ pub(super) fn plan_nested_layout_elements(
                         )
                         - *margin_bottom;
                 }
+            }
+            LayoutElement::Image {
+                width: _,
+                height,
+                flow_extra_bottom,
+                margin_top,
+                margin_bottom,
+                ..
+            } => {
+                cursor_y -= *margin_top;
+                planned.push(PlannedNestedElement {
+                    element,
+                    source_index: element_idx,
+                    origin_x: frame.origin_x,
+                    top_y: cursor_y,
+                    available_width: frame.available_width,
+                    blur_canvas_box: None,
+                });
+                cursor_y -= height + flow_extra_bottom + *margin_bottom;
             }
             _ => {}
         }


### PR DESCRIPTION
## Problem

Any `<img>` nested inside a block container (`div`, `p`, `td`) is silently dropped. Block layout funnels inline children into text-run collection, which has no image representation; table-cell collection likewise only understands text and nested tables. Images only render as near-top-level children of `<body>`.

Minimal repros (image invisible on v1.4.3 and current main):

```html
<div><img src="data:image/png;base64,…"></div>
<table><tr><td><img src="data:image/png;base64,…"></td></tr></table>
```

Real-world templates virtually always nest images inside table cells or divs, so entire documents lose their logos/barcodes with no error.

## Fix

- **Block flow:** children whose subtree contains an image are diverted to element layout (flushing accumulated text runs first) instead of text-run collection — in the mixed inline/block loop, the visual-wrapper loop, and the pure-inline fallback.
- **Table cells:** `<img>` elements encountered during cell content collection are loaded and emitted into the cell's `nested_rows`.
- **Renderer:** `render_nested_layout_elements` / `plan_nested_layout_elements` had no `Image` arm at all, so cell images had no paint path. Both gained one (y-cursor advance, XObject placement, page image ref registration).

Known limitation kept out of scope: diverted images render in block flow rather than true inline flow (consistent with existing top-level behavior), and cell `text-align` is not yet applied to image x-position.

## Tests

Five new layout tests covering img in div / p / span-in-div / td / styled-div-in-td. Full suite: 2258 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)