### PR TITLE
Remove em dashes from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ or WebAssembly.
 
 ## Why IronPress?
 
-- **Simple deployment** — one library or binary, with no browser runtime to install or manage.
-- **Document-focused layout** — flexbox, grid, tables, multi-column layout, `@page`, headers, and footers.
-- **Production typography** — custom font embedding and subsetting, Unicode/CJK fallback, SVG, and LaTeX-style math.
-- **Multiple runtimes** — the same Rust core ships to Rust, Python, Ruby, and WebAssembly.
-- **Defensive defaults** — HTML/SVG sanitization, constrained file access, and opt-in remote fetching policies.
+- **Simple deployment:** one library or binary, with no browser runtime to install or manage.
+- **Document-focused layout:** flexbox, grid, tables, multi-column layout, `@page`, headers, and footers.
+- **Production typography:** custom font embedding and subsetting, Unicode/CJK fallback, SVG, and LaTeX-style math.
+- **Multiple runtimes:** the same Rust core ships to Rust, Python, Ruby, and WebAssembly.
+- **Defensive defaults:** HTML/SVG sanitization, constrained file access, and opt-in remote fetching policies.
 
 ## Quick start
 


### PR DESCRIPTION
Replaces the five em dashes in the Why IronPress section with colons, without changing the content or removing any badges.