### PR TITLE
ci: fix crates.io publish preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: CI
 
 on:
+  workflow_dispatch:
+    inputs:
+      publish_crate:
+        description: Publish the crate from main after all required checks pass
+        type: boolean
+        required: true
+        default: false
   push:
     branches: [main]
     tags: ['v*']
@@ -111,7 +118,10 @@ jobs:
   publish-crate:
     runs-on: ubuntu-latest
     needs: [test, clippy, fmt]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' && inputs.publish_crate)
     permissions:
       contents: read
     steps:
@@ -123,7 +133,8 @@ jobs:
         run: |
           version="$(cargo metadata --no-deps --format-version 1 \
             | jq -r '.packages[] | select(.name == "ironpress") | .version')"
-          if cargo info "ironpress@${version}" >/dev/null 2>&1; then
+          # Force the remote lookup; otherwise Cargo resolves the checked-out package.
+          if cargo info --registry crates-io "ironpress@${version}" >/dev/null 2>&1; then
             echo "ironpress@${version} is already published"
           else
             cargo publish


### PR DESCRIPTION
## What

- Force `cargo info` to query crates.io instead of the checked-out package.
- Add an opt-in manual dispatch to recover a missed crate publication from `main`.
- Keep tests, Clippy, and formatting as required gates before a manual publish.

## Why

`cargo info ironpress@1.5.1` succeeds inside the 1.5.1 checkout with `from ./`.
The tag workflow therefore reported success while skipping crates.io publication.

The other 1.5.1 packages were published correctly. crates.io remains on 1.5.0.

## Verification

- The old command reproduces the false positive from the 1.5.1 checkout.
- The registry-only command fails for missing 1.5.1.
- The same command succeeds for published 1.5.0.
- Workflow YAML parses, the embedded shell passes `bash -n`, and `git diff --check` passes.

After merge, dispatch CI on `main` with `publish_crate=true` to publish 1.5.1 safely.
