### PR TITLE
feat: expose full HtmlConverter API in Python and Ruby bindings

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -38,11 +38,81 @@ fn markdown_to_pdf(markdown: &str) -> PyResult<Vec<u8>> {
 ///     >>> converter = HtmlConverter()
 ///     >>> converter.page_size("Letter")
 ///     >>> converter.margin(36.0)
+///     >>> converter.margin_sides(72.0, 36.0, 72.0, 36.0)
+///     >>> converter.compress(False)
 ///     >>> pdf = converter.convert("<h1>Hello</h1>")
 #[pyclass]
 struct HtmlConverter {
     page_size: ironpress_core::types::PageSize,
     margin: ironpress_core::types::Margin,
+    compress: Option<bool>,
+    jpeg_quality: Option<u8>,
+    auto_resize_images: Option<bool>,
+    source_image_dpi: Option<f32>,
+    filter_dpi: Option<f32>,
+    mask_dpi: Option<f32>,
+    background_dpi: Option<f32>,
+    occlusion_cull: Option<bool>,
+    sanitize: Option<bool>,
+    custom_fonts: Vec<(String, Vec<u8>)>,
+    base_path: Option<String>,
+    resource_root: Option<String>,
+    header: Option<String>,
+    footer: Option<String>,
+}
+
+impl HtmlConverter {
+    /// Build the Rust `HtmlConverter` from stored fields.
+    fn build_converter(&self) -> ironpress_core::HtmlConverter {
+        let mut converter = ironpress_core::HtmlConverter::new()
+            .page_size(self.page_size)
+            .margin(self.margin);
+
+        if let Some(compress) = self.compress {
+            converter = converter.compress(compress);
+        }
+        if let Some(quality) = self.jpeg_quality {
+            converter = converter.jpeg_quality(quality);
+        }
+        if let Some(enabled) = self.auto_resize_images {
+            converter = converter.auto_resize_images(enabled);
+        }
+        if let Some(dpi) = self.source_image_dpi {
+            converter = converter.image_dpi(dpi);
+        }
+        if let Some(dpi) = self.filter_dpi {
+            converter = converter.filter_dpi(dpi);
+        }
+        if let Some(dpi) = self.mask_dpi {
+            converter = converter.mask_dpi(dpi);
+        }
+        if let Some(dpi) = self.background_dpi {
+            converter = converter.background_raster_dpi(dpi);
+        }
+        if let Some(enabled) = self.occlusion_cull {
+            converter = converter.occlusion_cull(enabled);
+        }
+        if let Some(enabled) = self.sanitize {
+            converter = converter.sanitize(enabled);
+        }
+        for (name, data) in &self.custom_fonts {
+            converter = converter.add_font(name, data.clone());
+        }
+        if let Some(ref path) = self.base_path {
+            converter = converter.base_path(std::path::Path::new(path));
+        }
+        if let Some(ref root) = self.resource_root {
+            converter = converter.resource_root(std::path::Path::new(root));
+        }
+        if let Some(ref text) = self.header {
+            converter = converter.header(text.clone());
+        }
+        if let Some(ref text) = self.footer {
+            converter = converter.footer(text.clone());
+        }
+
+        converter
+    }
 }
 
 #[pymethods]
@@ -52,15 +122,52 @@ impl HtmlConverter {
         HtmlConverter {
             page_size: ironpress_core::types::PageSize::A4,
             margin: ironpress_core::types::Margin::default(),
+            compress: None,
+            jpeg_quality: None,
+            auto_resize_images: None,
+            source_image_dpi: None,
+            filter_dpi: None,
+            mask_dpi: None,
+            background_dpi: None,
+            occlusion_cull: None,
+            sanitize: None,
+            custom_fonts: Vec::new(),
+            base_path: None,
+            resource_root: None,
+            header: None,
+            footer: None,
         }
     }
 
-    /// Set uniform margin in points (72 points = 1 inch).
+    /// Set uniform page margin in points (72 points = 1 inch).
+    ///
+    /// Args:
+    ///     points: Margin size applied to all four sides.
     fn margin(&mut self, points: f32) {
         self.margin = ironpress_core::types::Margin::uniform(points);
     }
 
-    /// Set page size by name ("A4", "Letter", "Legal").
+    /// Set individual page margins in points (72 points = 1 inch).
+    ///
+    /// Args:
+    ///     top: Top margin in points.
+    ///     right: Right margin in points.
+    ///     bottom: Bottom margin in points.
+    ///     left: Left margin in points.
+    fn margin_sides(&mut self, top: f32, right: f32, bottom: f32, left: f32) {
+        self.margin = ironpress_core::types::Margin::new(top, right, bottom, left);
+    }
+
+    /// Set page size by name or custom dimensions.
+    ///
+    /// Supported names: "A4" (210x297mm), "Letter" (8.5x11in), "Legal" (8.5x14in).
+    /// For custom sizes, use `page_size_custom()`.
+    ///
+    /// Args:
+    ///     name: Page size name (case-insensitive).
+    ///
+    /// Raises:
+    ///     ValueError: If the name is not recognized.
     fn page_size(&mut self, name: &str) -> PyResult<()> {
         self.page_size = match name.to_lowercase().as_str() {
             "a4" => ironpress_core::types::PageSize::A4,
@@ -71,24 +178,252 @@ impl HtmlConverter {
         Ok(())
     }
 
+    /// Set a custom page size in points (72 points = 1 inch).
+    ///
+    /// Args:
+    ///     width: Page width in points.
+    ///     height: Page height in points.
+    fn page_size_custom(&mut self, width: f32, height: f32) {
+        self.page_size = ironpress_core::types::PageSize::new(width, height);
+    }
+
+    /// Enable or disable FlateDecode compression of page content streams.
+    ///
+    /// Compression is enabled by default. Disabling produces larger but
+    /// human-readable PDFs, useful for debugging.
+    ///
+    /// Args:
+    ///     enabled: Whether to compress content streams.
+    fn compress(&mut self, enabled: bool) {
+        self.compress = Some(enabled);
+    }
+
+    /// Set JPEG quality for optimized image embedding (0-100).
+    ///
+    /// The default is 95. Lower values produce smaller files at the cost
+    /// of image quality.
+    ///
+    /// Args:
+    ///     quality: JPEG quality level (0-100, clamped).
+    fn jpeg_quality(&mut self, quality: u8) {
+        self.jpeg_quality = Some(quality);
+    }
+
+    /// Enable or disable automatic downscaling of oversized source images.
+    ///
+    /// Enabled by default. When enabled, images larger than needed at the
+    /// target DPI are downscaled to reduce PDF file size.
+    ///
+    /// Args:
+    ///     enabled: Whether to auto-resize images.
+    fn auto_resize_images(&mut self, enabled: bool) {
+        self.auto_resize_images = Some(enabled);
+    }
+
+    /// Set the target source-image resolution in DPI (minimum 72, default 300).
+    ///
+    /// Controls the resolution at which embedded images are stored in the PDF.
+    /// Higher values produce sharper images at the cost of file size.
+    ///
+    /// Args:
+    ///     dpi: Target resolution in dots per inch.
+    fn image_dpi(&mut self, dpi: f32) {
+        self.source_image_dpi = Some(dpi);
+    }
+
+    /// Set the rasterization DPI for render-time blur/filter bitmaps.
+    ///
+    /// Controls the resolution of CSS filter effects like blur. The default
+    /// is 300 DPI.
+    ///
+    /// Args:
+    ///     dpi: Target resolution in dots per inch.
+    fn filter_dpi(&mut self, dpi: f32) {
+        self.filter_dpi = Some(dpi);
+    }
+
+    /// Set the rasterization DPI for CSS mask-image coverage bitmaps.
+    ///
+    /// The default 300 DPI preserves high-contrast coverage edges. It is
+    /// independent from blur/filter quality because mask coverage has
+    /// different sampling and compression characteristics.
+    ///
+    /// Args:
+    ///     dpi: Target resolution in dots per inch.
+    fn mask_dpi(&mut self, dpi: f32) {
+        self.mask_dpi = Some(dpi);
+    }
+
+    /// Set the target resolution for flattened background bitmaps.
+    ///
+    /// The default 192 DPI is the lowest tested physical-resolution baseline.
+    /// This setting affects only synthetic background images (e.g. gradients
+    /// with blend modes), never PDF geometry.
+    ///
+    /// Args:
+    ///     dpi: Target resolution in dots per inch.
+    fn background_raster_dpi(&mut self, dpi: f32) {
+        self.background_dpi = Some(dpi);
+    }
+
+    /// Enable or disable occlusion culling of raster images.
+    ///
+    /// When enabled, images that are fully covered by a later fully-opaque
+    /// rectangular element are skipped. Disabled by default. Conservative
+    /// and safe: only skips images that are guaranteed invisible.
+    ///
+    /// Args:
+    ///     enabled: Whether to enable occlusion culling.
+    fn occlusion_cull(&mut self, enabled: bool) {
+        self.occlusion_cull = Some(enabled);
+    }
+
+    /// Enable or disable HTML sanitization (enabled by default).
+    ///
+    /// When enabled, potentially dangerous HTML elements and attributes
+    /// (e.g. `<script>`, event handlers) are stripped before conversion.
+    ///
+    /// Args:
+    ///     enabled: Whether to sanitize input HTML.
+    fn sanitize(&mut self, enabled: bool) {
+        self.sanitize = Some(enabled);
+    }
+
+    /// Register a custom TrueType font.
+    ///
+    /// The name should match the `font-family` value used in CSS. The
+    /// font data must be the raw contents of a `.ttf` file.
+    ///
+    /// Args:
+    ///     name: Font family name (matched case-insensitively).
+    ///     ttf_data: Raw TrueType font file contents.
+    ///
+    /// Example:
+    ///     >>> converter = HtmlConverter()
+    ///     >>> with open("MyFont.ttf", "rb") as f:
+    ///     ...     converter.add_font("MyFont", f.read())
+    ///     >>> pdf = converter.convert('<p style="font-family: MyFont">Hello</p>')
+    fn add_font(&mut self, name: &str, ttf_data: Vec<u8>) {
+        self.custom_fonts.push((name.to_string(), ttf_data));
+    }
+
+    /// Set the base directory for resolving relative paths.
+    ///
+    /// When set, CSS `@import "styles.css"` and `@font-face src: url(...)`
+    /// paths are resolved relative to this directory. Only local file paths
+    /// are supported; remote URLs (http/https) are rejected for security.
+    ///
+    /// Args:
+    ///     path: Absolute path to the base directory.
+    ///
+    /// Example:
+    ///     >>> converter = HtmlConverter()
+    ///     >>> converter.base_path("/path/to/project")
+    ///     >>> pdf = converter.convert('<style>@import "styles.css";</style><p>Hi</p>')
+    fn base_path(&mut self, path: &str) {
+        self.base_path = Some(path.to_string());
+    }
+
+    /// Set the directory boundary authorized for document-local resources.
+    ///
+    /// By default, the base_path is both the URL base and the authorization
+    /// boundary. Set a broader root when a document legitimately references
+    /// shared assets in an ancestor directory. The base path must remain
+    /// inside this canonical root; traversal and symlink escapes are denied.
+    ///
+    /// Args:
+    ///     path: Absolute path to the authorized resource root.
+    fn resource_root(&mut self, path: &str) {
+        self.resource_root = Some(path.to_string());
+    }
+
+    /// Set a header text rendered at the top of each page.
+    ///
+    /// The header is placed in the top margin area of every page.
+    ///
+    /// Args:
+    ///     text: Header text string.
+    fn header(&mut self, text: &str) {
+        self.header = Some(text.to_string());
+    }
+
+    /// Set a footer text rendered at the bottom of each page.
+    ///
+    /// Use `{page}` for the current page number and `{pages}` for the
+    /// total page count. For example: `"Page {page} of {pages}"`.
+    ///
+    /// Args:
+    ///     text: Footer text string with optional placeholders.
+    ///
+    /// Example:
+    ///     >>> converter = HtmlConverter()
+    ///     >>> converter.footer("Page {page} of {pages}")
+    fn footer(&mut self, text: &str) {
+        self.footer = Some(text.to_string());
+    }
+
     /// Convert HTML to PDF bytes.
+    ///
+    /// Args:
+    ///     html: HTML string to convert.
+    ///
+    /// Returns:
+    ///     PDF document as bytes.
+    ///
+    /// Raises:
+    ///     ValueError: If conversion fails.
     fn convert(&self, html: &str) -> PyResult<Vec<u8>> {
-        let converter = ironpress_core::HtmlConverter::new()
-            .page_size(self.page_size)
-            .margin(self.margin);
-        converter
+        self.build_converter()
             .convert(html)
             .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     /// Convert Markdown to PDF bytes.
+    ///
+    /// Args:
+    ///     markdown: Markdown string to convert.
+    ///
+    /// Returns:
+    ///     PDF document as bytes.
+    ///
+    /// Raises:
+    ///     ValueError: If conversion fails.
     fn convert_markdown(&self, markdown: &str) -> PyResult<Vec<u8>> {
-        let converter = ironpress_core::HtmlConverter::new()
-            .page_size(self.page_size)
-            .margin(self.margin);
-        converter
+        self.build_converter()
             .convert_markdown(markdown)
             .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Convert HTML to PDF and write the result to a file.
+    ///
+    /// Args:
+    ///     html: HTML string to convert.
+    ///     path: Output file path.
+    ///
+    /// Raises:
+    ///     ValueError: If conversion or file writing fails.
+    fn convert_to_file(&self, html: &str, path: &str) -> PyResult<()> {
+        let pdf = self
+            .build_converter()
+            .convert(html)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        std::fs::write(path, pdf).map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Convert Markdown to PDF and write the result to a file.
+    ///
+    /// Args:
+    ///     markdown: Markdown string to convert.
+    ///     path: Output file path.
+    ///
+    /// Raises:
+    ///     ValueError: If conversion or file writing fails.
+    fn convert_markdown_to_file(&self, markdown: &str, path: &str) -> PyResult<()> {
+        let pdf = self
+            .build_converter()
+            .convert_markdown(markdown)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        std::fs::write(path, pdf).map_err(|e| PyValueError::new_err(e.to_string()))
     }
 }
 

--- a/bindings/ruby/src/lib.rs
+++ b/bindings/ruby/src/lib.rs
@@ -1,4 +1,12 @@
-use magnus::{Error, RString, Ruby, define_module, function, prelude::*};
+use std::cell::RefCell;
+use std::path::Path;
+
+use magnus::{
+    Error, IntoValue, RString, Ruby, Value,
+    class, define_module, function, method,
+    prelude::*,
+    typed_data,
+};
 
 fn html_to_pdf(ruby: &Ruby, html: String) -> Result<RString, Error> {
     let pdf = ironpress_core::html_to_pdf(&html)
@@ -12,10 +20,368 @@ fn markdown_to_pdf(ruby: &Ruby, markdown: String) -> Result<RString, Error> {
     Ok(ruby.str_from_slice(&pdf))
 }
 
+// ---------------------------------------------------------------------------
+// Inner state for the builder -- stored inside a RefCell so magnus method
+// receivers (&self) can mutate it.
+// ---------------------------------------------------------------------------
+
+struct ConverterInner {
+    page_size: ironpress_core::types::PageSize,
+    margin: ironpress_core::types::Margin,
+    compress: Option<bool>,
+    jpeg_quality: Option<u8>,
+    auto_resize_images: Option<bool>,
+    image_dpi: Option<f32>,
+    filter_dpi: Option<f32>,
+    mask_dpi: Option<f32>,
+    background_raster_dpi: Option<f32>,
+    occlusion_cull: Option<bool>,
+    sanitize: Option<bool>,
+    custom_fonts: Vec<(String, Vec<u8>)>,
+    base_path: Option<String>,
+    resource_root: Option<String>,
+    header: Option<String>,
+    footer: Option<String>,
+}
+
+impl Default for ConverterInner {
+    fn default() -> Self {
+        Self {
+            page_size: ironpress_core::types::PageSize::default(),
+            margin: ironpress_core::types::Margin::default(),
+            compress: None,
+            jpeg_quality: None,
+            auto_resize_images: None,
+            image_dpi: None,
+            filter_dpi: None,
+            mask_dpi: None,
+            background_raster_dpi: None,
+            occlusion_cull: None,
+            sanitize: None,
+            custom_fonts: Vec::new(),
+            base_path: None,
+            resource_root: None,
+            header: None,
+            footer: None,
+        }
+    }
+}
+
+impl ConverterInner {
+    /// Build an `ironpress_core::HtmlConverter` from the accumulated state.
+    fn build(&self) -> ironpress_core::HtmlConverter {
+        let mut c = ironpress_core::HtmlConverter::new()
+            .page_size(self.page_size)
+            .margin(self.margin);
+
+        if let Some(v) = self.compress {
+            c = c.compress(v);
+        }
+        if let Some(v) = self.jpeg_quality {
+            c = c.jpeg_quality(v);
+        }
+        if let Some(v) = self.auto_resize_images {
+            c = c.auto_resize_images(v);
+        }
+        if let Some(v) = self.image_dpi {
+            c = c.image_dpi(v);
+        }
+        if let Some(v) = self.filter_dpi {
+            c = c.filter_dpi(v);
+        }
+        if let Some(v) = self.mask_dpi {
+            c = c.mask_dpi(v);
+        }
+        if let Some(v) = self.background_raster_dpi {
+            c = c.background_raster_dpi(v);
+        }
+        if let Some(v) = self.occlusion_cull {
+            c = c.occlusion_cull(v);
+        }
+        if let Some(v) = self.sanitize {
+            c = c.sanitize(v);
+        }
+        for (name, data) in &self.custom_fonts {
+            c = c.add_font(name, data.clone());
+        }
+        if let Some(ref p) = self.base_path {
+            c = c.base_path(Path::new(p));
+        }
+        if let Some(ref p) = self.resource_root {
+            c = c.resource_root(Path::new(p));
+        }
+        if let Some(ref t) = self.header {
+            c = c.header(t.clone());
+        }
+        if let Some(ref t) = self.footer {
+            c = c.footer(t.clone());
+        }
+        c
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ruby-visible class: Ironpress::HtmlConverter
+//
+// All setter methods mutate the receiver and return `self` so calls can be
+// chained:
+//
+//   converter = Ironpress::HtmlConverter.new
+//                 .page_size("Letter")
+//                 .margin(36.0)
+//                 .compress(true)
+//   pdf = converter.convert("<h1>Hello</h1>")
+// ---------------------------------------------------------------------------
+
+#[magnus::wrap(class = "Ironpress::HtmlConverter", free_immediately, size)]
+struct RbHtmlConverter {
+    inner: RefCell<ConverterInner>,
+}
+
+// Type alias for the typed Ruby object handle that can be both dereferenced
+// to &RbHtmlConverter and converted back to a Ruby Value.
+type RbSelf = typed_data::Obj<RbHtmlConverter>;
+
+// --- helpers ---------------------------------------------------------------
+
+fn parse_page_size(ruby: &Ruby, name: &str) -> Result<ironpress_core::types::PageSize, Error> {
+    match name.to_lowercase().as_str() {
+        "a4" => Ok(ironpress_core::types::PageSize::A4),
+        "letter" => Ok(ironpress_core::types::PageSize::LETTER),
+        "legal" => Ok(ironpress_core::types::PageSize::LEGAL),
+        _ => Err(Error::new(
+            ruby.exception_arg_error(),
+            format!("Unknown page size: {name}"),
+        )),
+    }
+}
+
+// --- methods ---------------------------------------------------------------
+
+impl RbHtmlConverter {
+    /// `Ironpress::HtmlConverter.new` -- create with defaults.
+    fn new() -> Self {
+        Self {
+            inner: RefCell::new(ConverterInner::default()),
+        }
+    }
+
+    /// `page_size(name)` -- set page size by name ("A4", "Letter", "Legal").
+    fn page_size(ruby: &Ruby, rb_self: RbSelf, name: String) -> Result<Value, Error> {
+        let size = parse_page_size(ruby, &name)?;
+        rb_self.inner.borrow_mut().page_size = size;
+        Ok(rb_self.into_value_with(ruby))
+    }
+
+    /// `margin(points)` -- set uniform margin on all sides.
+    fn margin(ruby: &Ruby, rb_self: RbSelf, points: f64) -> Value {
+        rb_self.inner.borrow_mut().margin =
+            ironpress_core::types::Margin::uniform(points as f32);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `margin_sides(top, right, bottom, left)` -- set per-side margins.
+    fn margin_sides(
+        ruby: &Ruby,
+        rb_self: RbSelf,
+        top: f64,
+        right: f64,
+        bottom: f64,
+        left: f64,
+    ) -> Value {
+        rb_self.inner.borrow_mut().margin = ironpress_core::types::Margin::new(
+            top as f32,
+            right as f32,
+            bottom as f32,
+            left as f32,
+        );
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `compress(enabled)` -- enable/disable FlateDecode compression.
+    fn compress(ruby: &Ruby, rb_self: RbSelf, enabled: bool) -> Value {
+        rb_self.inner.borrow_mut().compress = Some(enabled);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `jpeg_quality(quality)` -- JPEG quality 0-100.
+    fn jpeg_quality(ruby: &Ruby, rb_self: RbSelf, quality: u8) -> Value {
+        rb_self.inner.borrow_mut().jpeg_quality = Some(quality);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `auto_resize_images(enabled)` -- enable/disable automatic image downscaling.
+    fn auto_resize_images(ruby: &Ruby, rb_self: RbSelf, enabled: bool) -> Value {
+        rb_self.inner.borrow_mut().auto_resize_images = Some(enabled);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `image_dpi(dpi)` -- source image resolution (min 72, default 300).
+    fn image_dpi(ruby: &Ruby, rb_self: RbSelf, dpi: f64) -> Value {
+        rb_self.inner.borrow_mut().image_dpi = Some(dpi as f32);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `filter_dpi(dpi)` -- blur/filter bitmap DPI.
+    fn filter_dpi(ruby: &Ruby, rb_self: RbSelf, dpi: f64) -> Value {
+        rb_self.inner.borrow_mut().filter_dpi = Some(dpi as f32);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `mask_dpi(dpi)` -- CSS mask-image coverage DPI.
+    fn mask_dpi(ruby: &Ruby, rb_self: RbSelf, dpi: f64) -> Value {
+        rb_self.inner.borrow_mut().mask_dpi = Some(dpi as f32);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `background_raster_dpi(dpi)` -- background bitmap DPI.
+    fn background_raster_dpi(ruby: &Ruby, rb_self: RbSelf, dpi: f64) -> Value {
+        rb_self.inner.borrow_mut().background_raster_dpi = Some(dpi as f32);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `occlusion_cull(enabled)` -- enable/disable occlusion culling.
+    fn occlusion_cull(ruby: &Ruby, rb_self: RbSelf, enabled: bool) -> Value {
+        rb_self.inner.borrow_mut().occlusion_cull = Some(enabled);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `sanitize(enabled)` -- enable/disable HTML sanitization.
+    fn sanitize(ruby: &Ruby, rb_self: RbSelf, enabled: bool) -> Value {
+        rb_self.inner.borrow_mut().sanitize = Some(enabled);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `add_font(name, ttf_data)` -- register a custom TrueType font.
+    fn add_font(ruby: &Ruby, rb_self: RbSelf, name: String, ttf_data: RString) -> Value {
+        let data = unsafe { ttf_data.as_slice() }.to_vec();
+        rb_self.inner.borrow_mut().custom_fonts.push((name, data));
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `base_path(path)` -- base directory for resolving relative paths.
+    fn base_path(ruby: &Ruby, rb_self: RbSelf, path: String) -> Value {
+        rb_self.inner.borrow_mut().base_path = Some(path);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `resource_root(path)` -- authorized resource boundary directory.
+    fn resource_root(ruby: &Ruby, rb_self: RbSelf, path: String) -> Value {
+        rb_self.inner.borrow_mut().resource_root = Some(path);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `header(text)` -- header text rendered at the top of each page.
+    fn header(ruby: &Ruby, rb_self: RbSelf, text: String) -> Value {
+        rb_self.inner.borrow_mut().header = Some(text);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `footer(text)` -- footer text rendered at the bottom of each page.
+    /// Use `{page}` for current page number and `{pages}` for total count.
+    fn footer(ruby: &Ruby, rb_self: RbSelf, text: String) -> Value {
+        rb_self.inner.borrow_mut().footer = Some(text);
+        rb_self.into_value_with(ruby)
+    }
+
+    /// `convert(html)` -- convert HTML to PDF bytes.
+    fn convert(ruby: &Ruby, rb_self: RbSelf, html: String) -> Result<RString, Error> {
+        let converter = rb_self.inner.borrow().build();
+        let pdf = converter
+            .convert(&html)
+            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
+        Ok(ruby.str_from_slice(&pdf))
+    }
+
+    /// `convert_markdown(markdown)` -- convert Markdown to PDF bytes.
+    fn convert_markdown(ruby: &Ruby, rb_self: RbSelf, markdown: String) -> Result<RString, Error> {
+        let converter = rb_self.inner.borrow().build();
+        let pdf = converter
+            .convert_markdown(&markdown)
+            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
+        Ok(ruby.str_from_slice(&pdf))
+    }
+
+    /// `convert_to_file(html, path)` -- convert HTML and write PDF to a file.
+    fn convert_to_file(
+        ruby: &Ruby,
+        rb_self: RbSelf,
+        html: String,
+        path: String,
+    ) -> Result<Value, Error> {
+        let converter = rb_self.inner.borrow().build();
+        let pdf = converter
+            .convert(&html)
+            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
+        std::fs::write(&path, &pdf)
+            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
+        Ok(rb_self.into_value_with(ruby))
+    }
+
+    /// `convert_markdown_to_file(markdown, path)` -- convert Markdown and write PDF to a file.
+    fn convert_markdown_to_file(
+        ruby: &Ruby,
+        rb_self: RbSelf,
+        markdown: String,
+        path: String,
+    ) -> Result<Value, Error> {
+        let converter = rb_self.inner.borrow().build();
+        let pdf = converter
+            .convert_markdown(&markdown)
+            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
+        std::fs::write(&path, &pdf)
+            .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
+        Ok(rb_self.into_value_with(ruby))
+    }
+}
+
 #[magnus::init]
-fn init(ruby: &Ruby) -> Result<(), Error> {
+fn init(_ruby: &Ruby) -> Result<(), Error> {
     let module = define_module("Ironpress")?;
+
+    // Module-level convenience functions (existing API).
     module.define_singleton_method("html_to_pdf", function!(html_to_pdf, 1))?;
     module.define_singleton_method("markdown_to_pdf", function!(markdown_to_pdf, 1))?;
+
+    // HtmlConverter class under the Ironpress module.
+    let klass = module.define_class("HtmlConverter", class::object())?;
+    klass.define_singleton_method("new", function!(RbHtmlConverter::new, 0))?;
+    klass.define_method("page_size", method!(RbHtmlConverter::page_size, 1))?;
+    klass.define_method("margin", method!(RbHtmlConverter::margin, 1))?;
+    klass.define_method("margin_sides", method!(RbHtmlConverter::margin_sides, 4))?;
+    klass.define_method("compress", method!(RbHtmlConverter::compress, 1))?;
+    klass.define_method("jpeg_quality", method!(RbHtmlConverter::jpeg_quality, 1))?;
+    klass.define_method(
+        "auto_resize_images",
+        method!(RbHtmlConverter::auto_resize_images, 1),
+    )?;
+    klass.define_method("image_dpi", method!(RbHtmlConverter::image_dpi, 1))?;
+    klass.define_method("filter_dpi", method!(RbHtmlConverter::filter_dpi, 1))?;
+    klass.define_method("mask_dpi", method!(RbHtmlConverter::mask_dpi, 1))?;
+    klass.define_method(
+        "background_raster_dpi",
+        method!(RbHtmlConverter::background_raster_dpi, 1),
+    )?;
+    klass.define_method("occlusion_cull", method!(RbHtmlConverter::occlusion_cull, 1))?;
+    klass.define_method("sanitize", method!(RbHtmlConverter::sanitize, 1))?;
+    klass.define_method("add_font", method!(RbHtmlConverter::add_font, 2))?;
+    klass.define_method("base_path", method!(RbHtmlConverter::base_path, 1))?;
+    klass.define_method("resource_root", method!(RbHtmlConverter::resource_root, 1))?;
+    klass.define_method("header", method!(RbHtmlConverter::header, 1))?;
+    klass.define_method("footer", method!(RbHtmlConverter::footer, 1))?;
+    klass.define_method("convert", method!(RbHtmlConverter::convert, 1))?;
+    klass.define_method(
+        "convert_markdown",
+        method!(RbHtmlConverter::convert_markdown, 1),
+    )?;
+    klass.define_method(
+        "convert_to_file",
+        method!(RbHtmlConverter::convert_to_file, 2),
+    )?;
+    klass.define_method(
+        "convert_markdown_to_file",
+        method!(RbHtmlConverter::convert_markdown_to_file, 2),
+    )?;
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **Python**: expand `HtmlConverter` from 4 methods to 20, covering the full Rust builder API
- **Ruby**: add `Ironpress::HtmlConverter` class with 22 methods (previously only module-level `html_to_pdf`/`markdown_to_pdf`)

## New methods (both bindings)

| Method | Description |
|--------|-------------|
| `margin_sides(top, right, bottom, left)` | Per-side margins |
| `page_size_custom(width, height)` | Custom page dimensions |
| `compress(enabled)` | FlateDecode compression |
| `jpeg_quality(quality)` | JPEG quality 0-100 |
| `auto_resize_images(enabled)` | Auto downscaling |
| `image_dpi(dpi)` | Source image resolution |
| `filter_dpi(dpi)` | Blur/filter bitmap DPI |
| `mask_dpi(dpi)` | CSS mask-image DPI |
| `background_raster_dpi(dpi)` | Background bitmap DPI |
| `occlusion_cull(enabled)` | Occlusion culling |
| `sanitize(enabled)` | HTML sanitization |
| `add_font(name, data)` | Custom TTF font |
| `base_path(path)` | Resource base directory |
| `resource_root(path)` | Resource boundary |
| `header(text)` | Page header |
| `footer(text)` | Page footer with `{page}/{pages}` |
| `convert_to_file(html, path)` | Convert + write to file |
| `convert_markdown_to_file(md, path)` | Convert markdown + write to file |

## Backward compatibility

- Python: existing `html_to_pdf()`, `markdown_to_pdf()`, and `HtmlConverter` API unchanged
- Ruby: existing `Ironpress.html_to_pdf()` and `Ironpress.markdown_to_pdf()` unchanged

## Test plan

- [ ] `cargo check` passes for both bindings
- [ ] CI (clippy, fmt, test) passes
- [ ] Python: `import ironpress; c = ironpress.HtmlConverter(); c.compress(False); c.convert("<h1>Hi</h1>")`
- [ ] Ruby: `require "ironpress"; c = Ironpress::HtmlConverter.new; c.header("Test"); c.convert("<h1>Hi</h1>")`