### PR TITLE
Fix text wrapping in stretched column flex items

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -9803,6 +9803,26 @@ mod tests {
     }
 
     #[test]
+    fn flex_column_text_uses_the_stretched_cross_size_for_wrapping() {
+        let html = r#"<div style="display:flex;flex-direction:column;font-size:11px">
+            <span style="font-weight:700">Hammer Drill SDS - A34</span>
+        </div>"#;
+        let pages = layout(
+            &parse_html(html).unwrap(),
+            PageSize::new(PageSize::A4.height, PageSize::A4.width),
+            Margin::uniform(0.0),
+        );
+        let text = find_page_text_block_containing(&pages[0].elements, "Hammer Drill SDS -")
+            .expect("flex-column product name");
+
+        assert_eq!(
+            text.lines.len(),
+            1,
+            "a stretched column flex item must wrap against the container width"
+        );
+    }
+
+    #[test]
     fn flex_column_with_background() {
         let html = r#"<div style="display: flex; flex-direction: column; background-color: #eee">
             <p>Child A</p>

--- a/src/layout/flex.rs
+++ b/src/layout/flex.rs
@@ -2345,7 +2345,14 @@ pub(crate) fn layout_flex_container(
         // width and inflate by padding/border, capped at the container — this
         // overrides the explicit `width` that `has_explicit_width` reflects.
         // When no explicit width/flex-basis and flex-grow is 0, measure the
-        // natural (intrinsic) content width so the item shrinks to fit.
+        // natural (intrinsic) content width so the item shrinks to fit. A
+        // stretched column item is the exception: its used cross size is the
+        // container width, so wrapping must use that width from the outset.
+        let stretches_column_cross_axis = !style.flex_direction.is_row()
+            && !has_explicit_width
+            && (item_align_self == AlignSelf::Stretch
+                || (item_align_self == AlignSelf::Auto
+                    && style.align_items == AlignItems::Stretch));
         let mut intrinsic_text_wrap_width = None;
         let child_w = if let Some(content_basis) = content_basis.filter(|_| !runs.is_empty()) {
             let natural_text_w = if content_basis == IntrinsicWidthKeyword::MinContent {
@@ -2358,7 +2365,11 @@ pub(crate) fn layout_flex_container(
             let intrinsic = FlexIntrinsicWidth::from_content(&child_style, natural_text_w);
             intrinsic_text_wrap_width = Some(intrinsic.text_wrap.min(width_for_percentages));
             intrinsic.paint.min(width_for_percentages)
-        } else if !has_explicit_width && child_style.flex_grow == 0.0 && !runs.is_empty() {
+        } else if !stretches_column_cross_axis
+            && !has_explicit_width
+            && child_style.flex_grow == 0.0
+            && !runs.is_empty()
+        {
             let natural_text_w = measure_runs_width(&runs, env.fonts);
             let pad_h = child_style.padding.horizontal();
             let border_h = child_style.border.horizontal_width();


### PR DESCRIPTION
Fixes #218

## Summary

- wrap auto-width column flex items against their stretched cross size
- preserve intrinsic sizing for non-stretched and explicit-width items
- add a regression test based on the reported A4 landscape product name

## Root cause

The text was wrapped at its intrinsic width before align-items: stretch expanded the flex item visually. The final box filled the container, but it retained the narrow two-line layout.

## Verification

- cargo fmt --all -- --check
- cargo test flex_column -- --nocapture
- cargo test layout::flex::cutoff_tests -- --nocapture
- cargo test --features remote flex_column_text_uses_the_stretched_cross_size_for_wrapping -- --nocapture
- exact CLI reproduction now renders both product names on one line
- all 3,309 library tests pass; two local parity-corpus checks also fail unchanged on origin/main because of checkout/provenance fixtures