### PR TITLE
fix(ci): identify crates.io availability checks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -127,6 +127,7 @@ jobs:
           ')"
           for attempt in {1..40}; do
             if curl --fail --silent --connect-timeout 5 --max-time 15 \
+              --user-agent "ironpress-release/${version} (https://github.com/gastongouron/ironpress)" \
               "https://crates.io/api/v1/crates/ironpress/${version}" >/dev/null; then
               break
             fi


### PR DESCRIPTION
## Summary

- Send an explicit `User-Agent` when checking crates.io availability.

## Root cause

crates.io returns HTTP 403 for the anonymous `curl` request used by the Ruby
release guard. The 1.5.3 crate is already available, but the guard cannot observe
it and waits until its ten-minute timeout.

## Validation

- Reproduced the 403 without a `User-Agent`.
- Confirmed the same endpoint returns 200 with this header.
- `actionlint` 1.7.12 passes.

## Recovery

After merge, rerun `Ruby Release` from `main` with `publish=true`.
