### PR TITLE
test: cover float-right rendering at PDF boundary

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -11820,54 +11820,6 @@ line 3</pre>
         );
     }
 
-    // --- Issue #101: float right positioning (layout side) ---
-    // Note: float positioning is handled by the renderer, not the layout engine.
-    // This test documents the current limitation: offset_left is 0 from layout.
-
-    #[test]
-    #[ignore] // TODO: fix float:right layout positioning (#101)
-    fn float_right_positions_at_right_edge() {
-        let html = r#"
-        <div style="width: 400px">
-            <div style="float: right; width: 100px; height: 50px; background: pink">Float</div>
-            <p>Text should wrap around the float.</p>
-        </div>
-        "#;
-        let nodes = parse_html(html).unwrap();
-        let pages = layout(&nodes, PageSize::A4, Margin::default());
-        // Find the floated element (pink background)
-        for (_, element) in &pages[0].elements {
-            if let Some(offset_left) = element
-                .inspect_text(|block| {
-                    (block.flow.float == Float::Right
-                        && !block.box_model.size.width.is_fill_available())
-                    .then_some(block.positioning.insets.left)
-                })
-                .flatten()
-            {
-                // Float right should have offset_left > 0 (pushed right)
-                // In a 400px (300pt) container with a 100px (75pt) float,
-                // the float should be near the right edge
-                assert!(
-                    offset_left > 50.0,
-                    "float:right should be positioned rightward, got offset_left={offset_left}"
-                );
-                return;
-            }
-        }
-        // Float right may not produce offset_left — the renderer handles it.
-        // Just verify the float property is preserved.
-        for (_, element) in &pages[0].elements {
-            if element
-                .inspect_text(|block| block.flow.float == Float::Right)
-                .unwrap_or(false)
-            {
-                return; // Float property is at least preserved
-            }
-        }
-        panic!("did not find any element with float:right");
-    }
-
     // --- Issue #103: horizontal separators via border-bottom ---
 
     #[test]

--- a/src/render/pdf/tests/layout.rs
+++ b/src/render/pdf/tests/layout.rs
@@ -285,13 +285,34 @@ fn absolute_position_offset() {
 }
 
 #[test]
-fn float_right_position() {
-    let html = r#"<div style="float: right; width: 100pt">Floated</div>"#;
-    let nodes = parse_html(html).unwrap();
-    let pages = layout(&nodes, PageSize::A4, Margin::default());
-    let pdf = render_pdf(&pages, PageSize::A4, Margin::default()).unwrap();
+fn nested_float_right_aligns_to_containing_block_edge() {
+    let html = r#"
+        <style>
+            @page { size: 400pt 200pt; margin: 0; }
+            html, body { margin: 0; }
+        </style>
+        <div style="width: 300pt; height: 100pt; background: #ff0000">
+            <div style="float: right; width: 75pt; height: 50pt; background: #00ff00">
+                Floated
+            </div>
+        </div>
+    "#;
+    let pdf = crate::HtmlConverter::new()
+        .compress(false)
+        .convert(html)
+        .unwrap();
     let pdf_str = String::from_utf8_lossy(&pdf);
-    assert!(pdf_str.contains("Floated"), "Should contain floated text");
+    let containing_block = rect_after_color(&pdf_str, "1 0 0 rg")
+        .expect("containing block background should be painted");
+    let floated_block =
+        rect_after_color(&pdf_str, "0 1 0 rg").expect("floated block background should be painted");
+
+    let containing_right = containing_block.0 + containing_block.2;
+    let floated_right = floated_block.0 + floated_block.2;
+    assert!(
+        (floated_right - containing_right).abs() < 0.01,
+        "float:right should align to its containing block's right edge: containing={containing_block:?}, floated={floated_block:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace the stale ignored layout test for `float: right`
- assert the rendered PDF geometry instead of an internal layout offset
- cover a right float nested inside a fixed-width containing block

## Context

Issue #101 was fixed in 1b45c46. The remaining ignored test still expected
the layout engine to set a horizontal offset, although the renderer owns that
final placement.

The new regression checks the user-visible contract: both painted right edges
must align.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib --quiet` — 3263 passed, 1 unrelated ignored
- `cargo test --lib --features remote --quiet` — 3274 passed, 1 unrelated ignored
