### PR TITLE
perf: cache and preload remote images

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,6 +543,10 @@ impl HtmlConverter {
         // Step 2: Parse HTML and extract stylesheets
         let mut result = parser::html::parse_html_with_styles(html)?;
         security::sanitizer::sanitize_dom_resources(&mut result.nodes, resource_loader.resources());
+        #[cfg(feature = "remote")]
+        resource_loader.preload_document_resources(security::sanitizer::document_image_references(
+            &result.nodes,
+        ));
 
         // Step 2b: Resolve every stylesheet URL against its CSS base URL.
         // Imported sheets change that base to their own directory, while the
@@ -1965,9 +1969,14 @@ fn main() {
                 } else {
                     "image/png"
                 };
+                let content_length = if path == "/oversized.png" {
+                    body.len() + 1024
+                } else {
+                    body.len()
+                };
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                    body.len()
+                    content_length
                 );
                 let _ = stream.write_all(response.as_bytes());
                 let _ = stream.write_all(body);
@@ -2039,6 +2048,35 @@ fn main() {
             seen.insert(path);
         }
         assert_eq!(seen, expected);
+    }
+
+    #[test]
+    #[cfg(feature = "remote")]
+    fn repeated_remote_images_cache_successes_and_failures_for_one_conversion() {
+        use std::time::Duration;
+
+        let (server, requests) = remote_fixture_server();
+        let html = format!(
+            r#"<img src="{server}/shared.png"><img src="{server}/shared.png">
+                <img src="{server}/oversized.png"><img src="{server}/oversized.png">"#
+        );
+        let host = "127.0.0.1".parse::<RemoteHost>().expect("valid host");
+
+        HtmlConverter::new()
+            .download_allow_list([host])
+            .download_max_body_size(512)
+            .convert(&html)
+            .expect("missing images do not fail the conversion");
+
+        let mut seen = Vec::new();
+        while let Ok(path) = requests.recv_timeout(Duration::from_millis(200)) {
+            seen.push(path);
+        }
+        assert_eq!(seen.iter().filter(|path| *path == "/shared.png").count(), 1);
+        assert_eq!(
+            seen.iter().filter(|path| *path == "/oversized.png").count(),
+            1
+        );
     }
 
     #[test]

--- a/src/security/resources/loader.rs
+++ b/src/security/resources/loader.rs
@@ -42,7 +42,7 @@ impl CachedResource {
 }
 
 #[cfg(feature = "remote")]
-/// Bound each document so remote resources cannot create unbounded sockets or buffers.
+/// Limit simultaneous connections and response reads for one document.
 const MAX_CONCURRENT_REMOTE_FETCHES: usize = 8;
 
 impl ResourceLoader {

--- a/src/security/resources/loader.rs
+++ b/src/security/resources/loader.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+#[cfg(feature = "remote")]
+use std::collections::HashSet;
+
 use crate::util::decode_base64;
 
 use super::{DocumentResources, ResolvedResource};
@@ -16,8 +19,31 @@ pub(crate) struct LoadedResource {
 #[derive(Debug, Default)]
 pub(crate) struct ResourceLoader {
     resources: DocumentResources,
-    cache: HashMap<ResolvedResource, LoadedResource>,
+    cache: HashMap<ResolvedResource, CachedResource>,
 }
+
+/// Result of one attempted load retained for the whole conversion.
+///
+/// The cache entry itself proves that the request was attempted. `loaded` is
+/// absent when policy, transport, or response limits made it unavailable.
+#[derive(Debug, Clone, Default)]
+struct CachedResource {
+    loaded: Option<LoadedResource>,
+}
+
+impl CachedResource {
+    fn new(loaded: Option<LoadedResource>) -> Self {
+        Self { loaded }
+    }
+
+    fn loaded(&self) -> Option<LoadedResource> {
+        self.loaded.clone()
+    }
+}
+
+#[cfg(feature = "remote")]
+/// Bound each document so remote resources cannot create unbounded sockets or buffers.
+const MAX_CONCURRENT_REMOTE_FETCHES: usize = 8;
 
 impl ResourceLoader {
     pub(crate) fn new(resources: DocumentResources) -> Self {
@@ -42,10 +68,82 @@ impl ResourceLoader {
     }
 
     pub(crate) fn load_resolved(&mut self, resource: ResolvedResource) -> Option<LoadedResource> {
-        if let Some(loaded) = self.cache.get(&resource) {
-            return Some(loaded.clone());
+        if let Some(cached) = self.cache.get(&resource) {
+            return cached.loaded();
         }
-        let loaded = match &resource {
+        let loaded = Self::load_uncached(&self.resources, &resource);
+        self.cache
+            .insert(resource, CachedResource::new(loaded.clone()));
+        loaded
+    }
+
+    #[cfg(feature = "remote")]
+    /// Fetch distinct remote references ahead of layout in bounded batches.
+    ///
+    /// Eager collection lets blocking requests overlap without moving resource
+    /// authority into layout. Every worker enters through [`Self::load_uncached`],
+    /// preserving the synchronous path's security and response-size policy.
+    pub(crate) fn preload_document_resources<'a>(
+        &mut self,
+        references: impl IntoIterator<Item = &'a str>,
+    ) {
+        let base = self.resources.base_path().map(Path::to_path_buf);
+        let mut unique = HashSet::new();
+        let mut pending = Vec::new();
+        for reference in references {
+            let Some(resource) = self.resources.resolve(reference, base.as_deref()) else {
+                continue;
+            };
+            if !matches!(resource, ResolvedResource::Remote(_))
+                || self.cache.contains_key(&resource)
+                || !unique.insert(resource.clone())
+            {
+                continue;
+            }
+            pending.push(resource);
+        }
+
+        for batch in pending.chunks(MAX_CONCURRENT_REMOTE_FETCHES) {
+            if let [resource] = batch {
+                let loaded = Self::load_uncached(&self.resources, resource);
+                self.cache
+                    .insert(resource.clone(), CachedResource::new(loaded));
+                continue;
+            }
+            let completed = std::thread::scope(|scope| {
+                let mut workers = Vec::with_capacity(batch.len());
+                let mut synchronous_fallbacks = Vec::new();
+                for resource in batch.iter().cloned() {
+                    let resources = &self.resources;
+                    let fallback = resource.clone();
+                    match std::thread::Builder::new().spawn_scoped(scope, move || {
+                        let loaded = Self::load_uncached(resources, &resource);
+                        (resource, CachedResource::new(loaded))
+                    }) {
+                        Ok(worker) => workers.push(worker),
+                        Err(_) => synchronous_fallbacks.push(fallback),
+                    }
+                }
+                let mut completed = workers
+                    .into_iter()
+                    .filter_map(|worker| worker.join().ok())
+                    .collect::<Vec<_>>();
+                completed.extend(synchronous_fallbacks.into_iter().map(|resource| {
+                    let loaded = Self::load_uncached(&self.resources, &resource);
+                    (resource, CachedResource::new(loaded))
+                }));
+                completed
+            });
+            self.cache.extend(completed);
+        }
+    }
+
+    /// Keep synchronous misses and concurrent preloads on one policy boundary.
+    fn load_uncached(
+        _resources: &DocumentResources,
+        resource: &ResolvedResource,
+    ) -> Option<LoadedResource> {
+        let loaded = match resource {
             ResolvedResource::Inline(uri) => load_data_uri(uri)?,
             ResolvedResource::Fragment(_) => return None,
             ResolvedResource::Local(path) => LoadedResource {
@@ -54,13 +152,12 @@ impl ResourceLoader {
             },
             #[cfg(feature = "remote")]
             ResolvedResource::Remote(url) => LoadedResource {
-                bytes: crate::security::network::fetch_authorized(url, &self.resources.network)?,
+                bytes: crate::security::network::fetch_authorized(url, &_resources.network)?,
                 media_type: None,
             },
             #[cfg(not(feature = "remote"))]
             ResolvedResource::Remote(_) => return None,
         };
-        self.cache.insert(resource, loaded.clone());
         Some(loaded)
     }
 }

--- a/src/security/resources/tests.rs
+++ b/src/security/resources/tests.rs
@@ -174,3 +174,78 @@ fn sanitized_css_preserves_inline_and_fragment_urls() {
         "a{filter:url(\"#fx\");background:url(\"DATA:image/png;base64,AA==\")}"
     );
 }
+
+#[cfg(feature = "remote")]
+#[test]
+fn distinct_remote_resources_are_preloaded_concurrently() {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::time::{Duration, Instant};
+
+    fn accept_before(listener: &TcpListener, deadline: Instant) -> Option<TcpStream> {
+        loop {
+            match listener.accept() {
+                Ok((stream, _)) => return Some(stream),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return None;
+                    }
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(_) => return None,
+            }
+        }
+    }
+
+    fn respond(mut stream: TcpStream) {
+        let mut request = [0; 1024];
+        let _ = stream.read(&mut request);
+        let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHELLO");
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("loopback fixture");
+    listener
+        .set_nonblocking(true)
+        .expect("non-blocking fixture");
+    let port = listener.local_addr().expect("fixture address").port();
+    let first_url = format!("http://127.0.0.1:{port}/first");
+    let second_url = format!("http://127.0.0.1:{port}/second");
+    let policy = NetworkPolicy::default()
+        .with_allow_list(["127.0.0.1".parse().expect("valid loopback host")]);
+    let resources = DocumentResources::new(None, None, policy);
+    let mut loader = ResourceLoader::new(resources);
+
+    let connected_concurrently = std::thread::scope(|scope| {
+        let preload = scope.spawn(|| {
+            loader.preload_document_resources([first_url.as_str(), second_url.as_str()]);
+        });
+        let first = accept_before(&listener, Instant::now() + Duration::from_secs(1))
+            .expect("first remote connection");
+        let second = accept_before(&listener, Instant::now() + Duration::from_secs(1));
+        if let Some(second) = second {
+            respond(first);
+            respond(second);
+            preload.join().expect("preload worker");
+            true
+        } else {
+            respond(first);
+            let second = accept_before(&listener, Instant::now() + Duration::from_secs(1))
+                .expect("sequential fallback connection");
+            respond(second);
+            preload.join().expect("preload worker");
+            false
+        }
+    });
+
+    assert!(
+        connected_concurrently,
+        "both requests must start before either response completes"
+    );
+    assert_eq!(
+        loader
+            .load_document_resource(&first_url)
+            .expect("cached first resource")
+            .bytes,
+        b"HELLO"
+    );
+}

--- a/src/security/sanitizer.rs
+++ b/src/security/sanitizer.rs
@@ -85,6 +85,30 @@ pub(crate) fn sanitize_dom_resources(nodes: &mut [DomNode], resources: &Document
     }
 }
 
+/// Image references that the HTML tree can request independently of layout.
+#[cfg(feature = "remote")]
+pub(crate) fn document_image_references(nodes: &[DomNode]) -> Vec<&str> {
+    fn collect<'a>(nodes: &'a [DomNode], references: &mut Vec<&'a str>) {
+        for node in nodes {
+            let DomNode::Element(element) = node else {
+                continue;
+            };
+            if element.tag == HtmlTag::Img {
+                references.extend(element.attributes.get("src").map(String::as_str));
+            }
+            if element.raw_tag_name.eq_ignore_ascii_case("image") {
+                references.extend(element.attributes.get("href").map(String::as_str));
+                references.extend(element.attributes.get("xlink:href").map(String::as_str));
+            }
+            collect(&element.children, references);
+        }
+    }
+
+    let mut references = Vec::new();
+    collect(nodes, &mut references);
+    references
+}
+
 fn authorize_attribute(
     attributes: &mut std::collections::HashMap<String, String>,
     name: &str,


### PR DESCRIPTION
Closes #195.

## What changed

- cache successful and failed resource loads for one conversion
- collect HTML and SVG image URLs before layout
- fetch distinct remote images in batches of at most eight
- keep preloads and cache misses on the same network policy path

The success cache already existed on `main` after #186. This completes the
failure-cache and bounded-concurrency parts of the issue.

## Verification

- `cargo test --lib` — 3,294 passed
- `cargo test --features remote --lib` — 3,307 passed
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --lib -- -D warnings`
- repeated success and failure references each issue one request
- distinct URLs connect before either response is released
