### PR TITLE
Fix PNG alpha/palette embedding and harden image dimension parsing

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -238,6 +238,9 @@ pub enum ImageFormat {
 pub struct PngMetadata {
     pub channels: u8,
     pub bit_depth: u8,
+    /// Indexed (palette) PNG — must go through full decode when embedding,
+    /// since a raw IDAT stream would need the PLTE as an /Indexed space.
+    pub indexed: bool,
 }
 
 /// Raster image bytes plus the source pixel dimensions required by the PDF renderer.
@@ -2596,6 +2599,26 @@ mod tests {
             nested_text.contains("1."),
             "Nested item should have ordered marker, got: {nested_text}"
         );
+    }
+
+    #[test]
+    fn layout_image_nan_dimension_attrs_fall_back() {
+        let html = format!(r#"<img src="{TEST_JPEG_DATA_URI}" width="NaN" height="NaN">"#);
+        let nodes = parse_html(&html).unwrap();
+        let pages = layout(&nodes, PageSize::A4, Margin::default());
+        let mut found = false;
+        for p in &pages {
+            for (_, e) in &p.elements {
+                if let LayoutElement::Image { width, height, .. } = e {
+                    found = true;
+                    assert!(
+                        width.is_finite() && height.is_finite(),
+                        "NaN attribute dimensions must not propagate: {width} x {height}"
+                    );
+                }
+            }
+        }
+        assert!(found, "image with NaN attrs should still lay out");
     }
 
     #[test]

--- a/src/layout/images.rs
+++ b/src/layout/images.rs
@@ -78,9 +78,20 @@ pub(crate) fn load_image_bytes(raw: Vec<u8>) -> Option<RasterImageAsset> {
         let metadata = PngMetadata {
             channels: png_info.channels,
             bit_depth: png_info.bit_depth,
+            indexed: png_info.color_type == 3,
+        };
+        // Alpha-bearing PNGs (gray+alpha or RGBA) cannot be embedded as a
+        // raw IDAT stream — PDF image XObjects carry no inline alpha, and
+        // declaring /DeviceRGB over 4-channel data corrupts the raster.
+        // Indexed PNGs need their palette resolved. Keep the full PNG so
+        // the renderer can decode (and split any alpha into an /SMask).
+        let data = if png_info.channels == 2 || png_info.channels == 4 || metadata.indexed {
+            raw
+        } else {
+            png_info.idat_data
         };
         Some(RasterImageAsset {
-            data: png_info.idat_data,
+            data,
             source_width: png_info.width,
             source_height: png_info.height,
             format: ImageFormat::Png,
@@ -166,11 +177,17 @@ pub(crate) fn load_image_from_element(
     let attr_width = parse_html_image_dimension(el.attributes.get("width"));
     let attr_height = parse_html_image_dimension(el.attributes.get("height"));
 
+    // Missing dimensions resolve against the intrinsic pixel size (at 0.75
+    // pt/px), preserving aspect ratio — matching browser replaced-element
+    // sizing rather than inventing a square or fixed box.
+    let intrinsic_w = (image.source_width.max(1) as f32) * 0.75;
+    let intrinsic_h = (image.source_height.max(1) as f32) * 0.75;
+    let ratio = intrinsic_h / intrinsic_w;
     let (width, height) = match (attr_width, attr_height) {
         (Some(w), Some(h)) => (w, h),
-        (Some(w), None) => (w, w), // fallback: square
-        (None, Some(h)) => (h, h),
-        (None, None) => (available_width.min(200.0), 150.0),
+        (Some(w), None) => (w, w * ratio),
+        (None, Some(h)) => (h / ratio, h),
+        (None, None) => (intrinsic_w, intrinsic_h),
     };
 
     let (width, height) = constrain_replaced_image_size(
@@ -282,7 +299,13 @@ pub(crate) fn add_inline_replaced_baseline_gap(
 pub(crate) fn parse_html_image_dimension(raw: Option<&String>) -> Option<f32> {
     let raw = raw?.trim();
     let raw = raw.strip_suffix("px").unwrap_or(raw);
-    raw.parse::<f32>().ok().map(|px| px * 0.75)
+    raw.parse::<f32>()
+        .ok()
+        // Real-world HTML contains width="NaN" and the like; a non-finite
+        // or negative dimension must fall back to intrinsic sizing rather
+        // than poison the PDF coordinate stream.
+        .filter(|px| px.is_finite() && *px >= 0.0)
+        .map(|px| px * 0.75)
 }
 
 struct SvgSizeSource<'a> {

--- a/src/parser/png.rs
+++ b/src/parser/png.rs
@@ -101,11 +101,13 @@ fn parse_png_with_limit(data: &[u8], max_idat: usize) -> Option<PngInfo> {
     }
 
     let channels = match color_type {
-        0 => 1,           // Grayscale
-        2 => 3,           // RGB
+        0 => 1, // Grayscale
+        2 => 3, // RGB
+        3 => 1, // Indexed (palette) — one index sample per pixel;
+        //                   embedding requires full decode, see load_image_bytes
         4 => 2,           // Grayscale + Alpha
         6 => 4,           // RGBA
-        _ => return None, // Unsupported (e.g., indexed color type 3)
+        _ => return None, // Unsupported
     };
 
     Some(PngInfo {
@@ -193,9 +195,18 @@ mod tests {
     }
 
     #[test]
-    fn parse_unsupported_color_type() {
-        // Color type 3 (indexed) is not supported
+    fn parse_indexed_color_type() {
+        // Color type 3 (indexed) parses; embedding decodes the palette later.
         let png = build_test_png(1, 1, 8, 3, &[0x78, 0x01, 0x01, 0x00, 0x00]);
+        let info = parse_png(&png).expect("indexed PNG should parse");
+        assert_eq!(info.color_type, 3);
+        assert_eq!(info.channels, 1);
+    }
+
+    #[test]
+    fn parse_truly_unsupported_color_type() {
+        // Color type 7 does not exist in the PNG spec.
+        let png = build_test_png(1, 1, 8, 7, &[0x78, 0x01, 0x01, 0x00, 0x00]);
         assert!(parse_png(&png).is_none());
     }
 

--- a/src/render/pdf.rs
+++ b/src/render/pdf.rs
@@ -5083,6 +5083,9 @@ struct DecodedPngImage {
 fn decode_png_for_pdf(raw: &[u8]) -> Option<DecodedPngImage> {
     let mut decoder = png_decoder::Decoder::new(std::io::Cursor::new(raw));
     decoder.ignore_checksums(true);
+    // Expand indexed (palette) pixels to RGB and sub-8-bit grayscale to
+    // 8-bit so the color-type match below only sees direct color data.
+    decoder.set_transformations(png_decoder::Transformations::EXPAND);
     let mut reader = decoder.read_info().ok()?;
     let output_size = reader.output_buffer_size()?;
     let mut buffer = vec![0; output_size];
@@ -5192,6 +5195,16 @@ impl PdfWriter {
         format: ImageFormat,
         png_metadata: Option<&PngMetadata>,
     ) -> usize {
+        // Alpha-bearing PNGs arrive as the full PNG file (see
+        // load_image_bytes) and go through the decode-and-split path so the
+        // alpha channel becomes an /SMask instead of corrupting the color
+        // stream. Checked before next_id() so no object id is leaked.
+        if format == ImageFormat::Png
+            && png_metadata.is_some_and(|m| m.channels == 2 || m.channels == 4 || m.indexed)
+            && let Some(id) = self.add_raw_png_image_object(data)
+        {
+            return id;
+        }
         let id = self.next_id();
         let header = match format {
             ImageFormat::Jpeg => {


### PR DESCRIPTION
## Problem

Two PNG classes common in real templates embed incorrectly or not at all:

- **RGBA / gray+alpha PNGs** pass their raw IDAT stream to the PDF writer declared as `/DeviceRGB` (or `/DeviceGray`) — a 3- or 1-channel color space over 4- or 2-channel data — producing corrupted rasters (colorful filter-noise instead of the image).
- **Indexed (palette) PNGs** are rejected by the minimal PNG parser (`color_type 3 => return None`) and the image is dropped entirely. Barcode generators commonly emit 1-bit palette PNGs.

Separately, `width="NaN"` — observed in real-world HTML — parses successfully via `f32::parse` and propagates NaN into the PDF `cm` operator, corrupting the coordinate stream.

## Fix

- Alpha-bearing PNGs keep their full raw bytes and route through the existing decode-and-split path (`add_raw_png_image_object`: color stream + `/SMask`), which was previously only used for SVG-embedded rasters. Plain RGB/gray PNGs keep the fast raw-IDAT path unchanged.
- Palette PNGs now parse (`PngInfo.color_type` retained, new `PngMetadata.indexed` flag) and decode with `Transformations::EXPAND` so the same path embeds them as direct color.
- `parse_html_image_dimension` rejects non-finite/negative values, falling back to intrinsic sizing.
- Images without dimension attributes previously used a fixed 200×150 box (and a square when only one attribute was given); they now use intrinsic pixel size at 0.75 pt/px preserving aspect ratio, matching browser replaced-element sizing.

## Tests

New tests: indexed PNG parses, truly-unsupported color type still rejected, NaN dimension attrs fall back to finite sizing. Full suite: 2255 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)