### PR TITLE
ci: migrate actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system fonts for Unicode rendering
         run: sudo apt-get update -qq && sudo apt-get install -y -qq fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji fonts-dejavu
@@ -36,7 +36,7 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: '1.88.0'
@@ -47,7 +47,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: '1.88.0'
@@ -57,7 +57,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -66,11 +66,11 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/wasm-pack
           key: wasm-pack-${{ runner.os }}-v1
@@ -80,9 +80,9 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-fuzz
           key: cargo-fuzz-${{ runner.os }}-v1
@@ -100,15 +100,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/wasm-pack
           key: wasm-pack-${{ runner.os }}-v1
@@ -137,7 +137,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Publish crate
         env:
@@ -157,16 +157,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-tarpaulin
           key: tarpaulin-${{ runner.os }}-v2
       - run: command -v cargo-tarpaulin || cargo install cargo-tarpaulin
       - run: cargo tarpaulin --lib --out xml --output-dir ./default-cov --skip-clean
       - run: cargo tarpaulin --lib --out xml --output-dir ./remote-cov --skip-clean --features remote
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         with:
           files: ./default-cov/cobertura.xml,./remote-cov/cobertura.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload current parity evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: parity-current-report
           if-no-files-found: warn

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -30,13 +30,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/wasm-pack
@@ -70,7 +70,7 @@ jobs:
           cp -R tests/parity/out playground/parity/
 
       - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: playground
       - id: deployment

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Build wheel
@@ -31,7 +31,7 @@ jobs:
           args: --release --out dist -i python3.12
           manylinux: auto
           working-directory: bindings/python
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-${{ matrix.target }}
           path: bindings/python/dist/*.whl
@@ -43,8 +43,8 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Build wheel
@@ -53,7 +53,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist -i python3.12
           working-directory: bindings/python
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.target }}
           path: bindings/python/dist/*.whl
@@ -62,8 +62,8 @@ jobs:
     name: Build wheels - Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Build wheel
@@ -71,7 +71,7 @@ jobs:
         with:
           args: --release --out dist -i python3.12
           working-directory: bindings/python
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-windows
           path: bindings/python/dist/*.whl
@@ -80,14 +80,14 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist
           working-directory: bindings/python
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: bindings/python/dist/*.tar.gz
@@ -101,7 +101,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           merge-multiple: true

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,7 +27,7 @@ jobs:
             ruby: "3.3"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -52,7 +52,7 @@ jobs:
           mkdir -p pkg
           mv ironpress-*.gem pkg/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: gem-${{ matrix.platform }}
           path: bindings/ruby/pkg/*.gem
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: gem-*
           merge-multiple: true


### PR DESCRIPTION
## Summary

- move GitHub JavaScript actions off the deprecated Node 20 runtime
- update artifact actions consistently across CI, parity, Python, Ruby, and Pages
- run the npm publishing job on Node 24

## Updated actions

- `actions/checkout`: v4 → v7
- `actions/cache`: v4 → v6
- `actions/setup-node`: v4 → v7
- `actions/setup-python`: v5 → v7
- `actions/upload-artifact`: v4 → v7
- `actions/download-artifact`: v4 → v8
- `actions/upload-pages-artifact`: v3 → v5
- `codecov/codecov-action`: v5 → v7

No commands, permissions, secrets, artifact names, or release conditions changed.

## Verification

- parsed every workflow as YAML
- `git diff --check`
- confirmed no replaced action version remains
- reviewed current inputs against each action's official README

Official references:

- https://github.com/actions/checkout
- https://github.com/actions/cache
- https://github.com/actions/setup-node
- https://github.com/actions/setup-python
- https://github.com/actions/upload-artifact
- https://github.com/actions/download-artifact
- https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0
- https://github.com/codecov/codecov-action
