### PR TITLE
Prepare Ironpress 1.5.2 and refresh dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,24 @@ jobs:
       - run: cargo test --verbose
       - run: cargo test --verbose --features remote
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.88.0'
+          targets: wasm32-unknown-unknown
+      - run: cargo check --all-features
+      - run: cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
+
   clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: '1.88.0'
           components: clippy
       - run: cargo clippy -- -D warnings
 
@@ -83,7 +95,7 @@ jobs:
 
   publish-npm:
     runs-on: ubuntu-latest
-    needs: [test, clippy, fmt, wasm]
+    needs: [test, msrv, clippy, fmt, wasm]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
@@ -117,7 +129,7 @@ jobs:
 
   publish-crate:
     runs-on: ubuntu-latest
-    needs: [test, clippy, fmt]
+    needs: [test, msrv, clippy, fmt]
     if: >-
       startsWith(github.ref, 'refs/tags/v') ||
       (github.event_name == 'workflow_dispatch' &&

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.5.2] — 2026-08-15
+
+### Changed
+
+- HTML parsing now uses `html5ever` and `markup5ever_rcdom` 0.39.
+- The declared MSRV is now Rust 1.88, matching the stable language features
+  already required by Ironpress. CI now verifies it directly.
+
+### Security
+
+- Tokio's supported version range now excludes releases affected by
+  RUSTSEC-2023-0001.
+
+### Compatibility
+
+- WebAssembly keeps `getrandom` 0.3 until `lightningcss` moves off that major,
+  preserving its required `wasm_js` feature wiring.
+
 ## [1.5.1] — 2026-08-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ironpress"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter with layout engine, LaTeX math, tables, images, custom fonts, and streaming output. No browser, no system dependencies."
 license = "MIT"
 repository = "https://github.com/gastongouron/ironpress"
@@ -28,7 +28,7 @@ wasm = ["wasm-bindgen", "js-sys", "getrandom/wasm_js"]
 [dependencies]
 cssparser-color = "0.1"
 cssparser = "0.33"
-html5ever = "0.38"
+html5ever = "0.39"
 lightningcss = { version = "=1.0.0-alpha.71", default-features = false }
 # lightningcss alpha.71 declares `parcel_selectors = "0.28.2"`, which also
 # admits 0.28.3 even though that release moved to an incompatible cssparser.
@@ -37,7 +37,7 @@ parcel_selectors = "=0.28.2"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 png_decoder = { package = "png", version = "0.18" }
 pulldown-cmark = "0.13"
-markup5ever_rcdom = "0.38"
+markup5ever_rcdom = "0.39"
 fontdb = "0.23"
 flate2 = "1"
 resvg = "0.47"
@@ -46,7 +46,7 @@ sha2 = "0.10"
 skrifa = "=0.42.1"
 subsetter = "=0.2.6"
 thiserror = "2"
-tokio = { version = "1", features = ["fs", "rt"], optional = true }
+tokio = { version = "1.23.1", features = ["fs", "rt"], optional = true }
 bogon = { version = "0.3", optional = true }
 core-net = { version = "0.1", optional = true }
 # The custom resolver lives in ureq's `unversioned` API. Pin the exact release
@@ -55,13 +55,15 @@ ureq = { version = "=3.3.0", optional = true }
 url = { version = "2.5", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }
+# lightningcss alpha.71 still uses getrandom 0.3 on wasm32. This direct edge
+# enables wasm_js for that shared dependency graph; 0.4 would leave 0.3 unconfigured.
 getrandom = { version = "0.3", optional = true }
 unicode-bidi = "0.3.18"
 unicode-linebreak = "0.1.5"
 unicode-segmentation = "1.13.2"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.23.1", features = ["macros", "rt-multi-thread"] }
 proptest = "1"
 criterion = { version = "0.8", features = ["html_reports"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pure rust HTML/CSS/Markdown to PDF converter. No browser, no system dependencies
 [![CI](https://github.com/gastongouron/ironpress/actions/workflows/ci.yml/badge.svg)](https://github.com/gastongouron/ironpress/actions)
 [![codecov](https://codecov.io/gh/gastongouron/ironpress/branch/main/graph/badge.svg?token=w36XIAwRxG)](https://codecov.io/gh/gastongouron/ironpress)
 [![deps.rs](https://deps.rs/repo/github/gastongouron/ironpress/status.svg)](https://deps.rs/repo/github/gastongouron/ironpress)
-[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue.svg)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://www.rust-lang.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Downloads](https://img.shields.io/crates/d/ironpress.svg)](https://crates.io/crates/ironpress)
 [![WASM](https://img.shields.io/badge/wasm-ready-blueviolet.svg)](../../wiki/WASM-Playground)

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-python"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
 publish = false
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ironpress"
-version = "1.5.1"
+version = "1.5.2"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter. No browser, no system dependencies."
 readme = "README.md"
 license = "MIT"

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-ruby"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
 publish = false
 

--- a/bindings/ruby/ironpress.gemspec
+++ b/bindings/ruby/ironpress.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "ironpress"
-  spec.version       = "1.5.1"
+  spec.version       = "1.5.2"
   spec.authors       = ["Paul Gaston Gouron"]
   spec.summary       = "Pure Rust HTML/CSS/Markdown to PDF converter"
   spec.description   = "Convert HTML, CSS, and Markdown to PDF with no browser or system dependencies. Native Rust extension for maximum performance."

--- a/src/layout/block.rs
+++ b/src/layout/block.rs
@@ -1391,7 +1391,7 @@ pub(crate) fn layout_block_element(
                             child_ancestors,
                         );
                     }
-                    DomNode::Element(child_el) if inline_children.is_inline_text(child_el_idx) => {
+                    DomNode::Element(_) if inline_children.is_inline_text(child_el_idx) => {
                         InlineRunCollector::new(
                             env.rules,
                             env.fonts,

--- a/src/parser/css/page.rs
+++ b/src/parser/css/page.rs
@@ -10,12 +10,11 @@ use cssparser::{Parser, ParserInput};
 /// Parse a CSS stylesheet and extract `@page` rules.
 pub fn parse_page_rules(css: &str) -> Vec<PageRule> {
     let preprocessed = preprocess_media_queries(css);
-    let rules = extract_page_rules(&preprocessed);
     // `@footnote` is a page-context rule. In particular, do not silently
     // accept a stylesheet-level `@footnote`: doing so turns an invalid source
     // into a document-wide footnote style and makes reference engines that
     // reject it appear wrong.
-    rules
+    extract_page_rules(&preprocessed)
 }
 
 /// Parse a CSS stylesheet and extract `@font-face` rules.

--- a/src/render/pdf/container/nested.rs
+++ b/src/render/pdf/container/nested.rs
@@ -546,10 +546,7 @@ pub(super) fn render_nested_container(
                 let (or, og, ob) = nk_outline_color
                     .unwrap_or(crate::types::Color::BLACK)
                     .to_f32_rgb();
-                content.push_str(&format!(
-                    "{or} {og} {ob} RG\n{ow} w\n",
-                    ow = nk_outline_width
-                ));
+                content.push_str(&format!("{or} {og} {ob} RG\n{nk_outline_width} w\n"));
                 content.push_str(
                     &nk_paint_geometry
                         .border_box

--- a/src/render/pdf/container/text.rs
+++ b/src/render/pdf/container/text.rs
@@ -827,34 +827,32 @@ pub(super) fn render_text_child(
                     ctx.text.pdf_writer,
                     ctx.text.page_images,
                 )
+            } else if decoration.is_some() {
+                render_run_glyphs_without_shadows(
+                    content,
+                    run,
+                    lx,
+                    run_y,
+                    crate::layout::text::line_primary_font_size(&merged),
+                    ctx.text.custom_fonts,
+                    ctx.text.prepared_custom_fonts,
+                    0.0,
+                    ctx.text.pdf_writer,
+                    ctx.text.page_images,
+                )
             } else {
-                if decoration.is_some() {
-                    render_run_glyphs_without_shadows(
-                        content,
-                        run,
-                        lx,
-                        run_y,
-                        crate::layout::text::line_primary_font_size(&merged),
-                        ctx.text.custom_fonts,
-                        ctx.text.prepared_custom_fonts,
-                        0.0,
-                        ctx.text.pdf_writer,
-                        ctx.text.page_images,
-                    )
-                } else {
-                    render_run_glyphs(
-                        content,
-                        run,
-                        lx,
-                        run_y,
-                        crate::layout::text::line_primary_font_size(&merged),
-                        ctx.text.custom_fonts,
-                        ctx.text.prepared_custom_fonts,
-                        0.0,
-                        ctx.text.pdf_writer,
-                        ctx.text.page_images,
-                    )
-                }
+                render_run_glyphs(
+                    content,
+                    run,
+                    lx,
+                    run_y,
+                    crate::layout::text::line_primary_font_size(&merged),
+                    ctx.text.custom_fonts,
+                    ctx.text.prepared_custom_fonts,
+                    0.0,
+                    ctx.text.pdf_writer,
+                    ctx.text.page_images,
+                )
             };
             if let Some(decoration) = &decoration {
                 decoration.paint_above_text(content);

--- a/src/render/pdf/math.rs
+++ b/src/render/pdf/math.rs
@@ -133,7 +133,7 @@ pub(super) fn render_math_glyphs(
 
                 // Check if character needs Symbol font
                 if let Some(sym_byte) = unicode_to_symbol(*ch) {
-                    let encoded = format!("\\{:03o}", sym_byte);
+                    let encoded = format!("\\{sym_byte:03o}");
                     content.push_str("BT\n");
                     content.push_str(&format!("/Symbol {font_size} Tf\n"));
                     content.push_str(&format!("{px} {py} Td\n"));

--- a/src/render/pdf/page_elements/container_decoration.rs
+++ b/src/render/pdf/page_elements/container_decoration.rs
@@ -325,10 +325,7 @@ pub(super) fn paint_container_decoration(
             let (or, og, ob) = c_outline_color
                 .unwrap_or(crate::types::Color::BLACK)
                 .to_f32_rgb();
-            content.push_str(&format!(
-                "{or} {og} {ob} RG\n{ow} w\n",
-                ow = c_outline_width
-            ));
+            content.push_str(&format!("{or} {og} {ob} RG\n{c_outline_width} w\n"));
             content.push_str(
                 &RoundedRect::new(
                     PdfRect::new(ol_x, ol_y, ol_w, ol_h),

--- a/src/render/pdf/pdf_text.rs
+++ b/src/render/pdf/pdf_text.rs
@@ -93,7 +93,7 @@ pub(crate) fn encode_pdf_text(text: &str) -> String {
             0x20..=0x7E => result.push(b as char),
             _ => {
                 // Octal escape: \NNN (3-digit, zero-padded)
-                result.push_str(&format!("\\{:03o}", b));
+                result.push_str(&format!("\\{b:03o}"));
             }
         }
     }

--- a/src/render/pdf/text_runs.rs
+++ b/src/render/pdf/text_runs.rs
@@ -80,10 +80,7 @@ pub(super) fn render_text_shadow_blur(
     );
     let img_name = format!("Im{img_obj_id}");
     content.push_str(&format!(
-        "q\n{w} 0 0 {h} {ix} {iy} cm\n/{name} Do\nQ\n",
-        w = w_pt,
-        h = h_pt,
-        name = img_name,
+        "q\n{w_pt} 0 0 {h_pt} {ix} {iy} cm\n/{img_name} Do\nQ\n"
     ));
     page_images.push(ImageRef {
         name: img_name,

--- a/src/render/pdf/writer_output.rs
+++ b/src/render/pdf/writer_output.rs
@@ -589,7 +589,7 @@ impl PdfWriter {
         out.write_all(xref_header.as_bytes())?;
         out.write_all(b"0000000000 65535 f \n")?;
         for offset in &offsets {
-            let entry = format!("{:010} 00000 n \n", offset);
+            let entry = format!("{offset:010} 00000 n \n");
             out.write_all(entry.as_bytes())?;
         }
 

--- a/src/security/sanitizer.rs
+++ b/src/security/sanitizer.rs
@@ -26,8 +26,7 @@ pub(crate) fn sanitize_html_with_resources(
     // Check input size
     if html.len() > MAX_INPUT_SIZE {
         return Err(IronpressError::SecurityError(format!(
-            "Input exceeds maximum size of {} bytes",
-            MAX_INPUT_SIZE
+            "Input exceeds maximum size of {MAX_INPUT_SIZE} bytes"
         )));
     }
 


### PR DESCRIPTION
## Summary

- bump Rust, WASM/npm, Python, and Ruby packages to 1.5.2
- update `html5ever` and `markup5ever_rcdom` to 0.39
- set the actual MSRV to Rust 1.88 and verify it in CI
- require Tokio 1.23.1 or newer to exclude RUSTSEC-2023-0001
- keep `getrandom` 0.3 because `lightningcss` still needs that graph on WASM
- pin Clippy to the MSRV so new toolchain lints do not break old code

## Why

Ironpress already uses let chains, stabilized in Rust 1.88.
The old 1.85 MSRV was therefore inaccurate.

Tokio 1.23.1 is the maintained branch floor patched for the named-pipe advisory.

Sources:
- https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/
- https://rustsec.org/advisories/RUSTSEC-2023-0001.html

## Validation

- `cargo test --lib`: 3,294 passed
- `cargo test --lib --features remote`: 3,307 passed
- Rust 1.88 native and WASM checks
- Rust 1.88 Clippy with warnings denied
- `cargo fmt --check`
- `cargo package --allow-dirty`
- Python binding `cargo check`

`wasm-pack` derives the npm version from the root Cargo package.
The tag workflow will therefore generate `pkg/package.json` at 1.5.2.

The local Ruby check reaches `rb-sys` but the macOS Ruby is 2.6.
The binding requires Ruby 3.0+, so its supported matrix remains covered by CI.