### PR TITLE
feat(server): add ironpress-server HTTP crate (Gotenberg-compatible HTML→PDF)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Keep the build context small and the release build deterministic.
+# NOTE: `assets/` must NOT be ignored — the library embeds fonts from it via
+# include_bytes!("../assets/...").
+
+target/
+.git/
+.github/
+.idea/
+.claude/
+.devcontainer/
+
+# Test-only (the parity corpus is large and is never compiled in a release build).
+# NOTE: keep `benches/` — the root Cargo.toml declares `[[bench]] conversion` and
+# Cargo validates that target's path when it parses the manifest, even though a
+# release build never compiles it.
+tests/
+fuzz/
+
+# Not needed to build the server.
+playground/
+docs/
+bindings/
+scripts/
+
+# Local artifacts / editor noise.
+*.pdf
+*.log
+.gitignore
+.gitattributes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ documentation = "https://docs.rs/ironpress"
 readme = "README.md"
 keywords = ["pdf", "html", "css", "markdown", "converter"]
 categories = ["text-processing", "encoding", "template-engine"]
-exclude = [".github/", ".claude/", "target/", "docs/", "tests/parity/", "scripts/"]
+exclude = [".github/", ".claude/", "target/", "docs/", "tests/parity/", "scripts/", "server/"]
+
+[workspace]
+members = ["server"]
+resolver = "2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+# ---- build stage ----
+FROM rust:1.88-bookworm AS builder
+WORKDIR /app
+
+# Copy the whole workspace (the server depends on the ironpress library crate)
+# and build the server binary in release mode.
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release -p ironpress-server && \
+    cp target/release/ironpress-server /usr/local/bin/ironpress-server
+
+# ---- runtime stage ----
+FROM debian:bookworm-slim
+# ca-certificates is only needed when IRONPRESS_REMOTE_ENABLED=true (TLS trust
+# for outbound https). It is tiny and harmless when remote fetching is off.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Run as a non-root system user.
+RUN useradd --system --uid 10001 --user-group ironpress
+COPY --from=builder /usr/local/bin/ironpress-server /usr/local/bin/ironpress-server
+USER ironpress
+
+# Operator-controlled defaults (override at `docker run` with -e).
+ENV IRONPRESS_PORT=3000 \
+    IRONPRESS_SANITIZE=true \
+    IRONPRESS_REMOTE_ENABLED=false
+EXPOSE 3000
+
+# Self-contained health check (no curl/wget needed).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD ["/usr/local/bin/ironpress-server", "--health"]
+
+ENTRYPOINT ["/usr/local/bin/ironpress-server"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ironpress-server"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+license = "MIT"
+description = "HTTP server exposing ironpress HTML-to-PDF conversion with a Gotenberg-compatible multipart form API."
+repository = "https://github.com/gastongouron/ironpress"
+publish = false
+
+[[bin]]
+name = "ironpress-server"
+path = "src/main.rs"
+
+[dependencies]
+# Remote fetching is compiled in, but gated at runtime by IRONPRESS_REMOTE_ENABLED
+# (default off -> a block-all network policy). A single binary/image is
+# configured per environment; there is no separate "remote" build.
+ironpress = { path = "..", features = ["remote"] }
+axum = { version = "0.8", features = ["multipart"] }
+tokio = { version = "1.23.1", features = ["rt-multi-thread", "macros", "net"] }
+tempfile = "3"
+regex = "1"
+serde_json = "1"

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,150 @@
+# ironpress-server
+
+A small HTTP server that exposes the [ironpress](../) HTML-to-PDF engine over a
+**Gotenberg-compatible** multipart form API. It is a separate workspace crate so
+the core `ironpress` library stays free of web-server dependencies.
+
+## Running
+
+```sh
+cargo run -p ironpress-server --release
+# ironpress-server 0.1.0 listening on http://0.0.0.0:3000 (sanitize=true, max_body=67108864 bytes)
+```
+
+### Startup configuration (operator-controlled, environment variables)
+
+These fix the process's behaviour and **cannot** be overridden by a request.
+Anything that affects the security posture lives here by design.
+
+| Variable                  | Default      | Meaning                                              |
+| ------------------------- | ------------ | ---------------------------------------------------- |
+| `IRONPRESS_PORT`          | `3000`       | TCP port to listen on.                               |
+| `IRONPRESS_SANITIZE`      | `true`       | Sanitize HTML before conversion. Disable only for fully trusted input. |
+| `IRONPRESS_MAX_BODY_BYTES`| `67108864`   | Maximum request body size (64 MiB).                  |
+| `IRONPRESS_REMOTE_ENABLED`| `false`      | Allow fetching remote document resources. Off = every remote reference is blocked before any connection. |
+
+#### Remote resources (SSRF surface)
+
+By default (`IRONPRESS_REMOTE_ENABLED=false`) the server fetches **nothing** from
+the network: `<img src="https://…">` and remote `@import` are rejected before any
+DNS/TCP, and only files you upload (staged in a private per-request temp
+directory) plus `data:` URIs load. The document still converts — blocked
+resources are simply absent.
+
+Set `IRONPRESS_REMOTE_ENABLED=true` to allow outbound fetching. The policy is
+then built **only** from these startup variables — never from a request — with
+SSRF-hardened defaults (all non-public address ranges, including loopback,
+private, link-local and cloud-metadata IPs, are denied):
+
+| Variable                          | Default | Meaning                                                        |
+| --------------------------------- | ------- | -------------------------------------------------------------- |
+| `IRONPRESS_REMOTE_ALLOW_HOSTS`    | —       | Comma-separated host allow-list. `example.com` = exact; `.example.com` = subdomains. An allow entry bypasses the IP-class checks (DNS pinning still applies). |
+| `IRONPRESS_REMOTE_DENY_HOSTS`     | —       | Comma-separated host deny-list (wins over allow).              |
+| `IRONPRESS_REMOTE_DENY_PRIVATE_IPS`| `true` | Reject non-public target addresses.                            |
+| `IRONPRESS_REMOTE_DENY_PUBLIC_IPS`| `false` | Reject public target addresses.                                |
+| `IRONPRESS_REMOTE_MAX_REDIRECTS`  | `8`     | Max redirects (each hop re-checked).                           |
+| `IRONPRESS_REMOTE_MAX_BODY_BYTES` | (lib default) | Max remote response size.                                |
+
+A malformed host pattern fails startup. For a hard no-egress guarantee, also cut
+egress at the network layer (`docker run --network none`, a k8s `NetworkPolicy`,
+or no route out of the pod) — that is independent of this flag.
+
+> **No sensitive knobs are request-controllable.** Sanitization and the entire
+> remote/allow-list/IP policy are startup-only. Per-request form fields can only
+> change cosmetic rendering options.
+
+## Routes
+
+### `POST /convert/html`
+
+`multipart/form-data`. Files are identified by their `filename`:
+
+| File          | Required | Purpose                                             |
+| ------------- | -------- | --------------------------------------------------- |
+| `index.html`  | yes      | The document to convert.                             |
+| `header.html` | no       | Running header (see header/footer note below).      |
+| `footer.html` | no       | Running footer.                                      |
+| *other files* | no       | Assets referenced by **relative** URL from the document (CSS via `@import`, images, fonts). |
+
+Response: `application/pdf`. The output filename comes from the optional
+`Gotenberg-Output-Filename` request header (default `output.pdf`).
+
+#### Options (form fields)
+
+Geometry fields use **inches** (Gotenberg convention) and are converted to points.
+
+| Field                 | Unit  | Default | Notes                                          |
+| --------------------- | ----- | ------- | ---------------------------------------------- |
+| `paperWidth`          | in    | 8.27 (A4) | Page width.                                   |
+| `paperHeight`         | in    | 11.69 (A4)| Page height.                                  |
+| `marginTop/Bottom/Left/Right` | in | 1     | Per-side margins.                             |
+| `landscape`           | bool  | `false` | Swaps width/height.                            |
+| `preferCssPageSize`   | bool  | —       | Accepted; ironpress already honors `@page`.    |
+| `printBackground`     | bool  | —       | Accepted; ironpress always paints backgrounds. |
+| `compress`            | bool  | `true`  | FlateDecode content streams.                   |
+| `imageDpi`            | DPI   | `300`   | Target source-image resolution.                |
+| `autoResizeImages`    | bool  | `true`  | Downscale oversized images (Lanczos3, shrink-only). |
+| `jpegQuality`         | 0–100 | `95`    | Re-encode quality.                             |
+| `filterDpi`           | DPI   | `300`   | Blur/filter raster resolution.                 |
+| `maskDpi`             | DPI   | `300`   | CSS-mask raster resolution.                    |
+| `backgroundRasterDpi` | DPI   | `192`   | Flattened-background resolution.               |
+| `occlusionCull`       | bool  | `false` | Skip images fully covered by later opaque boxes. |
+
+CSS `@page { size; margin }` in the document still overrides page geometry, as in
+the library. Browser-only Gotenberg fields (`scale`, `waitDelay`,
+`emulatedMediaType`, `nativePageRanges`, JavaScript options, …) are **accepted
+and ignored** — ironpress has no browser.
+
+#### Header / footer
+
+ironpress running headers/footers are a single line of **text** with `{page}` /
+`{pages}` placeholders, not full HTML. `header.html` / `footer.html` are
+translated best-effort:
+
+- `<span class="pageNumber"></span>` → `{page}`
+- `<span class="totalPages"></span>` → `{pages}`
+- all other markup is reduced to its text content (styling is lost).
+
+### `GET /health`
+
+`{"status":"up"}` — liveness probe.
+
+### `GET /version`
+
+`{"ironpress":"<lib version>","server":"<server version>"}`.
+
+## Example
+
+```sh
+curl -s -o out.pdf http://localhost:3000/convert/html \
+  -F "index.html=@index.html;filename=index.html" \
+  -F "header.html=@header.html;filename=header.html" \
+  -F "footer.html=@footer.html;filename=footer.html" \
+  -F "paperWidth=8.5" -F "paperHeight=11" -F "marginTop=0.5" \
+  -H "Gotenberg-Output-Filename: invoice"
+```
+
+## Docker
+
+A single image is built from the repository root (it builds the `ironpress`
+library and this server). One artifact, configured per environment via env vars.
+
+```sh
+# Build (from the repo root, where the Dockerfile lives)
+docker build -t ironpress-server .
+
+# Run — remote fetching off, no network egress
+docker run --rm -p 3000:3000 ironpress-server
+
+# Run — allow remote assets from one CDN only
+docker run --rm -p 3000:3000 \
+  -e IRONPRESS_REMOTE_ENABLED=true \
+  -e IRONPRESS_REMOTE_ALLOW_HOSTS=cdn.example.com \
+  ironpress-server
+
+# Hardened: block egress at the network layer regardless of app config
+docker run --rm -p 3000:3000 --network none ironpress-server
+```
+
+The image runs as a non-root user and ships a self-contained `HEALTHCHECK`
+(`ironpress-server --health`, a TCP liveness probe — no curl/wget needed).

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,0 +1,162 @@
+//! Operator-controlled server configuration, fixed at startup.
+//!
+//! Everything that affects the process's security posture lives here and is
+//! read once from the environment when the server boots. These values are
+//! deliberately NOT part of the per-request form surface: an untrusted caller
+//! must never be able to weaken sanitization or the network policy through a
+//! request field.
+
+use ironpress::{NetworkPolicy, RemoteHost};
+
+/// Remote-network policy environment variables. They take effect only when
+/// `IRONPRESS_REMOTE_ENABLED` is true; otherwise setting one is a no-op worth a
+/// warning.
+const REMOTE_POLICY_ENV_VARS: &[&str] = &[
+    "IRONPRESS_REMOTE_ALLOW_HOSTS",
+    "IRONPRESS_REMOTE_DENY_HOSTS",
+    "IRONPRESS_REMOTE_DENY_PRIVATE_IPS",
+    "IRONPRESS_REMOTE_DENY_PUBLIC_IPS",
+    "IRONPRESS_REMOTE_MAX_REDIRECTS",
+    "IRONPRESS_REMOTE_MAX_BODY_BYTES",
+];
+
+/// Server settings resolved from environment variables at startup.
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// TCP port to listen on (`IRONPRESS_PORT`, default `3000`).
+    pub port: u16,
+    /// Whether HTML is sanitized before conversion (`IRONPRESS_SANITIZE`,
+    /// default `true`). Disabling this trusts every request body; only do so
+    /// for a fully trusted caller behind your own boundary.
+    pub sanitize: bool,
+    /// Maximum accepted request body size in bytes
+    /// (`IRONPRESS_MAX_BODY_BYTES`, default 64 MiB).
+    pub max_body_bytes: usize,
+    /// Network policy for remote document resources. When remote fetching is
+    /// disabled this is a block-all policy (no host can be reached); when
+    /// enabled it is built entirely from the `IRONPRESS_REMOTE_*` variables.
+    /// Never influenced by a request.
+    pub network: NetworkPolicy,
+    /// Whether outbound fetching of remote resources is enabled at runtime
+    /// (`IRONPRESS_REMOTE_ENABLED`, default `false`).
+    pub remote_enabled: bool,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            port: 3000,
+            sanitize: true,
+            max_body_bytes: 64 * 1024 * 1024,
+            network: block_all_policy(),
+            remote_enabled: false,
+        }
+    }
+}
+
+impl ServerConfig {
+    /// Build the configuration from environment variables, falling back to the
+    /// documented defaults for anything unset. Returns an error string if a
+    /// remote host pattern is malformed.
+    pub fn from_env() -> Result<Self, String> {
+        let defaults = Self::default();
+        let remote_enabled = env_bool("IRONPRESS_REMOTE_ENABLED").unwrap_or(defaults.remote_enabled);
+
+        if !remote_enabled
+            && REMOTE_POLICY_ENV_VARS
+                .iter()
+                .any(|k| std::env::var(k).is_ok())
+        {
+            eprintln!(
+                "ironpress-server: warning: IRONPRESS_REMOTE_* policy variables are set but \
+                 IRONPRESS_REMOTE_ENABLED is not true — they are ignored and no remote resource \
+                 will be fetched."
+            );
+        }
+
+        // When remote fetching is off, every remote reference is rejected before
+        // any connection by a block-all policy. When on, the policy comes only
+        // from the environment (SSRF-hardened defaults), never from a request.
+        let network = if remote_enabled {
+            network_policy_from_env()?
+        } else {
+            block_all_policy()
+        };
+
+        Ok(Self {
+            port: env_parse("IRONPRESS_PORT").unwrap_or(defaults.port),
+            sanitize: env_bool("IRONPRESS_SANITIZE").unwrap_or(defaults.sanitize),
+            max_body_bytes: env_parse("IRONPRESS_MAX_BODY_BYTES").unwrap_or(defaults.max_body_bytes),
+            network,
+            remote_enabled,
+        })
+    }
+}
+
+/// A policy that rejects every remote address, blocking all outbound fetches
+/// before any TCP connection is made. Denying both the non-public and public
+/// address classes leaves no reachable target and no allow-list bypass.
+fn block_all_policy() -> NetworkPolicy {
+    NetworkPolicy::default()
+        .deny_private_ips(true)
+        .deny_public_ips(true)
+}
+
+/// Build the remote [`NetworkPolicy`] from `IRONPRESS_REMOTE_*` variables.
+///
+/// The base is the ironpress default (public hosts allowed, all non-public
+/// address ranges — loopback, private, link-local, cloud metadata — denied), so
+/// even a bare `--features remote` deployment is SSRF-hardened by default. Host
+/// patterns are validated here so a typo fails fast at startup rather than
+/// silently at request time.
+fn network_policy_from_env() -> Result<NetworkPolicy, String> {
+    let mut policy = NetworkPolicy::default();
+
+    if let Some(hosts) = env_hosts("IRONPRESS_REMOTE_ALLOW_HOSTS")? {
+        policy = policy.with_allow_list(hosts);
+    }
+    if let Some(hosts) = env_hosts("IRONPRESS_REMOTE_DENY_HOSTS")? {
+        policy = policy.with_deny_list(hosts);
+    }
+    if let Some(v) = env_bool("IRONPRESS_REMOTE_DENY_PRIVATE_IPS") {
+        policy = policy.deny_private_ips(v);
+    }
+    if let Some(v) = env_bool("IRONPRESS_REMOTE_DENY_PUBLIC_IPS") {
+        policy = policy.deny_public_ips(v);
+    }
+    if let Some(v) = env_parse::<u32>("IRONPRESS_REMOTE_MAX_REDIRECTS") {
+        policy = policy.max_redirects(v);
+    }
+    if let Some(v) = env_parse::<u64>("IRONPRESS_REMOTE_MAX_BODY_BYTES") {
+        policy = policy.max_body_size(v);
+    }
+
+    Ok(policy)
+}
+
+/// Parse a comma-separated host list into [`RemoteHost`] patterns.
+fn env_hosts(key: &str) -> Result<Option<Vec<RemoteHost>>, String> {
+    let Ok(raw) = std::env::var(key) else {
+        return Ok(None);
+    };
+    let mut hosts = Vec::new();
+    for part in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let host = part
+            .parse::<RemoteHost>()
+            .map_err(|e| format!("{key}: invalid host `{part}`: {e}"))?;
+        hosts.push(host);
+    }
+    Ok(Some(hosts))
+}
+
+fn env_parse<T: std::str::FromStr>(key: &str) -> Option<T> {
+    std::env::var(key).ok()?.trim().parse().ok()
+}
+
+fn env_bool(key: &str) -> Option<bool> {
+    match std::env::var(key).ok()?.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,0 +1,58 @@
+//! HTTP error type mapping conversion and request failures onto status codes.
+
+use axum::extract::multipart::MultipartError;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use ironpress::IronpressError;
+
+/// An error surfaced to the HTTP client as a status code plus a plain-text body.
+pub struct AppError {
+    status: StatusCode,
+    message: String,
+}
+
+impl AppError {
+    /// A `400 Bad Request` caused by malformed or invalid client input.
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
+
+    /// A `500 Internal Server Error` caused by a server-side failure.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+        }
+    }
+
+    /// Classify an ironpress conversion failure. Errors rooted in the caller's
+    /// document (parsing, CSS, layout, fonts, sanitizer rejection) are client
+    /// errors; rendering and I/O failures are server errors.
+    pub fn from_conversion(err: IronpressError) -> Self {
+        match &err {
+            IronpressError::ParseError(_)
+            | IronpressError::CssError(_)
+            | IronpressError::LayoutError(_)
+            | IronpressError::FontError(_)
+            | IronpressError::SecurityError(_) => Self::bad_request(err.to_string()),
+            IronpressError::RenderError(_) | IronpressError::IoError(_) => {
+                Self::internal(err.to_string())
+            }
+        }
+    }
+}
+
+impl From<MultipartError> for AppError {
+    fn from(err: MultipartError) -> Self {
+        Self::bad_request(format!("invalid multipart request: {err}"))
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (self.status, self.message).into_response()
+    }
+}

--- a/server/src/form.rs
+++ b/server/src/form.rs
@@ -1,0 +1,74 @@
+//! Multipart request parsing.
+//!
+//! The request follows the Gotenberg convention: files are identified by their
+//! `filename`, and everything else is a plain form field. `index.html` is the
+//! document; `header.html` / `footer.html` are the optional running header and
+//! footer; every other uploaded file is treated as a relative asset.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use axum::extract::Multipart;
+
+use crate::error::AppError;
+
+/// The decomposed parts of a conversion request.
+#[derive(Default)]
+pub struct FormData {
+    /// Contents of the required `index.html` document.
+    pub index_html: Option<String>,
+    /// Raw HTML of an optional running header file.
+    pub header_html: Option<String>,
+    /// Raw HTML of an optional running footer file.
+    pub footer_html: Option<String>,
+    /// Additional uploaded files as `(file_name, bytes)`, referenced by
+    /// relative URL from the document.
+    pub assets: Vec<(String, Vec<u8>)>,
+    /// Non-file form fields (rendering options).
+    pub fields: HashMap<String, String>,
+}
+
+/// Consume a multipart body into its [`FormData`] parts.
+pub async fn parse(mut multipart: Multipart) -> Result<FormData, AppError> {
+    let mut data = FormData::default();
+
+    while let Some(field) = multipart.next_field().await? {
+        let field_name = field.name().map(str::to_owned);
+        let file_name = field.file_name().map(str::to_owned);
+
+        match file_name {
+            // A file part.
+            Some(name) => {
+                let bytes = field.bytes().await?;
+                match name.as_str() {
+                    "index.html" => {
+                        data.index_html = Some(String::from_utf8_lossy(&bytes).into_owned());
+                    }
+                    "header.html" => {
+                        data.header_html = Some(String::from_utf8_lossy(&bytes).into_owned());
+                    }
+                    "footer.html" => {
+                        data.footer_html = Some(String::from_utf8_lossy(&bytes).into_owned());
+                    }
+                    // Any other file is an asset. Keep only the final path
+                    // component so a crafted `filename` cannot escape the
+                    // per-request temp directory.
+                    _ => {
+                        if let Some(base) = Path::new(&name).file_name().and_then(|n| n.to_str()) {
+                            data.assets.push((base.to_owned(), bytes.to_vec()));
+                        }
+                    }
+                }
+            }
+            // A plain form field (rendering option).
+            None => {
+                if let Some(key) = field_name {
+                    let value = field.text().await?;
+                    data.fields.insert(key, value);
+                }
+            }
+        }
+    }
+
+    Ok(data)
+}

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -1,0 +1,111 @@
+//! Route handlers.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Multipart, State};
+use axum::http::{HeaderMap, header};
+use axum::response::{IntoResponse, Response};
+
+use crate::config::ServerConfig;
+use crate::error::AppError;
+use crate::{form, header_footer, params};
+
+/// `GET /health` — liveness probe. Mirrors Gotenberg's `{"status":"up"}`.
+pub async fn health() -> impl IntoResponse {
+    Json(serde_json::json!({ "status": "up" }))
+}
+
+/// `GET /version` — reports the underlying ironpress and server versions.
+pub async fn version() -> impl IntoResponse {
+    Json(serde_json::json!({
+        "ironpress": ironpress::VERSION,
+        "server": env!("CARGO_PKG_VERSION"),
+    }))
+}
+
+/// `POST /convert/html` — convert an uploaded `index.html` (plus optional
+/// header/footer/asset files and rendering options) into a PDF.
+pub async fn convert_html(
+    State(config): State<Arc<ServerConfig>>,
+    headers: HeaderMap,
+    multipart: Multipart,
+) -> Result<Response, AppError> {
+    let data = form::parse(multipart).await?;
+
+    let index = data
+        .index_html
+        .ok_or_else(|| AppError::bad_request("missing required file `index.html`"))?;
+
+    // Stage the document's assets in a private temp directory. ironpress
+    // resolves relative URLs and the resource-authorization boundary against
+    // this directory, so a request can only reach files it uploaded.
+    let dir = tempfile::tempdir()
+        .map_err(|e| AppError::internal(format!("failed to create temp directory: {e}")))?;
+    for (name, bytes) in &data.assets {
+        let path = dir.path().join(name);
+        std::fs::write(&path, bytes)
+            .map_err(|e| AppError::internal(format!("failed to write asset `{name}`: {e}")))?;
+    }
+
+    let header = data
+        .header_html
+        .as_deref()
+        .map(header_footer::to_text)
+        .filter(|s| !s.is_empty());
+    let footer = data
+        .footer_html
+        .as_deref()
+        .map(header_footer::to_text)
+        .filter(|s| !s.is_empty());
+
+    let converter = params::build(
+        &data.fields,
+        dir.path(),
+        config.sanitize,
+        &config.network,
+        header,
+        footer,
+    )?;
+
+    // Conversion is CPU-bound and synchronous; keep it off the async runtime.
+    let pdf = tokio::task::spawn_blocking(move || converter.convert(&index))
+        .await
+        .map_err(|e| AppError::internal(format!("conversion task failed: {e}")))?
+        .map_err(AppError::from_conversion)?;
+
+    // The temp directory must outlive conversion (assets are read from disk);
+    // it is still in scope here, so drop it only after the PDF is produced.
+    drop(dir);
+
+    let filename = output_filename(&headers);
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/pdf".to_owned()),
+            (
+                header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{filename}\""),
+            ),
+        ],
+        pdf,
+    )
+        .into_response())
+}
+
+/// Resolve the output filename from the `Gotenberg-Output-Filename` request
+/// header, sanitized to a bare `*.pdf` name. Defaults to `output.pdf`.
+fn output_filename(headers: &HeaderMap) -> String {
+    let raw = headers
+        .get("Gotenberg-Output-Filename")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| std::path::Path::new(v).file_name().and_then(|n| n.to_str()))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("output");
+
+    if raw.to_ascii_lowercase().ends_with(".pdf") {
+        raw.to_owned()
+    } else {
+        format!("{raw}.pdf")
+    }
+}

--- a/server/src/header_footer.rs
+++ b/server/src/header_footer.rs
@@ -1,0 +1,82 @@
+//! Best-effort translation of Gotenberg-style header/footer HTML into the plain
+//! text ironpress supports.
+//!
+//! Gotenberg renders `header.html` / `footer.html` as full HTML documents in
+//! the page margins, using Chromium magic classes. ironpress only supports a
+//! single line of text per running header/footer with `{page}` / `{pages}`
+//! placeholders, so this module extracts text and maps the two page-numbering
+//! classes:
+//!
+//! - `<span class="pageNumber"></span>` -> `{page}`
+//! - `<span class="totalPages"></span>` -> `{pages}`
+//!
+//! All other markup (styling, `.date` / `.title` / `.url` helpers) is stripped
+//! to its text content. This is a documented, lossy approximation.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static PAGE_NUMBER: LazyLock<Regex> =
+    LazyLock::new(|| regex(r"(?is)<span\b[^>]*\bpageNumber\b[^>]*>.*?</span>"));
+static TOTAL_PAGES: LazyLock<Regex> =
+    LazyLock::new(|| regex(r"(?is)<span\b[^>]*\btotalPages\b[^>]*>.*?</span>"));
+static BLOCK_ELEMENTS: LazyLock<Regex> =
+    LazyLock::new(|| regex(r"(?is)<(style|script|head)\b[^>]*>.*?</(style|script|head)>"));
+static TAG: LazyLock<Regex> = LazyLock::new(|| regex(r"(?s)<[^>]+>"));
+static WHITESPACE: LazyLock<Regex> = LazyLock::new(|| regex(r"\s+"));
+
+fn regex(pattern: &str) -> Regex {
+    #[allow(clippy::expect_used)]
+    Regex::new(pattern).expect("static header/footer regex is valid")
+}
+
+/// Translate header/footer HTML into ironpress running-header text. Returns an
+/// empty string when nothing textual remains.
+pub fn to_text(html: &str) -> String {
+    let s = PAGE_NUMBER.replace_all(html, "{page}");
+    let s = TOTAL_PAGES.replace_all(&s, "{pages}");
+    let s = BLOCK_ELEMENTS.replace_all(&s, "");
+    let s = TAG.replace_all(&s, "");
+    let s = decode_basic_entities(&s);
+    WHITESPACE.replace_all(&s, " ").trim().to_owned()
+}
+
+fn decode_basic_entities(s: &str) -> String {
+    s.replace("&nbsp;", " ")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        // Ampersand last so earlier entity names are not corrupted.
+        .replace("&amp;", "&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_text;
+
+    #[test]
+    fn maps_page_numbering_classes() {
+        let html = r#"<span class="pageNumber"></span> / <span class="totalPages"></span>"#;
+        assert_eq!(to_text(html), "{page} / {pages}");
+    }
+
+    #[test]
+    fn keeps_static_text_and_strips_markup() {
+        let html = r#"<div style="font-size:8px"><b>Quarterly&nbsp;Report</b></div>"#;
+        assert_eq!(to_text(html), "Quarterly Report");
+    }
+
+    #[test]
+    fn drops_style_blocks() {
+        let html = "<style>.x{color:red}</style><p>Footer &amp; notes</p>";
+        assert_eq!(to_text(html), "Footer & notes");
+    }
+
+    #[test]
+    fn empty_when_no_text() {
+        assert_eq!(to_text("<div></div>"), "");
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,0 +1,84 @@
+//! `ironpress-server` — a small HTTP wrapper around the ironpress HTML-to-PDF
+//! engine, with a Gotenberg-compatible multipart form API.
+//!
+//! Routes:
+//! - `POST /convert/html` — convert `index.html` (+ optional header/footer/asset
+//!   files and rendering options) to a PDF.
+//! - `GET /health` — liveness probe.
+//! - `GET /version` — ironpress and server versions.
+//!
+//! Security-relevant settings (HTML sanitization, body-size limit) are fixed at
+//! startup via environment variables and cannot be overridden per request. See
+//! [`config::ServerConfig`].
+
+mod config;
+mod error;
+mod form;
+mod handlers;
+mod header_footer;
+mod params;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::DefaultBodyLimit;
+use axum::routing::{get, post};
+
+use config::ServerConfig;
+
+#[tokio::main]
+async fn main() {
+    // Self-contained container HEALTHCHECK: `ironpress-server --health` exits 0
+    // if the listener accepts a TCP connection, 1 otherwise. Avoids needing curl
+    // or wget in the runtime image.
+    if std::env::args().any(|a| a == "--health") {
+        let port: u16 = std::env::var("IRONPRESS_PORT")
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(3000);
+        let ok = std::net::TcpStream::connect(("127.0.0.1", port)).is_ok();
+        std::process::exit(if ok { 0 } else { 1 });
+    }
+
+    let config = match ServerConfig::from_env() {
+        Ok(config) => Arc::new(config),
+        Err(e) => {
+            eprintln!("ironpress-server: invalid configuration: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let app = Router::new()
+        .route("/health", get(handlers::health))
+        .route("/version", get(handlers::version))
+        .route("/convert/html", post(handlers::convert_html))
+        .layer(DefaultBodyLimit::max(config.max_body_bytes))
+        .with_state(config.clone());
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            eprintln!("ironpress-server: failed to bind {addr}: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!(
+        "ironpress-server {} listening on http://{addr} (sanitize={}, max_body={} bytes, remote={})",
+        env!("CARGO_PKG_VERSION"),
+        config.sanitize,
+        config.max_body_bytes,
+        if config.remote_enabled {
+            "enabled (policy from IRONPRESS_REMOTE_* env)"
+        } else {
+            "disabled (remote fetches blocked)"
+        },
+    );
+
+    if let Err(e) = axum::serve(listener, app).await {
+        eprintln!("ironpress-server: server error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/server/src/params.rs
+++ b/server/src/params.rs
@@ -1,0 +1,210 @@
+//! Mapping of per-request form fields onto an [`HtmlConverter`].
+//!
+//! Only safe rendering knobs are accepted here. Security-relevant settings
+//! (sanitization, network policy) come from [`crate::config::ServerConfig`] and
+//! are passed in explicitly — never read from the request.
+//!
+//! Geometry fields use Gotenberg's units (inches) and are converted to points.
+//! Browser-only Gotenberg fields (`scale`, `waitDelay`, `emulatedMediaType`,
+//! `nativePageRanges`, JavaScript options, ...) have no meaning without a
+//! browser and are ignored.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use ironpress::{HtmlConverter, Margin, NetworkPolicy, PageSize};
+
+use crate::error::AppError;
+
+/// Points per inch. Gotenberg expresses paper and margin sizes in inches;
+/// ironpress works in points.
+const PT_PER_INCH: f32 = 72.0;
+
+/// Build a converter from the request fields, injecting the operator-controlled
+/// `sanitize` policy and the per-request asset base directory.
+pub fn build(
+    fields: &HashMap<String, String>,
+    base: &Path,
+    sanitize: bool,
+    network: &NetworkPolicy,
+    header: Option<String>,
+    footer: Option<String>,
+) -> Result<HtmlConverter, AppError> {
+    // Paper size: start from A4 and override either dimension if supplied.
+    let mut page = PageSize::A4;
+    if let Some(w) = parse_f32(fields, "paperWidth")? {
+        page.width = w * PT_PER_INCH;
+    }
+    if let Some(h) = parse_f32(fields, "paperHeight")? {
+        page.height = h * PT_PER_INCH;
+    }
+    if parse_bool(fields, "landscape")?.unwrap_or(false) {
+        page = PageSize::new(page.height, page.width);
+    }
+
+    // Margins: start from the ironpress default (1 inch) and override per side.
+    let mut margin = Margin::default();
+    if let Some(v) = parse_f32(fields, "marginTop")? {
+        margin.top = v * PT_PER_INCH;
+    }
+    if let Some(v) = parse_f32(fields, "marginBottom")? {
+        margin.bottom = v * PT_PER_INCH;
+    }
+    if let Some(v) = parse_f32(fields, "marginLeft")? {
+        margin.left = v * PT_PER_INCH;
+    }
+    if let Some(v) = parse_f32(fields, "marginRight")? {
+        margin.right = v * PT_PER_INCH;
+    }
+
+    let mut converter = HtmlConverter::new()
+        .page_size(page)
+        .margin(margin)
+        .sanitize(sanitize)
+        .base_path(base)
+        .resource_root(base)
+        // Operator-controlled remote policy (inert unless the `remote` feature
+        // is built in). Never sourced from the request.
+        .network_policy(network.clone());
+
+    // ironpress-native rendering knobs.
+    if let Some(v) = parse_bool(fields, "compress")? {
+        converter = converter.compress(v);
+    }
+    if let Some(v) = parse_bool(fields, "autoResizeImages")? {
+        converter = converter.auto_resize_images(v);
+    }
+    if let Some(v) = parse_u8_clamped(fields, "jpegQuality", 0, 100)? {
+        converter = converter.jpeg_quality(v);
+    }
+    if let Some(v) = parse_f32(fields, "imageDpi")? {
+        converter = converter.image_dpi(v);
+    }
+    if let Some(v) = parse_f32(fields, "filterDpi")? {
+        converter = converter.filter_dpi(v);
+    }
+    if let Some(v) = parse_f32(fields, "maskDpi")? {
+        converter = converter.mask_dpi(v);
+    }
+    if let Some(v) = parse_f32(fields, "backgroundRasterDpi")? {
+        converter = converter.background_raster_dpi(v);
+    }
+    if let Some(v) = parse_bool(fields, "occlusionCull")? {
+        converter = converter.occlusion_cull(v);
+    }
+
+    if let Some(text) = header {
+        if !text.is_empty() {
+            converter = converter.header(text);
+        }
+    }
+    if let Some(text) = footer {
+        if !text.is_empty() {
+            converter = converter.footer(text);
+        }
+    }
+
+    // Accepted for Gotenberg compatibility but need no explicit action:
+    // ironpress already honors `@page` rules (preferCssPageSize) and always
+    // paints backgrounds (printBackground). Parse them so an invalid value is
+    // still rejected rather than silently misread.
+    let _ = parse_bool(fields, "preferCssPageSize")?;
+    let _ = parse_bool(fields, "printBackground")?;
+
+    Ok(converter)
+}
+
+fn parse_f32(fields: &HashMap<String, String>, key: &str) -> Result<Option<f32>, AppError> {
+    match fields.get(key) {
+        None => Ok(None),
+        Some(raw) => raw
+            .trim()
+            .parse::<f32>()
+            .map(Some)
+            .map_err(|_| AppError::bad_request(format!("field `{key}` must be a number, got `{raw}`"))),
+    }
+}
+
+fn parse_bool(fields: &HashMap<String, String>, key: &str) -> Result<Option<bool>, AppError> {
+    match fields.get(key) {
+        None => Ok(None),
+        Some(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" | "on" => Ok(Some(true)),
+            "false" | "0" | "no" | "off" => Ok(Some(false)),
+            _ => Err(AppError::bad_request(format!(
+                "field `{key}` must be a boolean, got `{raw}`"
+            ))),
+        },
+    }
+}
+
+fn parse_u8_clamped(
+    fields: &HashMap<String, String>,
+    key: &str,
+    min: u8,
+    max: u8,
+) -> Result<Option<u8>, AppError> {
+    match fields.get(key) {
+        None => Ok(None),
+        Some(raw) => raw
+            .trim()
+            .parse::<i64>()
+            .map(|n| Some(n.clamp(i64::from(min), i64::from(max)) as u8))
+            .map_err(|_| {
+                AppError::bad_request(format!("field `{key}` must be an integer, got `{raw}`"))
+            }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fields(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn builds_with_defaults() {
+        let base = std::path::Path::new("/tmp");
+        let net = NetworkPolicy::default();
+        assert!(build(&fields(&[]), base, true, &net, None, None).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_numeric_paper_width() {
+        let base = std::path::Path::new("/tmp");
+        let net = NetworkPolicy::default();
+        let err = build(&fields(&[("paperWidth", "wide")]), base, true, &net, None, None);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn rejects_bad_boolean() {
+        let base = std::path::Path::new("/tmp");
+        let net = NetworkPolicy::default();
+        assert!(build(&fields(&[("landscape", "maybe")]), base, true, &net, None, None).is_err());
+    }
+
+    #[test]
+    fn accepts_full_option_set() {
+        let base = std::path::Path::new("/tmp");
+        let net = NetworkPolicy::default();
+        let f = fields(&[
+            ("paperWidth", "8.5"),
+            ("paperHeight", "11"),
+            ("marginTop", "0.5"),
+            ("landscape", "true"),
+            ("jpegQuality", "80"),
+            ("imageDpi", "150"),
+            ("autoResizeImages", "false"),
+            ("compress", "true"),
+            ("preferCssPageSize", "true"),
+            ("printBackground", "true"),
+        ]);
+        assert!(build(&f, base, true, &net, Some("Title".into()), Some("{page}".into())).is_ok());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,9 @@ pub use security::resources::{InvalidRemoteHost, NetworkPolicy, RemoteHost};
 pub use style::raster_quality::{CoverageCompression, JpegCompression, RasterQuality};
 pub use types::{CornerRadii, CornerRadius, EdgeSizes, Margin, PageSize};
 
+/// The version of the ironpress crate, taken from its Cargo package metadata.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Convert an HTML string to PDF bytes using default settings (A4, 1-inch margins).
 ///
 /// The HTML is sanitized before conversion to remove potentially dangerous


### PR DESCRIPTION
New `ironpress-server` workspace crate exposing HTML-to-PDF over HTTP:

- Routes: POST /convert/html (multipart, Gotenberg-compatible params), GET /health, GET /version.
- Security config is startup-only (sanitize, remote network policy); per-request form fields are limited to safe rendering knobs — no sanitize/allow-list/IP.
- Remote fetching gated at runtime by IRONPRESS_REMOTE_ENABLED (default off = block-all policy). Allow/deny/IP lists come from IRONPRESS_REMOTE_* env only; private IPs denied by default (SSRF-hardened).
- Gotenberg-style header.html/footer.html translated best-effort to ironpress text (.pageNumber to {page}, .totalPages to {pages}).
- Single multi-stage Dockerfile: non-root, self-contained --health HEALTHCHECK, plus .dockerignore.
- Library: add public ironpress::VERSION; convert repo to a Cargo workspace.