### PR TITLE
fix(layout): preserve computed inline boxes beside block siblings

### DIFF
--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -1081,8 +1081,51 @@ pub(crate) fn layout_block_element(
             } else {
                 output
             };
+            // Atomic inlines need one source-ordered row before a block sibling
+            // splits the surrounding formatting context.
+            let mut atomic_inline_segments =
+                InlineFormattingContext::new(style, env.rules, child_ancestors, env.font_metrics())
+                    .atomic_layout_segments(inline_sequence)
+                    .into_iter()
+                    .peekable();
+            let mut emitted_atomic_until = 0;
             let mut child_el_idx = 0;
             for (child_index, child) in el.children.iter().enumerate() {
+                if atomic_inline_segments
+                    .peek()
+                    .is_some_and(|segment| segment.start() == child_index)
+                {
+                    flush_runs(
+                        &mut runs,
+                        inner_width,
+                        style,
+                        available_width,
+                        block_w,
+                        effective_height,
+                        auto_offset_left,
+                        el,
+                        target,
+                        env.fonts,
+                    );
+                    if let Some(segment) = atomic_inline_segments.next()
+                        && layout_inline_mixed_sequence_with_env(
+                            segment,
+                            style,
+                            &ctx.with_parent(inner_width, Some(available_height), style.font_size),
+                            target,
+                            child_ancestors,
+                            env,
+                        )
+                    {
+                        emitted_atomic_until = segment.end();
+                    }
+                }
+                if child_index < emitted_atomic_until {
+                    if matches!(child, DomNode::Element(_)) {
+                        child_el_idx += 1;
+                    }
+                    continue;
+                }
                 match child {
                     DomNode::Text(_) => {
                         InlineRunCollector::new(env.rules, env.fonts, env.counter_state).collect(

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2931,7 +2931,7 @@ pub(crate) fn flatten_nodes(
     }
     let atomic_inline_segments =
         InlineFormattingContext::new(parent_style, env.rules, ancestors, env.font_metrics())
-            .atomic_layout_segments(inline_sequence);
+            .environment_aware_atomic_layout_segments(inline_sequence);
     let mut atomic_inline_segments = atomic_inline_segments.into_iter().peekable();
     let mut element_index = 0;
     let mut preceding_siblings: Vec<(String, Vec<String>)> = Vec::new();

--- a/src/layout/inline_formatting.rs
+++ b/src/layout/inline_formatting.rs
@@ -642,6 +642,14 @@ impl AtomicInlineKind {
 }
 
 impl InlineFormattingRole {
+    /// Text and the established embedded inline-block path are collected as
+    /// runs. Other atomic boxes are owned by their source-ordered row segment.
+    pub(crate) fn uses_text_run_layout(self, element: &ElementNode) -> bool {
+        matches!(self, Self::Text)
+            || matches!(self, Self::Atomic(AtomicInlineKind::InlineBlock))
+                && element.tag.is_inline()
+    }
+
     pub(crate) fn of(element: &ElementNode, style: &ComputedStyle) -> Self {
         if style.display == Display::None {
             return Self::Hidden;
@@ -782,15 +790,33 @@ impl<'a> InlineFormattingContext<'a> {
         saw_atomic
     }
 
-    /// Maximal source-order ranges that remain inside one inline formatting
-    /// context and contain an environment-aware atomic inline.
-    ///
-    /// Block/table participants split the ranges but do not force later inline
-    /// content onto the legacy per-element path. Each returned sequence retains
-    /// the complete sibling list for selector matching.
+    /// Maximal source-order ranges that contain any atomic inline and remain
+    /// inside one inline formatting context.
     pub(crate) fn atomic_layout_segments<'b>(
         &self,
         sequence: InlineContentSequence<'b>,
+    ) -> Vec<InlineContentSequence<'b>> {
+        self.atomic_layout_segments_requiring(sequence, |_| true)
+    }
+
+    /// Maximal source-order ranges that contain an atomic inline requiring
+    /// access to the layout environment.
+    pub(crate) fn environment_aware_atomic_layout_segments<'b>(
+        &self,
+        sequence: InlineContentSequence<'b>,
+    ) -> Vec<InlineContentSequence<'b>> {
+        self.atomic_layout_segments_requiring(sequence, |kind| {
+            kind.requires_environment_aware_layout()
+        })
+    }
+
+    /// Block/table participants split ranges without forcing later inline
+    /// content onto the legacy per-element path. Each returned sequence keeps
+    /// the complete sibling list for selector matching.
+    fn atomic_layout_segments_requiring<'b>(
+        &self,
+        sequence: InlineContentSequence<'b>,
+        requires_segment: impl Fn(AtomicInlineKind) -> bool,
     ) -> Vec<InlineContentSequence<'b>> {
         let source = sequence.source_nodes();
         let mut siblings =
@@ -820,7 +846,7 @@ impl<'a> InlineFormattingContext<'a> {
 
             match InlineFormattingRole::of(element, &style) {
                 InlineFormattingRole::Atomic(kind) => {
-                    segment_has_atomic |= kind.requires_environment_aware_layout();
+                    segment_has_atomic |= requires_segment(kind);
                 }
                 InlineFormattingRole::OutOfFlow => {}
                 InlineFormattingRole::Outside => {

--- a/src/layout/tests/atomic_inline.rs
+++ b/src/layout/tests/atomic_inline.rs
@@ -1,7 +1,7 @@
 use crate::layout::elements::{FlexRow, LayoutVisitor, TextBlock};
 use crate::layout::engine::visit_layout_tree;
 
-use super::support::layout_pages;
+use super::support::{layout_pages, visible_inline_box_runs, visible_runs};
 
 #[derive(Default)]
 struct AtomicBoxCount {
@@ -44,4 +44,40 @@ fn inline_block_embedded_between_text_is_not_laid_out_twice() {
     assert_eq!(pages.len(), 1);
     assert_eq!(count.embedded, 1);
     assert_eq!(count.independent_cells, 0);
+}
+
+#[test]
+fn computed_inline_level_boxes_survive_adjacent_block_siblings() {
+    for tag in ["div", "p", "section", "label"] {
+        for display in ["inline", "inline-block", "inline-flex"] {
+            for inline_first in [true, false] {
+                let inline = format!(r#"<{tag} class="subject">STEM</{tag}>"#);
+                let children = if inline_first {
+                    format!(r#"{inline}<div>SIB</div>"#)
+                } else {
+                    format!(r#"<div>SIB</div>{inline}"#)
+                };
+                let markup = format!(
+                    r#"<style>.subject {{ display: {display}; }}</style><div>{children}</div>"#
+                );
+                let visible_text = visible_runs(&markup)
+                    .into_iter()
+                    .chain(visible_inline_box_runs(&markup))
+                    .map(|run| run.text)
+                    .collect::<String>();
+                let case = format!("tag={tag}, display={display}, inline_first={inline_first}");
+
+                assert_eq!(
+                    visible_text.matches("STEM").count(),
+                    1,
+                    "{case}: {visible_text:?}"
+                );
+                assert_eq!(
+                    visible_text.matches("SIB").count(),
+                    1,
+                    "{case}: {visible_text:?}"
+                );
+            }
+        }
+    }
 }

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -25,7 +25,7 @@ use super::engine::{
 };
 use super::helpers::DropCap;
 use super::inline_formatting::{
-    GeneratedContentStyles, InlineContentSequence, InlineSiblingCursor,
+    GeneratedContentStyles, InlineContentSequence, InlineFormattingRole, InlineSiblingCursor,
 };
 use super::list_markers::format_counter_value;
 use super::text_emphasis::TextEmphasisMetrics;
@@ -3341,35 +3341,36 @@ fn collect_text_runs_inner(
             }
             DomNode::Element(el) => {
                 let selector_ctx = siblings.next_context(el, ancestors);
-                if super::engine::collects_as_inline_text(el.tag) || el.tag == HtmlTag::Br {
-                    if el.tag == HtmlTag::Br {
-                        runs.push(TextRun {
-                            text: "\n".to_string(),
-                            font_size: used_font_size(parent_style, fonts),
-                            font_family: resolve_style_font_family(parent_style, fonts),
-                            line_height_factor: text_run_line_height_factor(parent_style, fonts),
-                            ..Default::default()
-                        });
-                    } else if el.attributes.contains_key("data-math") {
-                        // Skip math elements — they are rendered as MathBlock
-                        // by flatten_element, not as inline text runs.
+                if el.tag == HtmlTag::Br {
+                    runs.push(TextRun {
+                        text: "\n".to_string(),
+                        font_size: used_font_size(parent_style, fonts),
+                        font_family: resolve_style_font_family(parent_style, fonts),
+                        line_height_factor: text_run_line_height_factor(parent_style, fonts),
+                        ..Default::default()
+                    });
+                    continue;
+                }
+
+                let classes = el.class_list();
+                let style = compute_style_with_context_with_font_metrics(
+                    el.tag,
+                    el.style_attr(),
+                    parent_style,
+                    rules,
+                    el.tag_name(),
+                    &classes,
+                    el.id(),
+                    &el.attributes,
+                    &selector_ctx,
+                    FontMetrics::new(fonts),
+                );
+                let role = InlineFormattingRole::of(el, &style);
+                if role.uses_text_run_layout(el) {
+                    if el.attributes.contains_key("data-math") {
+                        // Math elements are rendered as MathBlock by
+                        // flatten_element, not as inline text runs.
                     } else {
-                        let classes = el.class_list();
-                        let style = compute_style_with_context_with_font_metrics(
-                            el.tag,
-                            el.style_attr(),
-                            parent_style,
-                            rules,
-                            el.tag_name(),
-                            &classes,
-                            el.id(),
-                            &el.attributes,
-                            &selector_ctx,
-                            FontMetrics::new(fonts),
-                        );
-                        if style.position.is_absolute() {
-                            continue;
-                        }
                         let counter_scope = counter_state.enter_element(&style);
                         if style.float == Float::Footnote {
                             let mut footnote_text = String::new();


### PR DESCRIPTION
## Summary

- classify inline participation from the computed `display` value before collecting text runs
- keep atomic inline content in one source-ordered row when a block sibling splits the surrounding formatting context
- preserve the existing embedded inline-block paint path without emitting boxes twice
- cover the reported matrix: `div`, `p`, `section`, and `label`; `inline`, `inline-block`, and `inline-flex`; sibling before and after

Closes #180.

## Root cause

The mixed block/inline path decided whether to collect an element from its HTML tag before resolving its style. A block-like tag with an inline-level computed display could therefore be excluded from both the text-run path and the independent block path.

The fix resolves one shared `InlineFormattingRole` from computed style and gives atomic inline segments an explicit paint owner across anonymous block boundaries.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib` — 3,262 passed, 2 ignored
- 24-case regression matrix for the combinations reported in #180
- full parity corpus completed with no new `FAIL`; the local report gate remained blocked only by four pre-existing invalid-provenance references and the local Poppler 22.12 identity differing from the pinned 24.08 binary

No parity report or oracle generated with the unpinned local rasterizer is included.
