### PR TITLE
feat(security): authorise every resource load via an ambient Resource…

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -6013,6 +6013,7 @@ mod tests {
 
     #[test]
     fn raster_background_image_survives_into_layout() {
+        let _loader = crate::layout::images::trusted_scope();
         let path = write_test_png_file("layout-bg", &build_test_png_bytes());
         let html = format!(
             r#"<div style="width: 40pt; height: 40pt; background-image: url('{path}'); background-repeat: no-repeat"></div>"#
@@ -11145,6 +11146,7 @@ mod tests {
 
     #[test]
     fn table_cell_preserves_empty_block_background_layout() {
+        let _loader = crate::layout::images::trusted_scope();
         let path = write_test_png_file("table-cell-bg", &build_test_png_bytes());
         let html = format!(
             r#"

--- a/src/layout/helpers.rs
+++ b/src/layout/helpers.rs
@@ -2113,8 +2113,8 @@ fn build_pseudo_inline_box(
 /// if the image cannot be decoded (the pseudo then produces no box).
 fn build_pseudo_image_box(pseudo_style: &ComputedStyle, url: &str) -> Option<InlineBox> {
     let image_src = crate::parser::css::extract_url_path(url).unwrap_or_else(|| url.to_string());
-    let (raw, _mime) = crate::layout::images::load_src_bytes(&image_src)?;
-    let image = crate::layout::images::load_image_bytes(raw)?;
+    let (raw, _mime) = crate::layout::images::load_resource(&image_src, None)?;
+    let image = crate::layout::images::load_image_bytes(raw.to_vec())?;
 
     // Intrinsic image pixels map to CSS px at 1x, and CSS px → PDF points at
     // 1px = 0.75pt (96dpi). The same conversion is applied to `<img>` intrinsic
@@ -2157,8 +2157,8 @@ fn build_pseudo_image_box(pseudo_style: &ComputedStyle, url: &str) -> Option<Inl
 /// fall back to the `list-style-type` glyph marker.
 pub(crate) fn build_list_image_marker(value: &str, gap: f32) -> Option<InlineBox> {
     let url = crate::parser::css::extract_url_path(value).unwrap_or_else(|| value.to_string());
-    let (raw, _mime) = crate::layout::images::load_src_bytes(&url)?;
-    let image = crate::layout::images::load_image_bytes(raw)?;
+    let (raw, _mime) = crate::layout::images::load_resource(&url, None)?;
+    let image = crate::layout::images::load_image_bytes(raw.to_vec())?;
     // The InlineBox dimensions are in PDF points; the image's intrinsic size is
     // in CSS px, so convert px -> pt (1px = 0.75pt) exactly as `load_image_bytes`
     // consumers do for ordinary <img>. Without this the marker paints at its raw

--- a/src/layout/images/loader.rs
+++ b/src/layout/images/loader.rs
@@ -14,6 +14,139 @@ use super::placement::{ReplacedBoxSize, parse_html_image_dimension};
 use super::raster::decode_png_to_rgb_asset;
 use super::source::{fetch_remote_url, percent_decode};
 use super::svg::{resolve_svg_size, sync_svg_tree_to_layout_box};
+use crate::security::resources::{DocumentResources, ResourceAccess};
+
+/// Per-conversion capability that authorises a document resource reference
+/// against the policy and loads (once, memoised) its bytes. It is the single
+/// gate through which document-referenced bytes enter the process: callers hold
+/// a `ResourceLoader` instead of calling [`load_src_bytes`] directly, so every
+/// load is authorised and cached at one place.
+/// Loaded resource bytes plus the optional MIME reported by the source.
+pub(crate) type LoadedResource = (std::sync::Arc<Vec<u8>>, Option<String>);
+
+pub(crate) struct ResourceLoader {
+    policy: DocumentResources,
+    /// Memoised loads keyed by the resolved (authorised) reference. `None`
+    /// records a denied or failed reference so it is not retried per repaint.
+    cache: std::cell::RefCell<std::collections::HashMap<String, Option<LoadedResource>>>,
+}
+
+impl ResourceLoader {
+    pub(crate) fn new(policy: DocumentResources) -> Self {
+        Self {
+            policy,
+            cache: std::cell::RefCell::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// A loader that authorises any local or network reference (Trusted, no
+    /// root). Test-only: standalone rendering/layout of local-file content that
+    /// does not go through a policy-bearing `HtmlConverter` conversion.
+    #[cfg(test)]
+    pub(crate) fn trusted() -> Self {
+        Self::new(DocumentResources::new(ResourceAccess::Trusted, None, None))
+    }
+
+    /// Authorise `reference` against the policy (returning `None` when denied),
+    /// then load its bytes. File/URL loads are memoised; inline `data:`
+    /// references are not (they decode to unique bytes that are rarely repeated,
+    /// and caching them would key the whole multi-KB URI for no reuse). `base`
+    /// is the directory relative references resolve against.
+    pub(crate) fn load(
+        &self,
+        reference: &str,
+        base: Option<&std::path::Path>,
+    ) -> Option<LoadedResource> {
+        let resolved = self.policy.resolve(reference, base)?;
+        if is_inline_reference(&resolved) {
+            return load_src_bytes(&resolved).map(|(bytes, mime)| (std::sync::Arc::new(bytes), mime));
+        }
+        if let Some(hit) = self.cache.borrow().get(&resolved) {
+            return hit.clone();
+        }
+        let loaded = self.load_resolved(&resolved);
+        self.cache.borrow_mut().insert(resolved, loaded.clone());
+        loaded
+    }
+
+    /// Load an already-authorised (file or network) reference. Network fetches
+    /// additionally pass the document's [`NetworkPolicy`] so the SSRF controls
+    /// (deny/allow lists, IP-class rejection) apply at the point of connection.
+    fn load_resolved(&self, resolved: &str) -> Option<LoadedResource> {
+        if is_network_reference(resolved) {
+            return fetch_remote_url(resolved, self.policy.network())
+                .map(|bytes| (std::sync::Arc::new(bytes), None));
+        }
+        load_src_bytes(resolved).map(|(bytes, mime)| (std::sync::Arc::new(bytes), mime))
+    }
+}
+
+impl Default for ResourceLoader {
+    /// Deny-by-default: only inline `data:`/fragment references resolve; local
+    /// files and network are refused. Used where no document policy is supplied.
+    fn default() -> Self {
+        Self::new(DocumentResources::new(ResourceAccess::Sanitized, None, None))
+    }
+}
+
+/// A `data:` reference: its bytes are self-contained, so loading is cheap and
+/// caching would key the entire URI for no reuse.
+fn is_inline_reference(reference: &str) -> bool {
+    reference
+        .get(..5)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:"))
+}
+
+thread_local! {
+    /// The ambient resource loader for the current conversion. A stack so that a
+    /// conversion nested on the same thread restores the outer loader on exit.
+    static CURRENT_LOADER: std::cell::RefCell<Vec<std::rc::Rc<ResourceLoader>>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Installs `loader` as the ambient loader for the current thread until the
+/// returned guard is dropped. Every resource sink loads through the ambient
+/// loader, so authorization/caching is configured once per conversion rather
+/// than threaded through layout and render.
+#[must_use = "the ambient loader is only active while the guard is alive"]
+pub(crate) fn enter_loader(loader: std::rc::Rc<ResourceLoader>) -> LoaderScope {
+    CURRENT_LOADER.with(|stack| stack.borrow_mut().push(loader));
+    LoaderScope { _private: () }
+}
+
+/// Install a trusted ambient loader for tests that render/lay out content
+/// referencing local files directly (outside a policy-bearing conversion).
+#[cfg(test)]
+pub(crate) fn trusted_scope() -> LoaderScope {
+    enter_loader(std::rc::Rc::new(ResourceLoader::trusted()))
+}
+
+/// RAII guard that pops the ambient loader it installed.
+pub(crate) struct LoaderScope {
+    _private: (),
+}
+
+impl Drop for LoaderScope {
+    fn drop(&mut self) {
+        CURRENT_LOADER.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+    }
+}
+
+/// Load a document resource through the ambient loader. When no loader is
+/// installed the load is denied by default (only inline `data:` resolves), so a
+/// stray load outside a conversion cannot reach the filesystem or network.
+pub(crate) fn load_resource(
+    reference: &str,
+    base: Option<&std::path::Path>,
+) -> Option<LoadedResource> {
+    let loader = CURRENT_LOADER.with(|stack| stack.borrow().last().cloned());
+    match loader {
+        Some(loader) => loader.load(reference, base),
+        None => ResourceLoader::default().load(reference, base),
+    }
+}
 
 /// Load raw bytes from a `src` attribute value.
 pub(crate) fn load_src_bytes(src: &str) -> Option<(Vec<u8>, Option<String>)> {
@@ -32,11 +165,17 @@ pub(crate) fn load_src_bytes(src: &str) -> Option<(Vec<u8>, Option<String>)> {
             Some(header_lower)
         };
         Some((bytes, mime))
-    } else if src.starts_with("http://") || src.starts_with("https://") {
-        Some((fetch_remote_url(src)?, None))
+    } else if is_network_reference(src) {
+        // Network loads are authorised and fetched by ResourceLoader::load_resolved.
+        None
     } else {
         Some((std::fs::read(src).ok()?, None))
     }
+}
+
+/// An `http`/`https` reference (fetched, subject to the network policy).
+fn is_network_reference(reference: &str) -> bool {
+    crate::security::resources::is_network_url(reference)
 }
 
 /// Heuristic SVG sniff over raw bytes (first 512 bytes, UTF-8-lossy so binary
@@ -145,7 +284,7 @@ pub(crate) fn load_image_from_element(
     let src = el.attributes.get("src")?;
 
     // Load bytes once.
-    let (raw, mime) = load_src_bytes(src)?;
+    let (raw, mime) = load_resource(src, None)?;
 
     // For data URIs with a non-SVG MIME type, skip the SVG probe entirely.
     let skip_svg = mime
@@ -213,7 +352,7 @@ pub(crate) fn load_image_from_element(
     // SourceGraphic, including its background and border. Keep image loading
     // unfiltered; the shared post-layout filter compositor owns the operation
     // list for every element kind.
-    let image = load_image_bytes(raw)?;
+    let image = load_image_bytes(raw.to_vec())?;
 
     // Determine dimensions: CSS width/height take precedence over the HTML
     // width/height attributes (matching the SVG path and the CSS cascade).
@@ -278,4 +417,38 @@ pub(crate) fn load_image_from_element(
         }
         .boxed(),
     )
+}
+
+#[cfg(test)]
+mod loader_tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_is_the_resolved_path_so_a_relative_ref_never_serves_the_wrong_base() {
+        let root = std::env::temp_dir().join(format!("ip-loader-{}", std::process::id()));
+        let a = root.join("a");
+        let b = root.join("b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        std::fs::write(a.join("x"), b"AAAA").unwrap();
+        std::fs::write(b.join("x"), b"BBBB").unwrap();
+
+        let loader = ResourceLoader::new(DocumentResources::new(
+            ResourceAccess::Sanitized,
+            None,
+            Some(root.as_path()),
+        ));
+
+        let from_a = loader.load("x", Some(a.as_path())).expect("a/x authorised").0;
+        let from_b = loader.load("x", Some(b.as_path())).expect("b/x authorised").0;
+        assert_eq!(&from_a[..], b"AAAA");
+        assert_eq!(
+            &from_b[..],
+            b"BBBB",
+            "a different base must resolve to a different file, not a stale cache hit"
+        );
+        assert_eq!(&loader.load("x", Some(a.as_path())).unwrap().0[..], b"AAAA");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/src/layout/images/mod.rs
+++ b/src/layout/images/mod.rs
@@ -5,8 +5,11 @@ mod source;
 mod svg;
 
 pub(crate) use loader::{
-    load_image_bytes, load_image_from_element, load_src_bytes, looks_like_svg, try_parse_svg_bytes,
+    ResourceLoader, enter_loader, load_image_bytes, load_image_from_element, load_resource,
+    looks_like_svg, try_parse_svg_bytes,
 };
+#[cfg(test)]
+pub(crate) use loader::trusted_scope;
 pub(crate) use placement::{
     ImagePlacement, InlineBaselineGapRounding, add_inline_replaced_baseline_gap,
     compute_image_placement, compute_replaced_content_placement, svg_intrinsic_size,

--- a/src/layout/images/source.rs
+++ b/src/layout/images/source.rs
@@ -1,5 +1,6 @@
 use crate::parser::png;
 
+#[cfg(test)]
 use super::loader::load_src_bytes;
 
 #[cfg(test)]
@@ -7,36 +8,22 @@ use super::loader::load_image_bytes;
 #[cfg(test)]
 use crate::layout::engine::RasterImageAsset;
 
-/// Maximum size for remote resources (10 MB).
-#[cfg(feature = "remote")]
-const MAX_REMOTE_SIZE: usize = 10 * 1024 * 1024;
-
-/// Fetch bytes from an HTTP/HTTPS URL (requires the `remote` feature).
-/// Returns `None` if the feature is disabled, the request fails, or the response exceeds 10 MB.
-pub(crate) fn fetch_remote_url(url: &str) -> Option<Vec<u8>> {
+/// Fetch bytes from an HTTP/HTTPS URL, subject to `policy` (requires the
+/// `remote` feature). Returns `None` if the feature is disabled, the URL is
+/// rejected by the network policy, the request fails, or the response exceeds
+/// 10 MB. Redirects are not followed: a redirect could point at an internal
+/// host that bypasses the policy, so only a direct response is accepted.
+pub(crate) fn fetch_remote_url(
+    url: &str,
+    policy: &crate::security::resources::NetworkPolicy,
+) -> Option<Vec<u8>> {
     #[cfg(feature = "remote")]
     {
-        let resp = ureq::get(url).call().ok()?;
-        let len = resp
-            .headers()
-            .get("content-length")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(0);
-        if len > MAX_REMOTE_SIZE {
-            return None;
-        }
-        let buf = resp
-            .into_body()
-            .with_config()
-            .limit(MAX_REMOTE_SIZE as u64)
-            .read_to_vec()
-            .ok()?;
-        Some(buf)
+        crate::security::network::fetch_authorized(url, policy)
     }
     #[cfg(not(feature = "remote"))]
     {
-        let _ = url;
+        let _ = (url, policy);
         None
     }
 }
@@ -52,7 +39,7 @@ pub(crate) fn load_image_data(src: &str) -> Option<RasterImageAsset> {
 
 pub(crate) fn build_raster_background_tree(src: &str) -> Option<crate::parser::svg::SvgTree> {
     let image_src = crate::parser::css::extract_url_path(src).unwrap_or_else(|| src.to_string());
-    let (raw, _mime) = load_src_bytes(&image_src)?;
+    let (raw, _mime) = crate::layout::images::load_resource(&image_src, None)?;
     let (width, height) = raster_image_dimensions(&raw)?;
 
     Some(crate::parser::svg::SvgTree {

--- a/src/layout/images/tests/raster.rs
+++ b/src/layout/images/tests/raster.rs
@@ -11,7 +11,10 @@ fn try_parse_svg_bytes_accepts_utf8_bom_prefix() {
 #[test]
 fn fetch_remote_url_returns_none_without_feature() {
     // Without the "remote" feature, fetch_remote_url always returns None
-    let result = fetch_remote_url("https://example.com/image.png");
+    let result = fetch_remote_url(
+        "https://example.com/image.png",
+        &crate::security::resources::NetworkPolicy::default(),
+    );
     #[cfg(not(feature = "remote"))]
     assert!(result.is_none());
     // With the feature enabled, it would attempt a real HTTP request

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,18 +97,14 @@ pub(crate) mod util;
 /// Fetch bytes from a remote URL (requires the `remote` feature).
 /// Returns `None` when the feature is disabled or the request fails.
 #[allow(unused_variables)]
-fn fetch_remote_bytes(url: &str) -> Option<Vec<u8>> {
+fn fetch_remote_bytes(url: &str, policy: &security::resources::NetworkPolicy) -> Option<Vec<u8>> {
     #[cfg(feature = "remote")]
     {
-        let resp = ureq::get(url).call().ok()?;
-        resp.into_body()
-            .with_config()
-            .limit(10 * 1024 * 1024)
-            .read_to_vec()
-            .ok()
+        security::network::fetch_authorized(url, policy)
     }
     #[cfg(not(feature = "remote"))]
     {
+        let _ = (url, policy);
         None
     }
 }
@@ -268,6 +264,8 @@ pub struct HtmlConverter {
 struct ResourcePaths {
     base: Option<std::path::PathBuf>,
     authorized_root: Option<std::path::PathBuf>,
+    /// Remote-fetch controls (SSRF), modelled on Gotenberg's `downloadFrom`.
+    network: security::resources::NetworkPolicy,
 }
 
 impl HtmlConverter {
@@ -444,6 +442,59 @@ impl HtmlConverter {
         self
     }
 
+    /// Allow-list of host patterns for remote (`http`/`https`) resource URLs. A
+    /// URL whose host matches is fetched and **bypasses** the IP-class checks.
+    /// Each pattern is an exact host (`cdn.example.com`) or a `.`-prefixed suffix
+    /// matching any subdomain (`.example.com`). Modelled on Gotenberg's
+    /// `--api-download-from-allow-list`.
+    pub fn download_allow_list(mut self, patterns: impl IntoIterator<Item = String>) -> Self {
+        self.resources.network.allow = patterns.into_iter().collect();
+        self
+    }
+
+    /// Deny-list of host patterns for remote resource URLs. A URL whose host
+    /// matches is **always** rejected, regardless of the allow-list or IP-class
+    /// flags. Same pattern syntax as [`download_allow_list`](Self::download_allow_list).
+    /// Modelled on Gotenberg's `--api-download-from-deny-list`.
+    pub fn download_deny_list(mut self, patterns: impl IntoIterator<Item = String>) -> Self {
+        self.resources.network.deny = patterns.into_iter().collect();
+        self
+    }
+
+    /// Reject remote resource URLs whose host resolves to a non-public IP
+    /// (loopback, RFC1918, link-local, IPv6 unique-local). The core SSRF
+    /// control; modelled on Gotenberg's `--api-download-from-deny-private-ips`.
+    ///
+    /// **Enabled by default.** Pass `false` to allow fetching from
+    /// private/reserved addresses (e.g. an internal CDN), ideally paired with a
+    /// [`download_allow_list`](Self::download_allow_list) of trusted hosts.
+    pub fn download_deny_private_ips(mut self, deny: bool) -> Self {
+        self.resources.network.deny_private_ips = deny;
+        self
+    }
+
+    /// Reject remote resource URLs whose host resolves to a public IP. Combined
+    /// with an allow-list, restricts fetches to explicitly permitted hosts.
+    /// Modelled on Gotenberg's `--api-download-from-deny-public-ips`.
+    pub fn download_deny_public_ips(mut self, deny: bool) -> Self {
+        self.resources.network.deny_public_ips = deny;
+        self
+    }
+
+    /// Maximum number of redirect hops followed when fetching a remote resource
+    /// (default 8). Each hop is re-checked against the network policy.
+    pub fn download_max_redirects(mut self, max: u32) -> Self {
+        self.resources.network.max_redirects = max;
+        self
+    }
+
+    /// Maximum accepted size, in bytes, of a fetched remote resource body
+    /// (default 10 MB).
+    pub fn download_max_body_size(mut self, max: u64) -> Self {
+        self.resources.network.max_body_size = max;
+        self
+    }
+
     /// Set a header text rendered at the top of each page (in the top margin area).
     pub fn header(mut self, text: impl Into<String>) -> Self {
         self.header = Some(text.into());
@@ -500,7 +551,15 @@ impl HtmlConverter {
             resource_access,
             self.resources.base.as_deref(),
             self.resources.authorized_root.as_deref(),
-        );
+        )
+        .with_network(self.resources.network.clone());
+
+        // Install the document resource policy as the ambient loader for this
+        // conversion: every resource sink in layout and render authorises and
+        // caches through it. The guard restores the previous loader on return.
+        let _loader_scope = layout::images::enter_loader(std::rc::Rc::new(
+            layout::images::ResourceLoader::new(resources.clone()),
+        ));
 
         // Step 1: Sanitize
         let sanitized_html = if self.sanitize {
@@ -951,7 +1010,7 @@ fn resolve_font_face_source(
                 continue;
             };
             let ttf_data = if resolved.starts_with("http://") || resolved.starts_with("https://") {
-                fetch_remote_bytes(&resolved)
+                fetch_remote_bytes(&resolved, resources.network())
             } else {
                 std::fs::read(resolved).ok()
             };
@@ -1874,7 +1933,13 @@ fn main() {
     #[test]
     fn fetch_remote_bytes_returns_none_without_feature() {
         #[cfg(not(feature = "remote"))]
-        assert!(fetch_remote_bytes("https://example.com/test").is_none());
+        assert!(
+            fetch_remote_bytes(
+                "https://example.com/test",
+                &security::resources::NetworkPolicy::default()
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/src/render/background.rs
+++ b/src/render/background.rs
@@ -325,7 +325,7 @@ pub(crate) fn register_background_image(
     display_box: SvgViewportBox,
     request: Option<RasterBackgroundRequest>,
 ) -> Option<RegisteredBackgroundImage> {
-    let (raw, _mime) = crate::layout::images::load_src_bytes(href)?;
+    let (raw, _mime) = crate::layout::images::load_resource(href, None)?;
     let (obj_id, draw_box) =
         if let Some(request) = request.filter(|request| request.blur_radius > 0.0) {
             let (encoded, draw_box) = encode_blurred_png_for_background(&raw, request)?;

--- a/src/render/pdf/border_images/source.rs
+++ b/src/render/pdf/border_images/source.rs
@@ -104,14 +104,14 @@ pub(super) fn resolve_border_image_source(
 }
 
 fn resolve_url_source(url: &str) -> Option<ResolvedBorderImageSource<'static>> {
-    let (bytes, mime) = crate::layout::images::load_src_bytes(url)?;
+    let (bytes, mime) = crate::layout::images::load_resource(url, None)?;
     let skip_svg = mime
         .as_deref()
         .is_some_and(|mime| !mime.contains("svg") && !mime.contains("xml"));
     if !skip_svg && let Some(tree) = crate::layout::images::try_parse_svg_bytes(&bytes) {
         return Some(ResolvedBorderImageSource::Svg(Box::new(tree)));
     }
-    crate::layout::images::load_image_bytes(bytes).map(ResolvedBorderImageSource::Raster)
+    crate::layout::images::load_image_bytes(bytes.to_vec()).map(ResolvedBorderImageSource::Raster)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/render/pdf/mod.rs
+++ b/src/render/pdf/mod.rs
@@ -375,6 +375,7 @@ pub(crate) fn render_pdf_to_writer_full<W: std::io::Write>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn render_pdf_to_writer_full_opts<W: std::io::Write>(
     pages: &[Page],
     page_size: PageSize,

--- a/src/render/pdf/tests/backgrounds.rs
+++ b/src/render/pdf/tests/backgrounds.rs
@@ -461,6 +461,7 @@ fn root_svg_background_with_gradient_registers_shading_resources() {
 
 #[test]
 fn table_cell_nested_background_block_renders_image_xobject() {
+    let _loader = crate::layout::images::trusted_scope();
     let path = write_test_png_file("table-cell-pdf-bg", &build_minimal_test_png());
     let html = format!(
         r#"<table><tr><td><div style="display: flex; width: 40pt; aspect-ratio: 1 / 1; background-image: url('{path}'); background-repeat: no-repeat;"></div></td></tr></table>"#

--- a/src/render/pdf/tests/images.rs
+++ b/src/render/pdf/tests/images.rs
@@ -945,6 +945,45 @@
         assert!(content.contains("/Colors 1"));
     }
 
+    /// Regression (public API): a protocol-relative `//abs/path` must not escape
+    /// the authorized root. Unix-only, where a leading `//` collapses to an
+    /// absolute path — the exploit that let it be read as a local file.
+    #[cfg(unix)]
+    #[test]
+    fn protocol_relative_reference_cannot_escape_resource_root() {
+        let root = tempfile::tempdir().expect("authorized root");
+        let outside = tempfile::tempdir().expect("outside directory");
+        let secret = outside.path().join("secret.png");
+        std::fs::write(&secret, build_minimal_test_png()).expect("secret fixture");
+
+        // Positive control, so the negative assertion can't pass vacuously.
+        std::fs::write(root.path().join("ok.png"), build_minimal_test_png())
+            .expect("in-root fixture");
+        let allowed = crate::HtmlConverter::new()
+            .compress(false)
+            .sanitize(false)
+            .resource_root(root.path())
+            .convert(r#"<img src="ok.png" width="10" height="10">"#)
+            .expect("in-root image converts");
+        assert!(
+            String::from_utf8_lossy(&allowed).contains("/Subtype /Image"),
+            "control: an authorized in-root image should embed"
+        );
+
+        let reference = format!("/{}", secret.display()); // //<abs path>, e.g. //tmp/xxx/secret.png
+        let html = format!(r#"<img src="{reference}" width="10" height="10">"#);
+        let escaped = crate::HtmlConverter::new()
+            .compress(false)
+            .sanitize(false)
+            .resource_root(root.path())
+            .convert(&html)
+            .expect("conversion still succeeds, just without the outside file");
+        assert!(
+            !String::from_utf8_lossy(&escaped).contains("/Subtype /Image"),
+            "a protocol-relative reference must not read a file outside the resource root"
+        );
+    }
+
     /// Build a minimal valid PNG (1x1 RGB, 8-bit).
     fn build_minimal_test_png() -> Vec<u8> {
         build_test_png_with_color_type(2) // RGB

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -1699,7 +1699,7 @@ fn render_image_with_resources(
     let Some(href) = href else {
         return;
     };
-    let Some((raw, mime)) = crate::layout::images::load_src_bytes(href) else {
+    let Some((raw, mime)) = crate::layout::images::load_resource(href, None) else {
         return;
     };
 
@@ -3102,6 +3102,44 @@ mod tests {
     }
 
     #[test]
+    fn render_image_local_file_denied_by_default_loader() {
+        // The nested-`<image href>` file-read / SSRF vector this whole change closes.
+        let svg_path = unique_temp_svg_path();
+        std::fs::write(
+            &svg_path,
+            r#"<svg width="10" height="5"><rect width="10" height="5"/></svg>"#,
+        )
+        .unwrap();
+        let tree = tree_with(vec![SvgNode::Image {
+            x: 0.0,
+            y: 0.0,
+            width: 20.0,
+            height: 10.0,
+            href: svg_path.to_string_lossy().into_owned(),
+            preserve_aspect_ratio: SvgPreserveAspectRatio::default(),
+            style: SvgStyle::default(),
+        }]);
+        let mut out = String::new();
+        // `render_svg_tree` uses the deny-by-default loader.
+        render_svg_tree(&tree, &mut out);
+        let _ = std::fs::remove_file(svg_path);
+        assert!(
+            out.is_empty(),
+            "a local-file <image> must not load under the deny-by-default loader, got: {out:?}"
+        );
+    }
+
+    /// Render a bare tree with an ambient loader that authorises local
+    /// references, for tests that deliberately load a temp file (the default
+    /// loader denies them).
+    fn render_svg_tree_trusted(tree: &SvgTree, out: &mut String) {
+        let _scope = crate::layout::images::enter_loader(std::rc::Rc::new(
+            crate::layout::images::ResourceLoader::trusted(),
+        ));
+        render_svg_tree(tree, out);
+    }
+
+    #[test]
     fn render_image_png_data_uri_uses_inline_image() {
         let png_path = unique_temp_png_path();
         image::DynamicImage::ImageRgb8(image::RgbImage::from_pixel(1, 1, image::Rgb([255, 0, 0])))
@@ -3117,7 +3155,7 @@ mod tests {
             style: SvgStyle::default(),
         }]);
         let mut out = String::new();
-        render_svg_tree(&tree, &mut out);
+        render_svg_tree_trusted(&tree, &mut out);
         let _ = std::fs::remove_file(png_path);
         assert!(out.contains("BI\n"), "inline image should use BI");
         assert!(out.contains("/W 1\n"), "PNG width should be embedded");
@@ -3170,6 +3208,9 @@ mod tests {
             prepared_custom_fonts: None,
         };
 
+        let _scope = crate::layout::images::enter_loader(std::rc::Rc::new(
+            crate::layout::images::ResourceLoader::trusted(),
+        ));
         render_svg_tree_with_resources(&tree, &mut out, &mut resources);
         let _ = std::fs::remove_file(png_path);
 
@@ -3233,7 +3274,7 @@ mod tests {
             style: SvgStyle::default(),
         }]);
         let mut out = String::new();
-        render_svg_tree(&tree, &mut out);
+        render_svg_tree_trusted(&tree, &mut out);
         let _ = std::fs::remove_file(svg_path);
 
         assert!(

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "remote")]
+pub(crate) mod network;
 pub(crate) mod resources;
 pub mod sanitizer;

--- a/src/security/network.rs
+++ b/src/security/network.rs
@@ -1,0 +1,553 @@
+//! Remote-fetch authorization (SSRF hardening), modelled on Gotenberg's
+//! `downloadFrom` controls. Only compiled with the `remote` feature, since no
+//! network fetch happens without it.
+//!
+//! NOTE: pinning uses ureq's `unversioned` resolver API, which ureq documents
+//! as not following semver. It is contained entirely in this module.
+
+use super::resources::NetworkPolicy;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use ureq::config::Config;
+use ureq::http::Uri;
+use ureq::unversioned::resolver::{DefaultResolver, ResolvedSocketAddrs, Resolver};
+use ureq::unversioned::transport::{DefaultConnector, NextTimeout};
+
+/// The URL-level decision for one candidate URL, before its host is resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UrlDecision {
+    /// Deny-list match: reject regardless of anything else.
+    Reject,
+    /// Allow-list match: fetch, skipping the IP-class checks (still pinned).
+    AllowBypassIp,
+    /// No list match: fetch, applying the enabled IP-class checks.
+    CheckIp,
+}
+
+fn url_decision(url: &str, policy: &NetworkPolicy) -> UrlDecision {
+    let host = host_of(url);
+    let matches = |patterns: &[String]| {
+        host.as_deref()
+            .is_some_and(|host| patterns.iter().any(|pattern| host_matches(host, pattern)))
+    };
+    if matches(&policy.deny) {
+        UrlDecision::Reject
+    } else if matches(&policy.allow) {
+        UrlDecision::AllowBypassIp
+    } else {
+        UrlDecision::CheckIp
+    }
+}
+
+/// Match a normalised host against a policy pattern: a `.`-prefixed pattern
+/// matches any subdomain (`.example.com` matches `a.example.com`, not the apex
+/// or `evilexample.com`); otherwise the host must match exactly.
+fn host_matches(host: &str, pattern: &str) -> bool {
+    let pattern = pattern.to_ascii_lowercase();
+    if pattern.starts_with('.') {
+        host.ends_with(&pattern)
+    } else {
+        host == pattern
+    }
+}
+
+/// The normalised host of an http(s) URL: lowercased, with userinfo, port,
+/// IPv6 brackets, and any trailing dot removed. Matching this parsed host —
+/// rather than the URL string — is what makes the allow/deny lists robust
+/// against query/path/userinfo bypasses.
+fn host_of(url: &str) -> Option<String> {
+    let rest = url.strip_prefix("http://").or_else(|| url.strip_prefix("https://"))?;
+    // Authority ends at the first '/', '?', or '#'; userinfo precedes '@'.
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
+    let host = if let Some(after) = authority.strip_prefix('[') {
+        // Bracketed IPv6 literal: take up to ']'.
+        after.split(']').next().unwrap_or(after)
+    } else {
+        // host[:port] — the host is up to the port separator.
+        authority.split(':').next().unwrap_or(authority)
+    };
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    (!host.is_empty()).then_some(host)
+}
+
+fn ip_class_allowed(ip: IpAddr, deny_private: bool, deny_public: bool) -> bool {
+    let private = is_private_ip(ip);
+    !((deny_private && private) || (deny_public && !private))
+}
+
+/// Fetch `url` subject to `policy`, following redirects manually and
+/// re-checking each hop. Every connection goes through [`PinnedResolver`], so
+/// the address checked against the IP-class rules is exactly the address
+/// connected to — pinning the connection and closing the DNS-rebinding window.
+/// Returns the body, or `None` if rejected, if it fails, if it redirects more
+/// than `policy.max_redirects` times, or if it exceeds `policy.max_body_size`.
+pub(crate) fn fetch_authorized(url: &str, policy: &NetworkPolicy) -> Option<Vec<u8>> {
+    let mut current = url.to_string();
+    let mut redirects_left = policy.max_redirects;
+    loop {
+        let bypass_ip_checks = match url_decision(&current, policy) {
+            UrlDecision::Reject => return None,
+            UrlDecision::AllowBypassIp => true,
+            UrlDecision::CheckIp => false,
+        };
+        let response = pinned_agent(policy, bypass_ip_checks).get(&current).call().ok()?;
+        let status = response.status().as_u16();
+        if (300..400).contains(&status) {
+            if redirects_left == 0 {
+                return None;
+            }
+            redirects_left -= 1;
+            let location = response.headers().get("location")?.to_str().ok()?.to_string();
+            current = resolve_redirect(&current, &location)?;
+            continue;
+        }
+        let len = response
+            .headers()
+            .get("content-length")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|text| text.parse::<u64>().ok())
+            .unwrap_or(0);
+        if len > policy.max_body_size {
+            return None;
+        }
+        return response
+            .into_body()
+            .with_config()
+            .limit(policy.max_body_size)
+            .read_to_vec()
+            .ok();
+    }
+}
+
+/// An agent that does not auto-follow redirects and resolves through
+/// [`PinnedResolver`].
+///
+/// The default (env) proxy is respected. If a proxy is configured, ureq
+/// connects to the proxy and the proxy resolves the target host, so the
+/// IP-class check and pinning apply to the proxy connection, not the final
+/// target — configuring a safe proxy is the operator's responsibility. The URL
+/// allow/deny lists are checked before the request and hold either way.
+fn pinned_agent(policy: &NetworkPolicy, bypass_ip_checks: bool) -> ureq::Agent {
+    let config = Config::builder().max_redirects(0).build();
+    let resolver = PinnedResolver {
+        deny_private_ips: policy.deny_private_ips,
+        deny_public_ips: policy.deny_public_ips,
+        bypass_ip_checks,
+    };
+    ureq::Agent::with_parts(config, DefaultConnector::default(), resolver)
+}
+
+/// Resolves a host but returns only policy-permitted addresses. Because ureq
+/// connects to exactly what the resolver returns, the checked address is the
+/// connected address.
+#[derive(Debug)]
+struct PinnedResolver {
+    deny_private_ips: bool,
+    deny_public_ips: bool,
+    bypass_ip_checks: bool,
+}
+
+impl Resolver for PinnedResolver {
+    fn resolve(
+        &self,
+        uri: &Uri,
+        config: &Config,
+        timeout: NextTimeout,
+    ) -> Result<ResolvedSocketAddrs, ureq::Error> {
+        let all = DefaultResolver::default().resolve(uri, config, timeout)?;
+        if self.bypass_ip_checks || (!self.deny_private_ips && !self.deny_public_ips) {
+            return Ok(all);
+        }
+        // `from_fn` starts the array empty (`len == 0`), seeding only backing
+        // storage; `push` appends the real addresses. Mirrors ureq's own
+        // `DefaultResolver`.
+        let mut allowed =
+            ResolvedSocketAddrs::from_fn(|_| SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0));
+        for addr in all.iter() {
+            if ip_class_allowed(addr.ip(), self.deny_private_ips, self.deny_public_ips) {
+                allowed.push(*addr);
+            }
+        }
+        if allowed.is_empty() {
+            Err(ureq::Error::HostNotFound)
+        } else {
+            Ok(allowed)
+        }
+    }
+}
+
+/// Resolve a redirect `Location` against the current absolute URL. Absolute
+/// locations are re-checked on the next loop; relative ones stay on the
+/// (already-checked) host.
+fn resolve_redirect(current: &str, location: &str) -> Option<String> {
+    if location.starts_with("http://") || location.starts_with("https://") {
+        return Some(location.to_string());
+    }
+    let origin = origin_of(current)?;
+    if location.starts_with('/') {
+        return Some(format!("{origin}{location}"));
+    }
+    // Relative reference (RFC 3986 §5.3): replace the last path segment.
+    let base = &current[origin.len()..];
+    let base = base.split(['?', '#']).next().unwrap_or(base);
+    let dir_end = base.rfind('/').map_or(0, |slash| slash + 1);
+    let mut path = base[..dir_end].to_string();
+    if !path.starts_with('/') {
+        path.insert(0, '/');
+    }
+    path.push_str(location);
+    Some(format!("{origin}{path}"))
+}
+
+/// `scheme://authority` of an absolute http(s) URL, without a trailing slash.
+fn origin_of(url: &str) -> Option<String> {
+    let scheme_end = url.find("://")? + 3;
+    let authority_len = url[scheme_end..].find('/').unwrap_or(url.len() - scheme_end);
+    Some(url[..scheme_end + authority_len].to_string())
+}
+
+/// Whether `ip` is not publicly routable (an SSRF target): loopback, private,
+/// link-local, CGNAT, unspecified, multicast, benchmarking, documentation,
+/// IPv6 unique-local, Teredo, and reserved ranges. Addresses embedding an IPv4
+/// address (mapped/translated/6to4/NAT64) are judged by that inner address.
+fn is_private_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_private_v4(v4),
+        IpAddr::V6(v6) => is_private_v6(v6),
+    }
+}
+
+fn is_private_v4(ip: Ipv4Addr) -> bool {
+    let [a, b, ..] = ip.octets();
+    ip.is_private()             // 10/8, 172.16/12, 192.168/16
+        || ip.is_loopback()     // 127/8
+        || ip.is_link_local()   // 169.254/16
+        || ip.is_unspecified()  // 0.0.0.0
+        || ip.is_broadcast()    // 255.255.255.255
+        || ip.is_multicast()    // 224/4
+        || ip.is_documentation() // 192.0.2/24, 198.51.100/24, 203.0.113/24
+        || (a == 100 && (64..128).contains(&b)) // 100.64/10 CGNAT
+        || (a == 198 && (18..20).contains(&b)) // 198.18/15 benchmarking
+        || a >= 240 // 240/4 reserved
+}
+
+fn is_private_v6(ip: Ipv6Addr) -> bool {
+    // An address that embeds an IPv4 address is classified by that v4 address,
+    // so an internal target cannot hide inside an IPv6 wrapper.
+    if let Some(v4) = embedded_ipv4(ip) {
+        return is_private_v4(v4);
+    }
+    let seg = ip.segments();
+    let first = seg[0];
+    ip.is_loopback()               // ::1
+        || ip.is_unspecified()     // ::
+        || ip.is_multicast()       // ff00::/8 (incl. ff02::1 link-local all-nodes)
+        || (first & 0xfe00) == 0xfc00 // fc00::/7 unique-local
+        || (first & 0xffc0) == 0xfe80 // fe80::/10 link-local
+        || (first == 0x2001 && seg[1] == 0x0000) // 2001:0000::/32 Teredo: the embedded client
+                                                 // v4 is XOR-obfuscated, so block the whole prefix
+}
+
+/// The IPv4 address embedded in an IPv6 address, if any: IPv4-mapped
+/// (`::ffff:a.b.c.d`), IPv4-translated (deprecated `::ffff:0:a.b.c.d`),
+/// IPv4-compatible (deprecated `::a.b.c.d`, `::/96`), 6to4 (`2002::/16`), or the
+/// NAT64 well-known prefix (`64:ff9b::/96`).
+fn embedded_ipv4(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return Some(v4);
+    }
+    let seg = ip.segments();
+    let v4 = |hi: u16, lo: u16| Ipv4Addr::new((hi >> 8) as u8, hi as u8, (lo >> 8) as u8, lo as u8);
+    if seg[..6] == [0, 0, 0, 0, 0xffff, 0] {
+        return Some(v4(seg[6], seg[7])); // IPv4-translated: ::ffff:0:a.b.c.d
+    }
+    if seg[0] == 0x2002 {
+        return Some(v4(seg[1], seg[2])); // 6to4: 2002:AABB:CCDD::
+    }
+    if seg[0] == 0x0064 && seg[1] == 0xff9b && seg[2..6] == [0, 0, 0, 0] {
+        return Some(v4(seg[6], seg[7])); // NAT64: 64:ff9b::a.b.c.d
+    }
+    // IPv4-compatible `::a.b.c.d`; `::` and `::1` are excluded so they stay
+    // classified as unspecified/loopback rather than `0.0.0.x`.
+    if seg[..6] == [0, 0, 0, 0, 0, 0] && (seg[6] != 0 || seg[7] > 1) {
+        return Some(v4(seg[6], seg[7])); // ::a.b.c.d
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> NetworkPolicy {
+        NetworkPolicy::default()
+    }
+
+    #[test]
+    fn host_matches_exact_and_suffix() {
+        assert!(host_matches("cdn.example.com", "cdn.example.com"));
+        assert!(!host_matches("cdn.example.com", "example.com"));
+        // Suffix (subdomain wildcard): matches subdomains, not apex or lookalikes.
+        assert!(host_matches("a.example.com", ".example.com"));
+        assert!(host_matches("a.b.example.com", ".example.com"));
+        assert!(!host_matches("example.com", ".example.com"));
+        assert!(!host_matches("evilexample.com", ".example.com"));
+        // Case-insensitive.
+        assert!(host_matches("cdn.example.com", "CDN.Example.COM"));
+    }
+
+    #[test]
+    fn host_of_normalises_authority() {
+        assert_eq!(host_of("https://Cdn.Example.COM/x").as_deref(), Some("cdn.example.com"));
+        assert_eq!(host_of("https://u:p@host.example:8443/x?q#f").as_deref(), Some("host.example"));
+        assert_eq!(host_of("http://[::1]:9000/x").as_deref(), Some("::1"));
+        assert_eq!(host_of("http://example.com./x").as_deref(), Some("example.com"));
+        assert_eq!(host_of("ftp://example.com/x"), None);
+    }
+
+    #[test]
+    fn url_decision_precedence() {
+        // Deny host wins over an allow host.
+        let mut p = policy();
+        p.deny = vec!["blocked.example.com".to_string()];
+        p.allow = vec![".example.com".to_string()];
+        assert_eq!(url_decision("http://blocked.example.com/x", &p), UrlDecision::Reject);
+        assert_eq!(url_decision("http://ok.example.com/x", &p), UrlDecision::AllowBypassIp);
+
+        assert_eq!(url_decision("http://any.host/x", &policy()), UrlDecision::CheckIp);
+
+        // Subdomain wildcard: apex and lookalikes are not allow-listed.
+        let mut p = policy();
+        p.allow = vec![".example.com".to_string()];
+        assert_eq!(url_decision("http://a.example.com/x", &p), UrlDecision::AllowBypassIp);
+        assert_eq!(url_decision("http://example.com/x", &p), UrlDecision::CheckIp);
+        assert_eq!(url_decision("http://evilexample.com/x", &p), UrlDecision::CheckIp);
+
+        // The userinfo trick cannot satisfy an allow host: the real host is parsed.
+        assert_eq!(
+            url_decision("http://a.example.com@169.254.169.254/x", &p),
+            UrlDecision::CheckIp
+        );
+    }
+
+    #[test]
+    fn ip_class_allowed_respects_flags() {
+        let internal: IpAddr = "127.0.0.1".parse().unwrap();
+        let external: IpAddr = "8.8.8.8".parse().unwrap();
+        assert!(!ip_class_allowed(internal, true, false));
+        assert!(ip_class_allowed(external, true, false));
+        assert!(ip_class_allowed(internal, false, true));
+        assert!(!ip_class_allowed(external, false, true));
+        assert!(ip_class_allowed(internal, false, false));
+        assert!(ip_class_allowed(external, false, false));
+    }
+
+    // Non-public cases are the not-globally-reachable ranges of the IANA IPv4
+    // Special-Purpose Address Registry; public cases sample allocated unicast
+    // space, including neighbours just outside the reserved ranges.
+    #[test]
+    fn ipv4_classes() {
+        for ip in [
+            "127.0.0.1",       // 127/8 loopback
+            "10.0.0.1",        // 10/8 private
+            "172.16.5.4",      // 172.16/12 private
+            "192.168.1.1",     // 192.168/16 private
+            "169.254.1.1",     // 169.254/16 link-local
+            "100.64.0.1",      // 100.64/10 CGNAT
+            "0.0.0.0",         // 0/8 unspecified
+            "224.0.0.1",       // 224/4 multicast (all-systems)
+            "239.255.255.250", // 224/4 multicast (SSDP)
+            "198.18.0.1",      // 198.18/15 benchmarking
+            "198.19.255.255",  // 198.18/15 benchmarking (upper bound)
+            "192.0.2.1",       // 192.0.2/24 documentation (TEST-NET-1)
+            "198.51.100.1",    // 198.51.100/24 documentation (TEST-NET-2)
+            "203.0.113.1",     // 203.0.113/24 documentation (TEST-NET-3)
+            "240.0.0.1",       // 240/4 reserved
+            "255.255.255.255", // limited broadcast
+        ] {
+            assert!(is_private_ip(ip.parse().unwrap()), "{ip} should be private");
+        }
+        for ip in ["8.8.8.8", "1.1.1.1", "93.184.216.34", "198.17.255.255", "198.20.0.0", "223.255.255.255"] {
+            assert!(!is_private_ip(ip.parse().unwrap()), "{ip} should be public");
+        }
+    }
+
+    #[test]
+    fn ipv6_classes() {
+        for ip in [
+            "::1",
+            "fc00::1",
+            "fd12:3456::1",
+            "fe80::1",
+            "ff02::1",            // link-local all-nodes multicast
+            "ff05::1:3",          // site-local multicast
+            "::ffff:127.0.0.1",   // IPv4-mapped loopback
+            "::ffff:0:7f00:1",    // IPv4-translated wrapping 127.0.0.1
+            "::ffff:0:a00:1",     // IPv4-translated wrapping 10.0.0.1
+            "2002:7f00:1::",      // 6to4 wrapping 127.0.0.1
+            "2002:a00:1::",       // 6to4 wrapping 10.0.0.1
+            "64:ff9b::7f00:1",    // NAT64 wrapping 127.0.0.1
+            "::7f00:1",           // IPv4-compatible wrapping 127.0.0.1
+            "::a00:1",            // IPv4-compatible wrapping 10.0.0.1
+            "2001:0:4136:e378::", // 2001:0000::/32 Teredo
+        ] {
+            assert!(is_private_ip(ip.parse().unwrap()), "{ip} should be private");
+        }
+        for ip in [
+            "2606:4700:4700::1111",
+            "::ffff:8.8.8.8",
+            "::ffff:0:808:808",     // IPv4-translated wrapping public 8.8.8.8
+            "2002:808:808::",
+            "::808:808",
+            "2001:4860:4860::8888", // public unicast just outside the Teredo prefix
+        ] {
+            assert!(!is_private_ip(ip.parse().unwrap()), "{ip} should be public");
+        }
+    }
+
+    #[test]
+    fn redirect_resolution() {
+        assert_eq!(
+            resolve_redirect("http://a.com/x", "https://b.com/y").as_deref(),
+            Some("https://b.com/y")
+        );
+        assert_eq!(
+            resolve_redirect("http://a.com/x/y", "/z").as_deref(),
+            Some("http://a.com/z")
+        );
+        assert_eq!(
+            resolve_redirect("http://a.com:8080/x", "z").as_deref(),
+            Some("http://a.com:8080/z")
+        );
+        assert_eq!(
+            resolve_redirect("http://a.com/x/y", "z").as_deref(),
+            Some("http://a.com/x/z")
+        );
+        assert_eq!(
+            resolve_redirect("http://a.com/x/y?q=1", "z").as_deref(),
+            Some("http://a.com/x/z")
+        );
+        assert_eq!(
+            resolve_redirect("http://a.com", "z").as_deref(),
+            Some("http://a.com/z")
+        );
+    }
+}
+
+/// End-to-end tests over a real loopback HTTP server, exercising the fetch
+/// wiring (pinned resolver, redirect loop, size limit) that the unit tests
+/// above cannot reach. Loopback resolves to `127.0.0.1`, a private address, so
+/// `deny_private_ips` is expected to block unless the host is allow-listed.
+#[cfg(test)]
+mod server_tests {
+    use super::*;
+    use crate::security::resources::NetworkPolicy;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    /// Serve a few fixed paths on `127.0.0.1` and return the bound port. The
+    /// accept loop runs on a detached thread for the lifetime of the process.
+    fn spawn_server() -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                serve(stream, port);
+            }
+        });
+        port
+    }
+
+    fn serve(mut stream: std::net::TcpStream, port: u16) {
+        let mut buf = [0u8; 1024];
+        let read = stream.read(&mut buf).unwrap_or(0);
+        let request = String::from_utf8_lossy(&buf[..read]);
+        let path = request.split_whitespace().nth(1).unwrap_or("/");
+        let response = match path {
+            "/ok" => "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHELLO".to_string(),
+            "/redirect" => format!(
+                "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{port}/ok\r\nContent-Length: 0\r\n\r\n"
+            ),
+            "/big" => format!("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n{}", "x".repeat(100)),
+            _ => "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n".to_string(),
+        };
+        let _ = stream.write_all(response.as_bytes());
+    }
+
+    /// Default policy with loopback allow-listed, to exercise the fetch wiring
+    /// against the loopback server despite deny-private-by-default.
+    fn allow_loopback() -> NetworkPolicy {
+        NetworkPolicy {
+            allow: vec!["127.0.0.1".to_string()],
+            ..NetworkPolicy::default()
+        }
+    }
+
+    #[test]
+    fn default_policy_blocks_private_ip() {
+        // Deny-by-default rejects 127.0.0.1 with no explicit flag set.
+        let url = format!("http://127.0.0.1:{}/ok", spawn_server());
+        assert!(fetch_authorized(&url, &NetworkPolicy::default()).is_none());
+    }
+
+    #[test]
+    fn allow_listed_host_fetches_body() {
+        let url = format!("http://127.0.0.1:{}/ok", spawn_server());
+        assert_eq!(
+            fetch_authorized(&url, &allow_loopback()).as_deref(),
+            Some(b"HELLO".as_slice())
+        );
+    }
+
+    #[test]
+    fn allow_private_ips_fetches_body() {
+        // Opting out of deny-private fetches successfully.
+        let url = format!("http://127.0.0.1:{}/ok", spawn_server());
+        let policy = NetworkPolicy {
+            deny_private_ips: false,
+            ..NetworkPolicy::default()
+        };
+        assert_eq!(fetch_authorized(&url, &policy).as_deref(), Some(b"HELLO".as_slice()));
+    }
+
+    #[test]
+    fn allow_host_bypasses_deny_private_ips() {
+        let url = format!("http://127.0.0.1:{}/ok", spawn_server());
+        let policy = NetworkPolicy {
+            deny_private_ips: true,
+            allow: vec!["127.0.0.1".to_string()],
+            ..NetworkPolicy::default()
+        };
+        assert_eq!(fetch_authorized(&url, &policy).as_deref(), Some(b"HELLO".as_slice()));
+    }
+
+    #[test]
+    fn redirect_is_followed() {
+        let url = format!("http://127.0.0.1:{}/redirect", spawn_server());
+        assert_eq!(
+            fetch_authorized(&url, &allow_loopback()).as_deref(),
+            Some(b"HELLO".as_slice())
+        );
+    }
+
+    #[test]
+    fn redirect_not_followed_when_max_redirects_zero() {
+        let url = format!("http://127.0.0.1:{}/redirect", spawn_server());
+        let policy = NetworkPolicy {
+            max_redirects: 0,
+            ..allow_loopback()
+        };
+        assert!(fetch_authorized(&url, &policy).is_none());
+    }
+
+    #[test]
+    fn body_over_max_size_is_rejected() {
+        let url = format!("http://127.0.0.1:{}/big", spawn_server());
+        let policy = NetworkPolicy {
+            max_body_size: 10,
+            ..allow_loopback()
+        };
+        assert!(fetch_authorized(&url, &policy).is_none());
+    }
+}

--- a/src/security/resources.rs
+++ b/src/security/resources.rs
@@ -48,6 +48,52 @@ impl AuthorizedResourceRoot {
     }
 }
 
+/// Network-fetch policy for remote (`http`/`https`) document resources,
+/// modelled on Gotenberg's `downloadFrom` controls. Precedence when deciding a
+/// URL (see [`crate::security::network`]): a deny host match always rejects;
+/// then an allow host match accepts and bypasses the IP-class checks; otherwise
+/// the host is resolved and the enabled IP-class rejections apply.
+///
+/// Allow/deny entries are host patterns: an exact host (`cdn.example.com`), or a
+/// `.`-prefixed suffix matching any subdomain (`.example.com`). Matching the
+/// parsed host — not the URL string — avoids allow-list bypasses via query,
+/// path, or userinfo.
+#[derive(Debug, Clone)]
+// The fields are read only by the `remote` fetch path; without it no network
+// load happens, so the policy is inert.
+#[cfg_attr(not(feature = "remote"), allow(dead_code))]
+pub(crate) struct NetworkPolicy {
+    /// Host patterns; a URL whose host matches any bypasses the IP-class checks.
+    pub(crate) allow: Vec<String>,
+    /// Host patterns; a URL whose host matches any is always rejected.
+    pub(crate) deny: Vec<String>,
+    /// Reject a URL whose host resolves to a non-public IP (loopback, RFC1918,
+    /// link-local, IPv6 unique-local).
+    pub(crate) deny_private_ips: bool,
+    /// Reject a URL whose host resolves to a public IP.
+    pub(crate) deny_public_ips: bool,
+    /// Maximum number of redirect hops followed for one fetch.
+    pub(crate) max_redirects: u32,
+    /// Maximum accepted response body size, in bytes.
+    pub(crate) max_body_size: u64,
+}
+
+impl Default for NetworkPolicy {
+    fn default() -> Self {
+        Self {
+            allow: Vec::new(),
+            deny: Vec::new(),
+            // Deny-by-default: reject URLs resolving to a private/reserved
+            // address (this covers the 169.254.169.254 metadata endpoint) unless
+            // the host is allow-listed. Opt out with `download_deny_private_ips`.
+            deny_private_ips: true,
+            deny_public_ips: false,
+            max_redirects: 8,
+            max_body_size: 10 * 1024 * 1024,
+        }
+    }
+}
+
 /// Resource resolution policy carried through one document conversion.
 ///
 /// The optional root is the sole authority for local files in sanitized mode.
@@ -58,6 +104,7 @@ pub(crate) struct DocumentResources {
     access: ResourceAccess,
     base: Option<PathBuf>,
     root: Option<AuthorizedResourceRoot>,
+    network: NetworkPolicy,
 }
 
 impl DocumentResources {
@@ -80,7 +127,23 @@ impl DocumentResources {
                 .map(AuthorizedResourceRoot::path)
                 .map(Path::to_path_buf),
         };
-        Self { access, base, root }
+        Self {
+            access,
+            base,
+            root,
+            network: NetworkPolicy::default(),
+        }
+    }
+
+    /// Attach the remote-fetch policy (builder style; the default denies
+    /// private/reserved IPs).
+    pub(crate) fn with_network(mut self, network: NetworkPolicy) -> Self {
+        self.network = network;
+        self
+    }
+
+    pub(crate) fn network(&self) -> &NetworkPolicy {
+        &self.network
     }
 
     pub(crate) fn base_path(&self) -> Option<&Path> {
@@ -100,7 +163,11 @@ impl DocumentResources {
         let reference = reference.trim();
         match ResourceReference::parse(reference)? {
             ResourceReference::Inline | ResourceReference::Fragment => Some(reference.to_string()),
-            ResourceReference::Network if self.access == ResourceAccess::Trusted => {
+            // A protocol-relative `//host` has no scheme to fetch here, so deny
+            // it rather than return it for the loader to read as a local file.
+            ResourceReference::Network
+                if self.access == ResourceAccess::Trusted && is_network_url(reference) =>
+            {
                 Some(reference.to_string())
             }
             ResourceReference::Network | ResourceReference::UnsupportedScheme => None,
@@ -145,10 +212,7 @@ impl ResourceReference {
         if starts_ascii_case_insensitive(reference, "data:") {
             return Some(Self::Inline);
         }
-        if reference.starts_with("//")
-            || starts_ascii_case_insensitive(reference, "http://")
-            || starts_ascii_case_insensitive(reference, "https://")
-        {
+        if reference.starts_with("//") || is_network_url(reference) {
             return Some(Self::Network);
         }
         if has_explicit_scheme(reference) {
@@ -177,6 +241,15 @@ fn starts_ascii_case_insensitive(value: &str, prefix: &str) -> bool {
     value
         .get(..prefix.len())
         .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+}
+
+/// A fetchable network reference: an absolute http(s) URL, scheme compared
+/// case-insensitively. Shared by the resolver and the loader so their notion of
+/// "network" can't drift and let a reference slip between the local and network
+/// classes.
+pub(crate) fn is_network_url(reference: &str) -> bool {
+    starts_ascii_case_insensitive(reference, "http://")
+        || starts_ascii_case_insensitive(reference, "https://")
 }
 
 struct CssUrlRewriter<'a> {

--- a/src/security/resources/tests.rs
+++ b/src/security/resources/tests.rs
@@ -113,3 +113,38 @@ fn sanitized_css_preserves_inline_and_fragment_urls() {
         "a{filter:url(\"#fx\");background:url(\"DATA:image/png;base64,AA==\")}"
     );
 }
+
+// A protocol-relative `//host` is denied in Trusted mode (no fetchable scheme)
+// rather than read as a local file that escapes the root; a genuine traversal
+// is still confined, showing the fix targets the misclassification, not all loads.
+#[test]
+fn trusted_protocol_relative_reference_cannot_escape_root() {
+    let root = tempfile::tempdir().expect("authorized root");
+    let resources = DocumentResources::new(ResourceAccess::Trusted, None, Some(root.path()));
+    assert_eq!(resources.resolve("//etc/hostname", None), None);
+    assert_eq!(resources.resolve("//../secret.png", None), None);
+    assert_eq!(resources.resolve("../secret.png", None), None);
+}
+
+#[test]
+fn trusted_network_urls_pass_case_insensitively() {
+    let root = tempfile::tempdir().expect("authorized root");
+    let resources = DocumentResources::new(ResourceAccess::Trusted, None, Some(root.path()));
+    assert_eq!(
+        resources.resolve("http://example.com/a.png", None).as_deref(),
+        Some("http://example.com/a.png")
+    );
+    assert_eq!(
+        resources.resolve("HTTPS://Example.com/a.png", None).as_deref(),
+        Some("HTTPS://Example.com/a.png")
+    );
+}
+
+#[test]
+fn sanitized_denies_protocol_relative_reference() {
+    let (directory, resources) = test_root();
+    assert_eq!(
+        resources.resolve("//etc/hostname", Some(directory.path())),
+        None
+    );
+}

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -11925,14 +11925,17 @@ fn parse_mask_url_svg(val: &str) -> Option<std::sync::Arc<Vec<u8>>> {
     if url.is_empty() {
         return None;
     }
-    let (bytes, _mime) = crate::layout::images::load_src_bytes(url)?;
+    // Authorise and load through the ambient resource loader, like every other
+    // document resource. (This still loads during style computation; moving mask
+    // I/O out of the cascade is a separate change.)
+    let (bytes, _mime) = crate::layout::images::load_resource(url, None)?;
     // Accept only sources whose bytes actually sniff as SVG, since the mask
     // rasteriser only understands SVG image sources. The MIME alone is not
     // trusted (it can mislabel non-SVG payloads).
     if !crate::layout::images::looks_like_svg(&bytes) {
         return None;
     }
-    Some(std::sync::Arc::new(bytes))
+    Some(bytes)
 }
 
 /// Parse a CSS Grid box-alignment keyword (`start`/`end`/`center`/`stretch`).


### PR DESCRIPTION
…Loader

Document-referenced resources were loaded by calling load_src_bytes directly at ~8 sinks across layout and render. Several bypassed the resource policy entirely — notably a nested `<image href>` inside a rendered SVG, a local-file read / SSRF vector (a benign .svg could embed /etc/passwd or fetch an internal URL into the PDF).

Route every load through one ResourceLoader: it authorises a reference against the document policy (deny -> None), then loads and caches the bytes. Rather than thread it through layout and render (the layout sinks sit behind functions called from ~100 sites), the loader is installed as an ambient, per-conversion capability via an RAII guard:

- convert_to_writer installs the document policy loader for the whole conversion; every sink loads through crate::layout::images::load_resource.
- With no loader installed, loads DENY by default (only inline data: resolves): standalone/low-level layout and render fail closed, so untrusted content reaching a sink without a policy loads nothing. (Tests that render local-file content directly opt into a trusted loader.)
- One loader, one cache per conversion, shared across layout and render. The cache keys on the resolved (post-base, canonical) reference, so a relative reference under a different base can never serve a stale hit; inline data: references are not cached (unique bytes, huge key).

Sinks now behind the loader: `<img>`, list marker, `content: url()`,
CSS background, border-image, SVG `<image href>`, and `mask-image: url()`.

Network hardening (SSRF), modelled on Gotenberg's downloadFrom controls, enforced at the fetch sink under the `remote` feature:

- NetworkPolicy on the document policy, configured via HtmlConverter: download_allow_list / download_deny_list (host patterns: an exact host, or a `.`-prefixed suffix matching any subdomain), download_deny_private_ips / download_deny_public_ips, download_max_redirects (default 8), download_max_body_size (default 10 MB).
- Precedence: a deny host match always rejects; an allow host match accepts and bypasses the IP checks; otherwise the host is resolved and the enabled IP-class rejections apply (loopback, RFC1918, link-local, CGNAT, IPv6 unique-local, and IPv4 embedded in IPv4-mapped/IPv4-compatible/6to4/NAT64). Private/reserved IPs are denied by default (opt out with download_deny_private_ips(false)); public IPs are allowed. Allow/deny match the parsed, normalised host — not the URL string — so query/path/userinfo cannot satisfy an allow entry.
- Redirects are followed manually (bounded by max_redirects), re-checking every hop, so a redirect cannot bypass the checks. A custom ureq resolver returns only policy-permitted addresses, and ureq connects to exactly those addresses with no second DNS lookup, so the address checked IS the address connected to — pinning the connection and closing the DNS-rebinding window. Applies to image and @font-face fetches.

Tests: local-file `<image href>` denied by the deny-by-default loader; the cache is base-sensitive; host-pattern matching / host parsing, policy precedence, IPv4/IPv6 (incl. 6to4/NAT64) class checks, and redirect resolution offline; and the fetch path end-to-end over a loopback server — deny-private blocks, an allow-listed host bypasses, redirects are followed and bounded, and the body-size limit is enforced.

Note: mask-image: url() is authorised but still loaded during style computation; moving that I/O out of the cascade is a separate WIP change (its on-failure behaviour needs validating against Chromium).