### PR TITLE
chore: update README benchmarks (Apple M2, 7 entries)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,17 @@ Thanks for your interest in contributing!
 - Keep PRs focused on a single change
 - Follow existing code style and conventions
 
+## Code comments
+
+The codebase is intentionally low on comments. Follow these conventions:
+
+- **`///` doc comments** on public (and most private) structs, enums, fields, and functions. This is the dominant style. Explain *why* when the code encodes a non-obvious spec rule or design choice — a bare *what* is not enough for layout/CSS logic.
+- **`//!` module-level docs** only when a file has a meaningful architectural role worth describing. Not on every file.
+- **`//` inline comments** sparingly, only to annotate non-trivial algorithmic steps.
+- **No block comments** (`/* */`).
+- **No `FIXME` or `HACK` markers.** `TODO:` is acceptable on `#[ignore]` tests.
+- Let well-named identifiers speak for themselves. Don't narrate what the code does, document why it does it that way.
+
 ## Reporting Issues
 
 Open an issue on GitHub with a clear description and, if possible, a minimal reproduction.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ Criterion measures complete, in-process conversion to PDF bytes:
 
 | Document | Representative median | Approx. conversions/sec |
 |----------|----------------------:|------------------------:|
-| Simple HTML (`<h1>` + `<p>`) | **1.3 ms** | 770 |
-| Styled HTML (CSS, lists, links) | **5.8 ms** | 170 |
-| Markdown (headings, code, lists) | **11 ms** | 89 |
-| Table (5 rows, styled headers) | **13 ms** | 75 |
-| Full report (tables, flex, progress bars) | **30 ms** | 33 |
+| Simple HTML (`<h1>` + `<p>`) | **0.93 ms** | 1,080 |
+| Styled HTML (CSS, lists, links) | **3.5 ms** | 285 |
+| Table (5 rows, styled headers) | **5.9 ms** | 170 |
+| Markdown (headings, code, lists) | **7.0 ms** | 143 |
+| Full report (tables, flex, progress bars) | **15.9 ms** | 63 |
+| Full report + header/footer | **15.9 ms** | 63 |
+| 200 CJK text-emphasis spans | **310 ms** | 3.2 |
 
-Measured on Linux x86-64 with a Ryzen 9 5950X and Rust 1.97.1 at commit
-`b4536834`. The benchmark profile uses `opt-level=3`, fat LTO, and one codegen
+Measured on macOS ARM (Apple M2) with Rust 1.94.0 at commit
+`600aadb`. The benchmark profile uses `opt-level=3`, fat LTO, and one codegen
 unit. Results depend on hardware and document content; conversions/sec is not a
 page-throughput claim. Reproduce the measurements with:
 


### PR DESCRIPTION
## Summary

- Refresh all benchmark numbers from Criterion run on Apple M2 (commit `600aadb`)
- Add two new benchmarks: `header_footer` and `text_emphasis_200_runs`
- Reorder table by median time (fastest first)

## Benchmark results

| Document | Median |
|----------|--------|
| Simple HTML | 0.93 ms |
| Styled HTML | 3.5 ms |
| Table | 5.9 ms |
| Markdown | 7.0 ms |
| Full report | 15.9 ms |
| Full report + header/footer | 15.9 ms |
| 200 CJK text-emphasis spans | 310 ms |

## Test plan

- [ ] Documentation only — no code changes