### PR TITLE
fix(ci): use pinned Poppler for playground parity reports

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   parity-gate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,48 +37,7 @@ jobs:
           key: parity-cargo-${{ runner.os }}-${{ hashFiles('Cargo.toml') }}
 
       - name: Install pinned Poppler and deterministic fonts
-        run: |
-          poppler_dir="$(mktemp -d)"
-          curl --fail --location --retry 3 \
-            --output "$poppler_dir/liblcms2-2.deb" \
-            https://archive.neon.kde.org/user/pool/main/l/lcms2/liblcms2-2_2.16-2+24.04+noble+release+build2_amd64.deb
-          curl --fail --location --retry 3 \
-            --output "$poppler_dir/libpoppler140.deb" \
-            https://archive.neon.kde.org/user/pool/main/p/poppler/libpoppler140_24.08.0-1+24.04+noble+release+build15_amd64.deb
-          curl --fail --location --retry 3 \
-            --output "$poppler_dir/poppler-utils.deb" \
-            https://archive.neon.kde.org/user/pool/main/p/poppler/poppler-utils_24.08.0-1+24.04+noble+release+build15_amd64.deb
-
-          printf '%s  %s\n' \
-            369ab216d40364743188a3df30b3a86285aede504ddde89eea9b1bab8dbcbda5 \
-            "$poppler_dir/liblcms2-2.deb" \
-            189bb9e6c22fa0f49f4ee8e802f62324a366ca776a52ebb8965fe1bb6affa448 \
-            "$poppler_dir/libpoppler140.deb" \
-            af3d09ab4a363949efba54e3a589888c032c7a1616a6039453f65e99e03f358e \
-            "$poppler_dir/poppler-utils.deb" |
-            sha256sum --check --strict
-
-          sudo apt-get update
-          sudo apt-get install -y \
-            "$poppler_dir/liblcms2-2.deb" \
-            "$poppler_dir/libpoppler140.deb" \
-            "$poppler_dir/poppler-utils.deb" \
-            jq \
-            fonts-noto-cjk \
-            fonts-liberation \
-            fonts-dejavu-core
-
-          printf '%s  %s\n' \
-            b1f76a56605df368efd233e09faad3bd910e50c0d6556c616a7c0b0adebf6013 \
-            /usr/bin/pdftoppm |
-            sha256sum --check --strict
-          test "$(/usr/bin/pdftoppm -v 2>&1 | head -n 1)" = "pdftoppm version 24.08.0"
-
-      - name: Install bundled Parity fonts
-        run: |
-          mkdir -p "$HOME/.local/share/fonts"
-          cp tests/parity/fonts/Parity*.ttf "$HOME/.local/share/fonts/"
-          fc-cache -f
+        run: scripts/parity-install-runtime.sh
 
       - name: Verify generated interaction product
         run: python3 scripts/generate-interaction-cartesian.py --check

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -48,11 +48,7 @@ jobs:
       - name: Install build tools
         run: |
           command -v wasm-pack || cargo install wasm-pack
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq poppler-utils fonts-liberation fonts-dejavu-core fonts-noto-cjk
-          mkdir -p "$HOME/.local/share/fonts"
-          cp tests/parity/fonts/Parity*.ttf "$HOME/.local/share/fonts/"
-          fc-cache -f
+          scripts/parity-install-runtime.sh
 
       - name: Build playground
         run: |
@@ -63,6 +59,7 @@ jobs:
       - name: Build feature parity report
         env:
           FONTCONFIG_FILE: ${{ github.workspace }}/tests/parity/fonts/fonts.conf
+          PARITY_PDFTOPPM: /usr/bin/pdftoppm
         run: scripts/parity.sh
 
       - name: Stage feature parity report

--- a/scripts/parity-install-runtime.sh
+++ b/scripts/parity-install-runtime.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+POPPLER_DIR="$(mktemp -d)"
+
+# Every report-producing job must use the rasterizer authenticated by the
+# committed parity baseline. Package-manager defaults are not deterministic.
+if [[ "$(dpkg --print-architecture)" != "amd64" ]]; then
+  echo "parity runtime requires Ubuntu 24.04 amd64" >&2
+  exit 1
+fi
+
+curl --fail --location --retry 3 \
+  --output "$POPPLER_DIR/liblcms2-2.deb" \
+  https://archive.neon.kde.org/user/pool/main/l/lcms2/liblcms2-2_2.16-2+24.04+noble+release+build2_amd64.deb
+curl --fail --location --retry 3 \
+  --output "$POPPLER_DIR/libpoppler140.deb" \
+  https://archive.neon.kde.org/user/pool/main/p/poppler/libpoppler140_24.08.0-1+24.04+noble+release+build15_amd64.deb
+curl --fail --location --retry 3 \
+  --output "$POPPLER_DIR/poppler-utils.deb" \
+  https://archive.neon.kde.org/user/pool/main/p/poppler/poppler-utils_24.08.0-1+24.04+noble+release+build15_amd64.deb
+
+printf '%s  %s\n' \
+  369ab216d40364743188a3df30b3a86285aede504ddde89eea9b1bab8dbcbda5 \
+  "$POPPLER_DIR/liblcms2-2.deb" \
+  189bb9e6c22fa0f49f4ee8e802f62324a366ca776a52ebb8965fe1bb6affa448 \
+  "$POPPLER_DIR/libpoppler140.deb" \
+  af3d09ab4a363949efba54e3a589888c032c7a1616a6039453f65e99e03f358e \
+  "$POPPLER_DIR/poppler-utils.deb" |
+  sha256sum --check --strict
+
+sudo apt-get update
+sudo apt-get install -y \
+  "$POPPLER_DIR/liblcms2-2.deb" \
+  "$POPPLER_DIR/libpoppler140.deb" \
+  "$POPPLER_DIR/poppler-utils.deb" \
+  jq \
+  fontconfig \
+  fonts-noto-cjk \
+  fonts-liberation \
+  fonts-dejavu-core
+
+printf '%s  %s\n' \
+  b1f76a56605df368efd233e09faad3bd910e50c0d6556c616a7c0b0adebf6013 \
+  /usr/bin/pdftoppm |
+  sha256sum --check --strict
+test "$(/usr/bin/pdftoppm -v 2>&1 | head -n 1)" = "pdftoppm version 24.08.0"
+
+mkdir -p "$HOME/.local/share/fonts"
+cp "$ROOT"/tests/parity/fonts/Parity*.ttf "$HOME/.local/share/fonts/"
+fc-cache -f


### PR DESCRIPTION
## Summary

- move the authenticated Poppler 24.08 and deterministic font setup into one shared parity runtime installer
- use that installer from both the parity gate and playground deployment
- pin both jobs to Ubuntu 24.04 and set `PARITY_PDFTOPPM` explicitly in the playground report step
- install `fontconfig` explicitly instead of relying on the hosted runner image

## Why

[Deploy Playground run 31270983610](https://github.com/gastongouron/ironpress/actions/runs/31270983610/job/93136798495#step:7:1884) used the Ubuntu default `pdftoppm 24.02.0`, while the committed parity baseline authenticates `24.08.0`. The parity gate correctly rejected the executable and version drift. The dedicated parity workflow was green because it already installed the pinned binary; its setup had not been propagated to the playground workflow.

No baseline, fixture, oracle, comparator, or renderer output is changed.

## Verification

- `bash -n scripts/parity-install-runtime.sh`
- parsed both modified workflow files as YAML
- checked both report-producing workflows use the shared installer and no workflow installs unpinned `poppler-utils`
- ran the installer end-to-end in `ubuntu:24.04` on `linux/amd64`; package checksums, `/usr/bin/pdftoppm` hash, and version checks all passed
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib` — 3,262 passed, 2 ignored

A full local `cargo test` reached two existing parity corpus tests that depend on Linux case-sensitive filesystem semantics. No Rust, fixture, oracle, manifest, lock, or parity-support file changes in this PR; GitHub Linux CI remains the authoritative full-suite check.