### PR TITLE
Skip parity work for website-only changes

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -23,11 +23,40 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Keep the required check present: workflows skipped by a top-level path
+      # filter remain pending on GitHub. Website-only changes instead complete
+      # this job without running the expensive renderer parity suite.
+      - name: Detect parity-relevant changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          changed_paths="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          run_parity=false
+          while IFS= read -r changed_path; do
+            [[ -z "$changed_path" ]] && continue
+            case "$changed_path" in
+              site/*|playground/*|scripts/check-site.mjs|.github/workflows/playground.yml) ;;
+              *) run_parity=true; break ;;
+            esac
+          done <<< "$changed_paths"
+          echo "run=$run_parity" >> "$GITHUB_OUTPUT"
+
+      - name: Skip parity for website-only changes
+        if: steps.changes.outputs.run != 'true'
+        run: echo "No renderer or parity inputs changed."
 
       - name: Install Rust
+        if: steps.changes.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
+        if: steps.changes.outputs.run == 'true'
         uses: actions/cache@v6
         with:
           path: |
@@ -37,23 +66,26 @@ jobs:
           key: parity-cargo-${{ runner.os }}-${{ hashFiles('Cargo.toml') }}
 
       - name: Install pinned Poppler and deterministic fonts
+        if: steps.changes.outputs.run == 'true'
         run: scripts/parity-install-runtime.sh
 
       - name: Verify generated interaction product
+        if: steps.changes.outputs.run == 'true'
         run: python3 scripts/generate-interaction-cartesian.py --check
 
       - name: Run parity test (committed PDF oracles)
+        if: steps.changes.outputs.run == 'true'
         env:
           FONTCONFIG_FILE: ${{ github.workspace }}/tests/parity/fonts/fonts.conf
           PARITY_PDFTOPPM: /usr/bin/pdftoppm
         run: scripts/parity.sh
 
       - name: Refs-freshness gate (refs.lock vs. current fixtures)
-        if: always()
+        if: always() && steps.changes.outputs.run == 'true'
         run: scripts/parity-gen-refs.sh --check
 
       - name: Upload current parity evidence
-        if: always()
+        if: always() && steps.changes.outputs.run == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: parity-current-report

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <img width="188" alt="4" src="https://github.com/user-attachments/assets/e8b569e6-e74c-4c0f-9e84-05cf37fae3ae" />
 
-# IronPress
+# ironpress
 
 Fast, in-process HTML/CSS/Markdown to PDF rendering in pure Rust. No browser,
 subprocess, or system dependencies.
@@ -28,12 +28,12 @@ subprocess, or system dependencies.
 
 </div>
 
-IronPress turns HTML, CSS, or Markdown into PDF bytes inside your application.
+ironpress turns HTML, CSS, or Markdown into PDF bytes inside your application.
 Its rendering engine handles document layout, font shaping, SVG, math, and PDF
 serialization without launching Chrome. Use it from Rust, the CLI, Python, Ruby,
 or WebAssembly.
 
-## Why IronPress?
+## Why ironpress?
 
 - **Simple deployment:** one library or binary, with no browser runtime to install or manage.
 - **Document-focused layout:** flexbox, grid, tables, multi-column layout, `@page`, headers, and footers.

--- a/playground/index.html
+++ b/playground/index.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>IronPress Playground — HTML and Markdown to PDF</title>
-  <meta name="description" content="Try IronPress in your browser: convert HTML, CSS, or Markdown to PDF locally with the pure-Rust WebAssembly rendering engine.">
+  <title>ironpress Playground: HTML and Markdown to PDF</title>
+  <meta name="description" content="Try ironpress in your browser: convert HTML, CSS, or Markdown to PDF locally with the pure-Rust WebAssembly rendering engine.">
   <link rel="canonical" href="https://gastongouron.github.io/ironpress/playground/">
   <link rel="icon" type="image/png" href="../assets/ironpress-logo.png">
   <meta name="theme-color" content="#161b22">
-  <meta property="og:title" content="IronPress HTML to PDF Playground">
-  <meta property="og:description" content="Convert HTML, CSS, and Markdown to PDF locally in your browser with IronPress WebAssembly.">
+  <meta property="og:title" content="ironpress HTML to PDF Playground">
+  <meta property="og:description" content="Convert HTML, CSS, and Markdown to PDF locally in your browser with ironpress WebAssembly.">
   <meta property="og:url" content="https://gastongouron.github.io/ironpress/playground/">
   <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png">
-  <meta property="og:image:alt" content="IronPress logo">
+  <meta property="og:image:alt" content="ironpress logo">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #0f1117; color: #e1e4e8; height: 100vh; display: flex; flex-direction: column; }
@@ -81,7 +81,7 @@
 
   <header>
     <div class="product-title">
-      <img src="../assets/ironpress-logo.png" alt="IronPress" width="34" height="34">
+      <img src="../assets/ironpress-logo.png" alt="ironpress" width="34" height="34">
       <h1><span>ironpress</span> playground</h1>
     </div>
     <nav aria-label="Playground navigation">
@@ -228,7 +228,7 @@ blockquote { border-left: 3pt solid #336699; padding-left: 10pt; color: #666; fo
 <li>Expanded to 3 new markets</li>
 <li>Hired 12 engineers</li>
 </ul>
-<blockquote>The best way to predict the future is to create it. — Peter Drucker</blockquote>`,
+<blockquote>The best way to predict the future is to create it. - Peter Drucker</blockquote>`,
 
 markdown: `# Project Documentation
 

--- a/site/guides/html-to-pdf-rust/index.html
+++ b/site/guides/html-to-pdf-rust/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>HTML to PDF in Rust Without Chrome | IronPress</title>
+    <title>HTML to PDF in Rust Without Chrome | ironpress</title>
     <meta
       name="description"
       content="Learn how to convert HTML and CSS to PDF in Rust without Headless Chrome, when an in-process renderer fits, and the tradeoffs to consider."
@@ -15,7 +15,7 @@
     <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png">
     <meta name="theme-color" content="#f3efe4">
     <meta property="og:type" content="article">
-    <meta property="og:site_name" content="IronPress">
+    <meta property="og:site_name" content="ironpress">
     <meta property="og:title" content="HTML to PDF in Rust Without Headless Chrome">
     <meta
       property="og:description"
@@ -29,7 +29,7 @@
       property="og:image"
       content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png"
     >
-    <meta property="og:image:alt" content="IronPress logo">
+    <meta property="og:image:alt" content="ironpress logo">
     <meta name="twitter:card" content="summary">
     <link rel="stylesheet" href="../../assets/styles.css">
     <link rel="stylesheet" href="../../assets/guide.css">
@@ -46,7 +46,7 @@
         },
         "publisher": {
           "@type": "Organization",
-          "name": "IronPress",
+          "name": "ironpress",
           "url": "https://gastongouron.github.io/ironpress/"
         },
         "mainEntityOfPage": "https://gastongouron.github.io/ironpress/guides/html-to-pdf-rust/",
@@ -59,14 +59,14 @@
 
     <header class="site-header">
       <div class="shell header-inner">
-        <a class="brand" href="../../" aria-label="IronPress home">
+        <a class="brand" href="../../" aria-label="ironpress home">
           <img
             src="../../assets/ironpress-logo.png"
-            alt="IronPress"
+            alt="ironpress"
             width="44"
             height="44"
           >
-          <span>IronPress</span>
+          <span>ironpress</span>
         </a>
         <nav aria-label="Primary navigation">
           <a href="../../#features">Features</a>
@@ -119,8 +119,8 @@
               document, ask it to print, and collect the resulting bytes.
             </p>
             <p>
-              That works—and remains the right choice for genuinely browser-like
-              pages—but it also makes a browser part of your production
+              That works and remains the right choice for genuinely browser-like
+              pages, but it also makes a browser part of your production
               architecture. Images need the correct executable and shared
               libraries. Workers need process lifecycle management. Cold starts,
               browser upgrades, timeouts, and untrusted network requests become
@@ -134,7 +134,7 @@
               </p>
             </div>
             <p>
-              <a href="https://github.com/gastongouron/ironpress">IronPress</a>
+              <a href="https://github.com/gastongouron/ironpress">ironpress</a>
               explores the second option. It is a Rust library that parses HTML
               and CSS, computes a paged layout, shapes text, and writes PDF bytes
               in the same process as your application. There is no browser
@@ -144,7 +144,7 @@
             <h2 id="architecture">What “in process” actually means</h2>
             <p>
               Removing the browser does not remove the work. It replaces a broad
-              browser engine with a purpose-built document pipeline. IronPress
+              browser engine with a purpose-built document pipeline. ironpress
               owns five stages:
             </p>
             <ol>
@@ -229,12 +229,12 @@ h2 {
             <p>
               Treat print templates as their own interface. Use physical units
               deliberately, make page breaks part of the design, embed the fonts
-              you need, and test representative long content—not only the tidy
+              you need, and test representative long content, not only the tidy
               one-page example.
             </p>
             <h3>Fonts, SVG, and math</h3>
             <p>
-              IronPress embeds custom TTF fonts with subsetting and uses Unicode
+              ironpress embeds custom TTF fonts with subsetting and uses Unicode
               fallback for scripts outside the base PDF fonts. Inline SVG stays
               vector where supported, and LaTeX-style expressions can be used for
               technical documents. Those features avoid the “everything became
@@ -245,7 +245,7 @@ h2 {
             <p>
               PDF benchmarks are easy to misread. Parsing a fragment is not the
               same as producing final bytes, and pages per second is not the same
-              as documents per second. IronPress benchmarks the complete
+              as documents per second. ironpress benchmarks the complete
               in-process call and reports representative medians.
             </p>
             <table>
@@ -275,7 +275,7 @@ h2 {
               quietly inherit all the access of its host process.
             </p>
             <p>
-              IronPress sanitizes HTML by default. Local files require an
+              ironpress sanitizes HTML by default. Local files require an
               explicit base path or resource root. Remote fetching is a feature
               you opt into, with controls for hosts, address classes, redirects,
               and response size. Production services should still apply network,
@@ -289,7 +289,7 @@ h2 {
               </p>
             </div>
 
-            <h2 id="decision">When to use IronPress—and when not to</h2>
+            <h2 id="decision">When to use ironpress and when not to</h2>
             <p>
               The renderer should match the source document. The following
               decision table is a more useful starting point than treating every
@@ -301,7 +301,7 @@ h2 {
               </thead>
               <tbody>
                 <tr>
-                  <td><strong>IronPress</strong></td>
+                  <td><strong>ironpress</strong></td>
                   <td>Known HTML/CSS templates, embedded conversion, serverless, offline, WASM</td>
                   <td>No JavaScript or exact browser-print parity</td>
                 </tr>
@@ -325,7 +325,7 @@ h2 {
             <p>
               Choose a browser when the source depends on JavaScript, browser
               layout quirks, canvas, or an exact screenshot of a web application.
-              Choose IronPress when you control a print-oriented template and
+              Choose ironpress when you control a print-oriented template and
               want conversion to behave like the rest of your Rust code: a
               library call with explicit inputs, outputs, and policies.
             </p>
@@ -333,7 +333,7 @@ h2 {
             <section class="article-cta" aria-labelledby="article-cta-title">
               <h2 id="article-cta-title">Try your own document</h2>
               <p>
-                The playground runs IronPress through WebAssembly, entirely in
+                The playground runs ironpress through WebAssembly, entirely in
                 your browser. Paste HTML or Markdown and inspect the PDF output.
               </p>
               <a class="button button-primary" href="../../playground/">
@@ -347,14 +347,14 @@ h2 {
 
     <footer class="site-footer">
       <div class="shell footer-inner">
-        <a class="brand" href="../../" aria-label="IronPress home">
+        <a class="brand" href="../../" aria-label="ironpress home">
           <img
             src="../../assets/ironpress-logo.png"
-            alt="IronPress"
+            alt="ironpress"
             width="36"
             height="36"
           >
-          <span>IronPress</span>
+          <span>ironpress</span>
         </a>
         <p>Pure-Rust document rendering. Open source under MIT.</p>
         <nav aria-label="Footer navigation">

--- a/site/index.html
+++ b/site/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>IronPress — HTML to PDF in Pure Rust</title>
+    <title>ironpress: HTML to PDF in Pure Rust</title>
     <meta
       name="description"
-      content="Convert HTML, CSS, and Markdown to PDF in process with IronPress, a fast pure-Rust engine with no browser, subprocess, or system dependencies."
+      content="Convert HTML, CSS, and Markdown to PDF in process with ironpress, a fast pure-Rust engine with no browser, subprocess, or system dependencies."
     >
     <link rel="canonical" href="https://gastongouron.github.io/ironpress/">
     <link rel="icon" type="image/png" href="./assets/ironpress-logo.png">
     <meta name="theme-color" content="#f3efe4">
     <meta property="og:type" content="website">
-    <meta property="og:site_name" content="IronPress">
-    <meta property="og:title" content="IronPress — HTML to PDF in Pure Rust">
+    <meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="ironpress: HTML to PDF in Pure Rust">
     <meta
       property="og:description"
       content="A fast, in-process HTML, CSS, and Markdown to PDF engine. No browser, subprocess, or system dependencies."
@@ -23,9 +23,9 @@
       property="og:image"
       content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png"
     >
-    <meta property="og:image:alt" content="IronPress logo">
+    <meta property="og:image:alt" content="ironpress logo">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="IronPress — HTML to PDF in Pure Rust">
+    <meta name="twitter:title" content="ironpress: HTML to PDF in Pure Rust">
     <meta
       name="twitter:description"
       content="A fast, in-process HTML, CSS, and Markdown to PDF engine."
@@ -39,13 +39,13 @@
             "@type": "WebSite",
             "@id": "https://gastongouron.github.io/ironpress/#website",
             "url": "https://gastongouron.github.io/ironpress/",
-            "name": "IronPress",
+            "name": "ironpress",
             "description": "Pure-Rust HTML, CSS, and Markdown to PDF engine"
           },
           {
             "@type": "SoftwareSourceCode",
             "@id": "https://gastongouron.github.io/ironpress/#software",
-            "name": "IronPress",
+            "name": "ironpress",
             "codeRepository": "https://github.com/gastongouron/ironpress",
             "programmingLanguage": "Rust",
             "runtimePlatform": ["Rust", "Python", "Ruby", "WebAssembly"],
@@ -61,14 +61,14 @@
 
     <header class="site-header">
       <div class="shell header-inner">
-        <a class="brand" href="./" aria-label="IronPress home">
+        <a class="brand" href="./" aria-label="ironpress home">
           <img
             src="./assets/ironpress-logo.png"
-            alt="IronPress"
+            alt="ironpress"
             width="44"
             height="44"
           >
-          <span>IronPress</span>
+          <span>ironpress</span>
         </a>
         <nav aria-label="Primary navigation">
           <a href="#features">Features</a>
@@ -89,7 +89,7 @@
             <p class="eyebrow"><span></span> Open source · MIT licensed</p>
             <h1>HTML to PDF.<br><em>In process.</em><br>In pure Rust.</h1>
             <p class="hero-lede">
-              Render HTML, CSS, and Markdown directly to PDF—without a browser,
+              Render HTML, CSS, and Markdown directly to PDF without a browser,
               a subprocess, or system dependencies.
             </p>
             <div class="button-row">
@@ -107,7 +107,7 @@
             </p>
           </div>
 
-          <div class="hero-visual" aria-label="HTML enters IronPress and a PDF comes out">
+          <div class="hero-visual" aria-label="HTML enters ironpress and a PDF comes out">
             <div class="source-window">
               <div class="window-bar">
                 <span></span><span></span><span></span>
@@ -125,7 +125,7 @@
             </div>
             <div class="engine-chip">
               <span class="engine-mark" aria-hidden="true">Fe</span>
-              <span><strong>IronPress</strong><small>single process</small></span>
+              <span><strong>ironpress</strong><small>single process</small></span>
             </div>
             <article class="pdf-sheet">
               <span class="pdf-label">PDF</span>
@@ -160,8 +160,8 @@
               <h2>A PDF engine,<br>not a browser in disguise.</h2>
             </div>
             <p>
-              IronPress owns the full rendering path—from parsing and layout to
-              font shaping and PDF output—so deployment stays predictable.
+              ironpress owns the full rendering path, from parsing and layout to
+              font shaping and PDF output. That keeps deployment predictable.
             </p>
           </div>
 
@@ -269,9 +269,9 @@ pdf = Ironpress.html_to_pdf(
         <div class="shell compare-grid">
           <div>
             <p class="eyebrow"><span></span> Choose the right renderer</p>
-            <h2>When IronPress fits.</h2>
+            <h2>When ironpress fits.</h2>
             <p class="compare-intro">
-              Use IronPress when the document is known HTML and CSS, deployment
+              Use ironpress when the document is known HTML and CSS, deployment
               simplicity matters, and conversion belongs inside your process.
             </p>
             <a class="text-link" href="./guides/html-to-pdf-rust/">
@@ -281,7 +281,7 @@ pdf = Ironpress.html_to_pdf(
           <div class="decision-list">
             <article>
               <span class="decision-yes" aria-hidden="true">✓</span>
-              <div><h3>Choose IronPress for</h3><p>Invoices, reports, certificates, server-side exports, and offline or WASM workflows.</p></div>
+              <div><h3>Choose ironpress for</h3><p>Invoices, reports, certificates, server-side exports, and offline or WASM workflows.</p></div>
             </article>
             <article>
               <span class="decision-no" aria-hidden="true">×</span>
@@ -310,14 +310,14 @@ pdf = Ironpress.html_to_pdf(
 
     <footer class="site-footer">
       <div class="shell footer-inner">
-        <a class="brand" href="./" aria-label="IronPress home">
+        <a class="brand" href="./" aria-label="ironpress home">
           <img
             src="./assets/ironpress-logo.png"
-            alt="IronPress"
+            alt="ironpress"
             width="36"
             height="36"
           >
-          <span>IronPress</span>
+          <span>ironpress</span>
         </a>
         <p>Pure-Rust document rendering. Open source under MIT.</p>
         <nav aria-label="Footer navigation">


### PR DESCRIPTION
## Summary

- keep the required `parity-gate` job present while skipping its heavy renderer steps for website-only changes
- classify `site/**`, `playground/**`, the static-site contract, and the Pages workflow as website-only inputs
- normalize the visible project name to `ironpress` across the README, landing page, guide, and playground
- remove all em dashes from the website and playground copy

## CI behavior

A top-level path filter is deliberately avoided because GitHub documents that a required workflow skipped by path filtering can remain Pending and block merging. The lightweight classifier keeps the required job visible and lets it complete successfully without installing Rust, Poppler, fonts, or running parity.

This PR changes the parity workflow itself, so parity still runs in full here. Future website-only PRs take the fast path.

GitHub reference: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow

## Validation

- `node scripts/check-site.mjs`
- parity workflow YAML parse and embedded Bash syntax check
- classifier checked against a website-only commit: `run=false`
- classifier checked against a renderer commit: `run=true`
- repository scan: zero exact `IronPress` brand occurrences
- public-copy scan: zero em dashes in `README.md`, `site/`, and `playground/`
- real Chrome checks for landing page, guide, and playground: all resources loaded, no console errors
- playground WebAssembly conversion generated a PDF successfully
- Lighthouse mobile: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100