### PR TITLE
Add first-class Node.js support to the WASM package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -100,8 +103,31 @@ jobs:
             | grep -qx "wasm-pack ${WASM_PACK_VERSION}" \
             || cargo install wasm-pack \
               --version "${WASM_PACK_VERSION}" --locked --force
-      - run: wasm-pack build --target web --features wasm --no-default-features
+      - run: scripts/build-wasm-package.sh
       - run: node scripts/test-wasm-font-packs.mjs
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wasm-package
+          path: pkg
+          retention-days: 1
+
+  node-package:
+    runs-on: ubuntu-latest
+    needs: wasm
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node: ['22', '24']
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: wasm-package
+          path: pkg
+      - run: node scripts/test-node-package.mjs
 
   python-bindings:
     runs-on: ubuntu-latest
@@ -156,30 +182,19 @@ jobs:
 
   publish-npm:
     runs-on: ubuntu-latest
-    needs: [release-metadata, test, msrv, clippy, fmt, wasm, python-bindings, ruby-bindings]
+    needs: [release-metadata, test, msrv, clippy, fmt, node-package, python-bindings, ruby-bindings]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/cache@v6
+      - uses: actions/download-artifact@v8
         with:
-          path: ~/.cargo/bin/wasm-pack
-          key: wasm-pack-${{ runner.os }}-${{ env.WASM_PACK_VERSION }}
-      - name: Install the pinned wasm-pack release
-        run: |
-          wasm-pack --version 2>/dev/null \
-            | grep -qx "wasm-pack ${WASM_PACK_VERSION}" \
-            || cargo install wasm-pack \
-              --version "${WASM_PACK_VERSION}" --locked --force
-      - run: wasm-pack build --target web --features wasm --no-default-features
+          name: wasm-package
+          path: pkg
       - name: Publish npm package
         working-directory: pkg
         env:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -14,7 +14,10 @@ on:
       - 'scripts/parity*.sh'
       - 'scripts/check-site.mjs'
       - 'scripts/build-font-packs.sh'
+      - 'scripts/build-wasm-package.sh'
+      - 'scripts/prepare-wasm-package.mjs'
       - 'scripts/test-wasm-font-packs.mjs'
+      - 'bindings/wasm/**'
       - 'font-packs/**'
       - 'Cargo.toml'
       - '.github/workflows/playground.yml'
@@ -77,7 +80,7 @@ jobs:
           scripts/parity-install-runtime.sh
 
       - name: Build playground
-        run: wasm-pack build --target web --features wasm --no-default-features
+        run: scripts/build-wasm-package.sh
 
       - name: Build optional font packs
         run: scripts/build-font-packs.sh dist/font-packs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- The existing npm package now exposes `ironpress/node`, an ESM entry point that
+  loads its packaged WebAssembly binary without consumer-side file handling.
+
+### CI
+
+- The packed npm artifact is installed, type-checked, and rendered through every
+  supported Node.js LTS line before that exact artifact can be published.
+
 ## [1.5.3] — 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ subprocess, or system dependencies.
 ironpress turns HTML, CSS, or Markdown into PDF bytes inside your application.
 Its rendering engine handles document layout, font shaping, SVG, math, and PDF
 serialization without launching Chrome. Use it from Rust, the CLI, Python, Ruby,
-or WebAssembly.
+Node.js, or browser WebAssembly.
 
 ## Why ironpress?
 
@@ -128,7 +128,7 @@ does not change page geometry. The CLI exposes the same controls through
 | **SVG** | Vector rendering: path, shapes, gradients, transforms, clip paths, `viewBox` | [Layout Engine](../../wiki/Layout-Engine) |
 | **Images** | JPEG + PNG, data URIs, local files, remote URLs (`remote` feature) | [Architecture](../../wiki/Architecture) |
 | **PDF** | PDF 1.4, bookmarks, link annotations, headers/footers, gradients, streaming output | [PDF Rendering](../../wiki/PDF-Rendering) |
-| **WASM** | `npm install ironpress` - runs 100% client-side in the browser | [WASM & Playground](../../wiki/WASM-Playground) |
+| **WASM** | `npm install ironpress` - runs in browsers and Node.js | [WASM & Playground](../../wiki/WASM-Playground) |
 | **Testing** | 3,200+ unit tests, property-based tests, 6 fuzz targets, 1,664-fixture parity corpus | [Testing Strategy](../../wiki/Testing-Strategy) |
 
 ## Custom fonts
@@ -213,6 +213,8 @@ pdf = converter.convert("<h1>Hello</h1>")
 npm install ironpress
 ```
 
+Browser entry point:
+
 ```javascript
 import init, { HtmlConverter } from 'ironpress';
 await init();
@@ -224,6 +226,25 @@ const pdf = converter.htmlToPdf('<h1>Hello</h1>');
 const blob = new Blob([pdf], { type: 'application/pdf' });
 converter.free();
 ```
+
+Node.js entry point:
+
+```javascript
+import init, { HtmlConverter } from 'ironpress/node';
+
+await init();
+
+const converter = new HtmlConverter();
+converter.pageSize('Letter');
+const pdf = converter.htmlToPdf('<h1>Hello from Node.js</h1>');
+converter.free();
+```
+
+`ironpress/node` locates and loads the WebAssembly binary shipped in the npm
+package. Applications do not need to resolve or read it themselves. This entry
+point uses the portable WebAssembly contract: document resources, custom fonts,
+and optional font packs remain caller-provided bytes. Local paths, direct file
+output, streaming, and remote fetching are not available.
 
 See [WASM & Playground](../../wiki/WASM-Playground).
 

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -1,25 +1,25 @@
 # Language bindings
 
-Ironpress exposes one rendering engine through Rust, Python, Ruby, and
-WebAssembly. Each binding keeps the conventions of its language while sharing
-the portable converter contract below.
+Ironpress exposes one rendering engine through Rust, Python, Ruby, browser
+WebAssembly, and Node.js WebAssembly. Each binding keeps the conventions of its
+runtime while sharing the portable converter contract below.
 
 ## Capability matrix
 
-| Capability | Rust | Python | Ruby | WebAssembly |
-|---|:---:|:---:|:---:|:---:|
-| HTML and Markdown to PDF bytes | Yes | Yes | Yes | Yes |
-| Reusable configured converter | Yes | Yes | Yes | Yes |
-| Page size and margins | Yes | Yes | Yes | Yes |
-| PDF and raster quality controls | Yes | Yes | Yes | Yes |
-| Sanitization | Yes | Yes | Yes | Yes |
-| Headers and footers | Yes | Yes | Yes | Yes |
-| Custom TTF fonts | Yes | Yes | Yes | Yes |
-| Optional CJK and emoji packs | Yes | Yes | Yes | Yes |
-| Local resource boundary | Yes | Yes | Yes | No |
-| Direct file output | Yes | Yes | Yes | No |
-| Streaming writer and async API | Yes | No | No | No |
-| Remote HTTP resources | Opt-in | No | No | No |
+| Capability | Rust | Python | Ruby | Browser WASM | Node.js WASM |
+|---|:---:|:---:|:---:|:---:|:---:|
+| HTML and Markdown to PDF bytes | Yes | Yes | Yes | Yes | Yes |
+| Reusable configured converter | Yes | Yes | Yes | Yes | Yes |
+| Page size and margins | Yes | Yes | Yes | Yes | Yes |
+| PDF and raster quality controls | Yes | Yes | Yes | Yes | Yes |
+| Sanitization | Yes | Yes | Yes | Yes | Yes |
+| Headers and footers | Yes | Yes | Yes | Yes | Yes |
+| Custom TTF fonts | Yes | Yes | Yes | Yes | Yes |
+| Optional CJK and emoji packs | Yes | Yes | Yes | Yes | Yes |
+| Local resource boundary | Yes | Yes | Yes | No | No |
+| Direct file output | Yes | Yes | Yes | No | No |
+| Streaming writer and async API | Yes | No | No | No | No |
+| Remote HTTP resources | Opt-in | No | No | No | No |
 
 WebAssembly receives font and document bytes from the host application. It does
 not read local paths. Remote resource loading remains available only through the
@@ -33,11 +33,13 @@ network access.
 | Rust | [`ironpress`](https://crates.io/crates/ironpress) | Source crate, Rust 1.88+ |
 | Python | [`ironpress`](https://pypi.org/project/ironpress/) | CPython 3.8+ ABI3 wheels for Linux, macOS, and Windows |
 | Ruby | [`ironpress`](https://rubygems.org/gems/ironpress) | Ruby 3.0+ source gem and native gems for Linux, macOS, and Windows |
-| WebAssembly | [`ironpress`](https://www.npmjs.com/package/ironpress) | Browser-targeted ES module and WebAssembly binary |
+| Browser WebAssembly | [`ironpress`](https://www.npmjs.com/package/ironpress) | Browser ESM entry and WebAssembly binary |
+| Node.js WebAssembly | [`ironpress/node`](https://www.npmjs.com/package/ironpress) | Node.js 22/24 ESM entry using the same WebAssembly binary |
 
-All four packages use the same Ironpress version. CI builds and installs the
-Python and Ruby artifacts before a release can publish them, and exercises the
-generated npm package through Node.
+All published packages use the same Ironpress version. CI builds and installs
+the Python and Ruby artifacts before a release can publish them. The generated
+npm tarball is installed, type-checked, and rendered through Node.js 22 and 24;
+the browser entry remains a separate required check.
 
 See the runtime guides for language-specific examples:
 

--- a/bindings/wasm/node.d.ts
+++ b/bindings/wasm/node.d.ts
@@ -1,0 +1,5 @@
+import type { InitOutput } from './ironpress.js';
+
+export * from './ironpress.js';
+
+export default function init(): Promise<InitOutput>;

--- a/bindings/wasm/node.js
+++ b/bindings/wasm/node.js
@@ -4,7 +4,14 @@ import initialize from './ironpress.js';
 
 export * from './ironpress.js';
 
-export default async function init() {
+let initialization;
+
+export default function init() {
+  initialization ??= initializeNode();
+  return initialization;
+}
+
+async function initializeNode() {
   try {
     const wasm = await readFile(new URL('./ironpress_bg.wasm', import.meta.url));
     return await initialize({ module_or_path: wasm });

--- a/bindings/wasm/node.js
+++ b/bindings/wasm/node.js
@@ -1,0 +1,18 @@
+import { readFile } from 'node:fs/promises';
+
+import initialize from './ironpress.js';
+
+export * from './ironpress.js';
+
+export default async function init() {
+  try {
+    const wasm = await readFile(new URL('./ironpress_bg.wasm', import.meta.url));
+    return await initialize({ module_or_path: wasm });
+  } catch (cause) {
+    throw new Error(
+      'Failed to initialize Ironpress WebAssembly in Node.js. ' +
+        'The packaged ironpress_bg.wasm asset could not be loaded or instantiated.',
+      { cause },
+    );
+  }
+}

--- a/scripts/build-wasm-package.sh
+++ b/scripts/build-wasm-package.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+wasm-pack build --target web --features wasm --no-default-features
+node scripts/prepare-wasm-package.mjs

--- a/scripts/prepare-wasm-package.mjs
+++ b/scripts/prepare-wasm-package.mjs
@@ -1,0 +1,42 @@
+import { copyFile, readFile, writeFile } from 'node:fs/promises';
+
+const packageDirectory = new URL('../pkg/', import.meta.url);
+const manifestUrl = new URL('package.json', packageDirectory);
+const manifest = JSON.parse(await readFile(manifestUrl, 'utf8'));
+
+if (manifest.name !== 'ironpress' || manifest.type !== 'module') {
+  throw new Error('wasm-pack did not generate the expected Ironpress ESM package');
+}
+
+await Promise.all(
+  ['node.js', 'node.d.ts'].map((file) =>
+    copyFile(
+      new URL(`../bindings/wasm/${file}`, import.meta.url),
+      new URL(file, packageDirectory),
+    ),
+  ),
+);
+
+manifest.files = [...new Set([...manifest.files, 'node.js', 'node.d.ts'])];
+manifest.exports = {
+  '.': {
+    types: './ironpress.d.ts',
+    import: './ironpress.js',
+    default: './ironpress.js',
+  },
+  './node': {
+    types: './node.d.ts',
+    import: './node.js',
+    default: './node.js',
+  },
+  './ironpress.js': {
+    types: './ironpress.d.ts',
+    import: './ironpress.js',
+    default: './ironpress.js',
+  },
+  './ironpress.d.ts': './ironpress.d.ts',
+  './ironpress_bg.wasm': './ironpress_bg.wasm',
+  './package.json': './package.json',
+};
+
+await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/scripts/test-node-package.mjs
+++ b/scripts/test-node-package.mjs
@@ -1,0 +1,94 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import {
+  copyFile,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCallback);
+const packageDirectory = fileURLToPath(new URL('../pkg/', import.meta.url));
+const fixtures = new URL('../tests/node-package/', import.meta.url);
+const fontPack = fileURLToPath(
+  new URL('../tests/fonts/IronpressCjkVertical.ttf', import.meta.url),
+);
+const cargoManifest = await readFile(
+  new URL('../Cargo.toml', import.meta.url),
+  'utf8',
+);
+const crateVersion = cargoManifest.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+if (!crateVersion) {
+  throw new Error('could not read the Ironpress crate version');
+}
+const projectDirectory = await mkdtemp(join(tmpdir(), 'ironpress-node-package-'));
+
+async function run(command, arguments_) {
+  return execFile(command, arguments_, {
+    cwd: projectDirectory,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+try {
+  const { stdout } = await run('npm', [
+    'pack',
+    packageDirectory,
+    '--json',
+    '--pack-destination',
+    projectDirectory,
+  ]);
+  const [{ filename }] = JSON.parse(stdout);
+  const tarball = join(projectDirectory, filename);
+
+  await writeFile(
+    join(projectDirectory, 'package.json'),
+    `${JSON.stringify({ private: true, type: 'module' }, null, 2)}\n`,
+  );
+  await Promise.all(
+    ['runtime.mjs', 'initialization-error.mjs', 'types.ts', 'tsconfig.json'].map(
+      (fixture) =>
+        copyFile(new URL(fixture, fixtures), join(projectDirectory, fixture)),
+    ),
+  );
+
+  await run('npm', [
+    'install',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    tarball,
+    'typescript@7.0.2',
+  ]);
+  await run(process.execPath, ['runtime.mjs', fontPack]);
+  await run(process.execPath, [
+    'node_modules/typescript/bin/tsc',
+    '--project',
+    'tsconfig.json',
+  ]);
+
+  const manifest = JSON.parse(
+    await readFile(
+      join(projectDirectory, 'node_modules/ironpress/package.json'),
+      'utf8',
+    ),
+  );
+  if (manifest.version !== crateVersion) {
+    throw new Error(
+      `installed npm version ${manifest.version} does not match ${crateVersion}`,
+    );
+  }
+
+  await rename(
+    join(projectDirectory, 'node_modules/ironpress/ironpress_bg.wasm'),
+    join(projectDirectory, 'node_modules/ironpress/ironpress_bg.wasm.missing'),
+  );
+  await run(process.execPath, ['initialization-error.mjs']);
+} finally {
+  await rm(projectDirectory, { recursive: true, force: true });
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{FontPack, FontPackKind, HtmlConverter, Margin, PageSize};
 
-/// Reusable browser-side converter.
+/// Reusable WebAssembly converter for browser and Node.js hosts.
 #[wasm_bindgen(js_name = HtmlConverter)]
 pub struct WasmHtmlConverter {
     converter: HtmlConverter,

--- a/tests/node-package/initialization-error.mjs
+++ b/tests/node-package/initialization-error.mjs
@@ -1,0 +1,13 @@
+import init from 'ironpress/node';
+
+try {
+  await init();
+  throw new Error('initialization unexpectedly succeeded without the packaged WASM binary');
+} catch (error) {
+  if (!error.message.includes('Failed to initialize Ironpress WebAssembly in Node.js')) {
+    throw error;
+  }
+  if (!error.cause) {
+    throw new Error('the Node initialization error did not preserve its cause');
+  }
+}

--- a/tests/node-package/runtime.mjs
+++ b/tests/node-package/runtime.mjs
@@ -7,7 +7,10 @@ if (typeof browserInit !== 'function') {
   throw new Error('the browser package entry point no longer exports its initializer');
 }
 
-await init();
+const [firstRuntime, secondRuntime] = await Promise.all([init(), init()]);
+if (firstRuntime !== secondRuntime || (await init()) !== firstRuntime) {
+  throw new Error('Node initialization is not idempotent');
+}
 
 const converter = new HtmlConverter();
 converter.pageSizeCustom(320, 480);

--- a/tests/node-package/runtime.mjs
+++ b/tests/node-package/runtime.mjs
@@ -1,0 +1,27 @@
+import { readFile } from 'node:fs/promises';
+
+import browserInit from 'ironpress';
+import init, { HtmlConverter } from 'ironpress/node';
+
+if (typeof browserInit !== 'function') {
+  throw new Error('the browser package entry point no longer exports its initializer');
+}
+
+await init();
+
+const converter = new HtmlConverter();
+converter.pageSizeCustom(320, 480);
+converter.addFontPack('cjk-jp', await readFile(process.argv[2]));
+
+const pdf = Buffer.from(converter.htmlToPdf("<p lang='ja'>第</p>"));
+converter.free();
+
+if (!pdf.subarray(0, 4).equals(Buffer.from('%PDF'))) {
+  throw new Error('the installed Node package did not produce a PDF');
+}
+if (!pdf.includes(Buffer.from('/MediaBox [0 0 320 480]'))) {
+  throw new Error('the Node converter configuration did not reach the PDF');
+}
+if (!pdf.includes(Buffer.from('DroidSansFallback'))) {
+  throw new Error('the caller-provided font pack did not reach the PDF');
+}

--- a/tests/node-package/tsconfig.json
+++ b/tests/node-package/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022", "ESNext.Disposable"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["types.ts"]
+}

--- a/tests/node-package/types.ts
+++ b/tests/node-package/types.ts
@@ -1,0 +1,13 @@
+import browserInit from 'ironpress';
+import nodeInit, { HtmlConverter, htmlToPdf } from 'ironpress/node';
+
+async function render(): Promise<Uint8Array> {
+  await nodeInit();
+  const converter = new HtmlConverter();
+  converter.pageSize('Letter');
+  converter.free();
+  return htmlToPdf('<h1>Typed Node.js consumer</h1>');
+}
+
+void browserInit;
+void render;


### PR DESCRIPTION
## Summary

- add the `ironpress/node` ESM entry to the existing npm package
- load only the packaged WASM asset through `import.meta.url`
- keep concurrent and repeated initialization idempotent
- preserve the browser root entry and existing public package paths
- install and test the real npm tarball on Node.js 22 and 24
- publish the exact artifact that passed the Node and browser checks
- document the shared portable WASM contract and its limits

No second package, Rust crate, renderer, or WebAssembly binary is introduced.

## Validation

- browser-targeted WASM package test
- installed npm tarball test on Node.js 22 and 24
- PDF generation with page configuration and a caller-provided font pack
- TypeScript 7 resolution for `ironpress` and `ironpress/node`
- missing-WASM diagnostic and preserved error cause
- `cargo fmt --check`
- `cargo +1.88.0 clippy -- -D warnings`

Closes #229
Part of #228
