### PR TITLE
fix(publish): exclude parity fixtures and bump bindings to 1.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/ironpress"
 readme = "README.md"
 keywords = ["pdf", "html", "css", "markdown", "converter"]
 categories = ["text-processing", "encoding", "template-engine"]
-exclude = [".github/", ".claude/", "target/", "docs/"]
+exclude = [".github/", ".claude/", "target/", "docs/", "tests/parity/", "tmpdiag/", "scripts/"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-python"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2024"
 publish = false
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ironpress"
-version = "1.4.3"
+version = "1.4.4"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter. No browser, no system dependencies."
 readme = "README.md"
 license = "MIT"

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-ruby"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2024"
 publish = false
 

--- a/bindings/ruby/ironpress.gemspec
+++ b/bindings/ruby/ironpress.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "ironpress"
-  spec.version       = "1.4.3"
+  spec.version       = "1.4.4"
   spec.authors       = ["Paul Gaston Gouron"]
   spec.summary       = "Pure Rust HTML/CSS/Markdown to PDF converter"
   spec.description   = "Convert HTML, CSS, and Markdown to PDF with no browser or system dependencies. Native Rust extension for maximum performance."


### PR DESCRIPTION
## Summary

- Exclude `tests/parity/`, `tmpdiag/`, `scripts/` from crate package (was 14 MB compressed, crates.io limit is 10 MB)
- Bump Python binding version 1.4.3 → 1.4.4 (`bindings/python/Cargo.toml`, `pyproject.toml`)
- Bump Ruby binding version 1.4.3 → 1.4.4 (`bindings/ruby/Cargo.toml`, `ironpress.gemspec`)

## Context

The v1.4.4 publish failed:
- **crates.io**: `413 Payload Too Large` — parity fixtures bloated the package to 14 MB
- **PyPI**: published 1.4.3 wheels (binding version wasn't bumped)
- **RubyGems**: published 1.4.3 gem (same reason)
- **npm**: 404 error — likely expired `NPM_TOKEN` secret (needs manual renewal)

After merge, we'll re-tag `v1.4.4` and re-trigger the publish workflows.

## Test plan

- [ ] `cargo package --list` shows ~416 files (not 3890)
- [ ] `cargo package --no-verify` reports < 10 MB compressed
- [ ] Binding versions all read 1.4.4