### PR TITLE
fix: restore release artifact publishing

### DIFF
--- a/.github/workflows/font-packs.yml
+++ b/.github/workflows/font-packs.yml
@@ -44,4 +44,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "${RELEASE_TAG}" font-packs/* --clobber
+        run: >-
+          gh release upload "${RELEASE_TAG}" font-packs/* --clobber
+          --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the current main version to RubyGems
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
@@ -52,6 +58,9 @@ jobs:
       - uses: actions/checkout@v7
       - name: Verify release version
         run: scripts/check-release-versions.sh
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
       - name: Cross-compile native gem
         id: cross-gem
         uses: oxidize-rb/actions/cross-gem@v1
@@ -92,7 +101,10 @@ jobs:
     needs: [source, native, test-linux]
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' && inputs.publish)
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - "bindings/ruby/**"
+      - ".github/workflows/ruby.yml"
   workflow_dispatch:
     inputs:
       publish:

--- a/bindings/ruby/Rakefile
+++ b/bindings/ruby/Rakefile
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 
 require "rake/testtask"
-require "rake/extensiontask"
 require "bundler/gem_tasks"
+require "rb_sys/extensiontask"
 
-Rake::ExtensionTask.new("ironpress_ruby") do |extension|
+GEMSPEC = Gem::Specification.load("ironpress.gemspec")
+
+RbSys::ExtensionTask.new("ironpress-ruby", GEMSPEC) do |extension|
   extension.ext_dir = "ext/ironpress"
   extension.lib_dir = "lib/ironpress"
   extension.source_pattern = "*.{rb,rs,toml,lock}"
+  extension.cross_compile = true
+  extension.cross_platform = [
+    "x86_64-linux",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "arm64-darwin",
+    "x64-mingw-ucrt"
+  ]
 end
 
 Rake::TestTask.new do |task|

--- a/bindings/ruby/lib/ironpress.rb
+++ b/bindings/ruby/lib/ironpress.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
+require "rbconfig"
 require_relative "ironpress/version"
-require_relative "ironpress/ironpress_ruby"
+
+ruby_api_version = RUBY_VERSION.split(".").first(2).join(".")
+versioned_extension = File.join(__dir__, "ironpress", ruby_api_version, "ironpress_ruby")
+source_extension = File.join(__dir__, "ironpress", "ironpress_ruby")
+extension_suffix = RbConfig::CONFIG.fetch("DLEXT")
+extension = if File.file?("#{versioned_extension}.#{extension_suffix}")
+              versioned_extension
+            else
+              source_extension
+            end
+require extension
 
 module Ironpress
   # Mutable Ruby facade over immutable native converter values.


### PR DESCRIPTION
## Summary

- Set up a writable Ruby before the cross-gem action.
- Model the Rust extension with `RbSys::ExtensionTask`.
- Exercise native gem packaging on relevant pull requests.
- Target the repository explicitly when attaching font packs.
- Add an explicit publish switch for manual Ruby recovery from main.

## Root causes

The upstream Ruby action runs `gem install rb_sys` on the host runner. Without
`ruby/setup-ruby`, Ubuntu resolves `GEM_HOME` to `/var/lib/gems`, which is not
writable by the runner user.

After fixing setup, the release exposed a second packaging defect. The generic
`Rake::ExtensionTask` only defined local compile tasks. `rb-sys-dock` requires
the crate-aware `RbSys::ExtensionTask` and a gemspec to create `native:*` gems.

The resulting multi-ABI gems store extensions below their Ruby API version,
such as `lib/ironpress/3.4/`. The loader now selects that versioned binary while
retaining the unversioned path used by local and source builds.

The font-pack upload job intentionally has no checkout. Its `gh` command needs
an explicit repository instead of relying on local Git metadata.

## Recovery

After merge, dispatch Ruby Release from `main` with publishing enabled. The
Rakefile is not shipped in the gem, so the runtime package remains equivalent
to the `v1.5.3` tag.

The `v1.5.3` font artifacts have already been verified against `sources.lock`
and attached to the release. This workflow fix prevents the same failure later.

## Validation

- `actionlint` 1.7.12
- Ruby syntax check
- native Rake task contract checked in Ruby/Rust containers
- five-platform build and two-version install dry-run on this PR
