### PR TITLE
chore(security): resolve PyO3 and workflow permission alerts

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -11,6 +11,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ironpress-core = { path = "../..", package = "ironpress" }
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }


### PR DESCRIPTION
## Summary

- upgrade the Python binding from PyO3 0.23 to 0.29
- resolve all three open PyO3 Dependabot advisories, including the high-severity iterator out-of-bounds read
- restrict the parity workflow token to read-only repository contents

## Validation

- PyO3 resolves to 0.29.2; all reported advisories are patched by 0.29.0 or earlier
- `cargo check --manifest-path bindings/python/Cargo.toml`
- `cargo test --manifest-path bindings/python/Cargo.toml`
- `cargo clippy --manifest-path bindings/python/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `maturin build` produced a CPython 3.13 wheel
- installed-wheel smoke test imported `ironpress` and produced a valid `%PDF` document
- parity workflow YAML parsed successfully
