### PR TITLE
chore: prepare v1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [1.5.0] — 2026-08-09
+
+### Added
+
+- Python now exposes the complete `HtmlConverter` builder, custom fonts,
+  file output, and Markdown conversion.
+- Ruby now provides `Ironpress::HtmlConverter` with the same builder controls
+  as the Rust API.
+
+### Fixed
+
+- Inline and atomic inline siblings keep their source order when a block
+  splits the surrounding formatting context.
+
+### Security
+
+- Python bindings use PyO3 0.29.
+- The parity workflow now has explicit read-only repository permissions.
+
+### CI
+
+- Parity and playground reports use the same pinned Poppler and font runtime.
+
+### Documentation
+
+- Benchmarks now include Apple M2 results, headers and footers, and CJK text
+  emphasis.
+
 ## [1.4.4] — 2026-07-29
 
 ### Chromium visual parity

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress"
-version = "1.4.4"
+version = "1.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter with layout engine, LaTeX math, tables, images, custom fonts, and streaming output. No browser, no system dependencies."

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-python"
-version = "1.4.4"
+version = "1.5.0"
 edition = "2024"
 publish = false
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ironpress"
-version = "1.4.4"
+version = "1.5.0"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter. No browser, no system dependencies."
 readme = "README.md"
 license = "MIT"

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-ruby"
-version = "1.4.4"
+version = "1.5.0"
 edition = "2024"
 publish = false
 

--- a/bindings/ruby/ironpress.gemspec
+++ b/bindings/ruby/ironpress.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "ironpress"
-  spec.version       = "1.4.4"
+  spec.version       = "1.5.0"
   spec.authors       = ["Paul Gaston Gouron"]
   spec.summary       = "Pure Rust HTML/CSS/Markdown to PDF converter"
   spec.description   = "Convert HTML, CSS, and Markdown to PDF with no browser or system dependencies. Native Rust extension for maximum performance."


### PR DESCRIPTION
## Summary

- Bump Rust, Python, and Ruby packages to 1.5.0.
- Add a curated changelog for changes since 1.4.4.

## Why a minor release

Python and Ruby gained new public builder APIs after 1.4.4.

## Checks

- cargo fmt --all --check
- cargo check
- Python binding cargo check

Main CI, parity, and playground are green at 4aa119d.

Ruby will run in CI with the supported Ruby matrix.