### PR TITLE
Standardize getting-started guides across runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ subprocess, or system dependencies.
 [![Playground](https://img.shields.io/badge/try_it-playground-blueviolet.svg)](https://gastongouron.github.io/ironpress/playground/)
 [![Parity report](https://img.shields.io/badge/parity-report-ff69b4.svg)](https://gastongouron.github.io/ironpress/parity/reports/)
 
-**[Website](https://gastongouron.github.io/ironpress/)** | **[Playground](https://gastongouron.github.io/ironpress/playground/)** | **[HTML-to-PDF guide](https://gastongouron.github.io/ironpress/guides/html-to-pdf-rust/)** | **[Parity report](https://gastongouron.github.io/ironpress/parity/reports/)** | **[Wiki](../../wiki)**
+**[Website](https://gastongouron.github.io/ironpress/)** | **[Get Started](https://gastongouron.github.io/ironpress/get-started/)** | **[Playground](https://gastongouron.github.io/ironpress/playground/)** | **[HTML-to-PDF guide](https://gastongouron.github.io/ironpress/guides/html-to-pdf-rust/)** | **[Parity report](https://gastongouron.github.io/ironpress/parity/reports/)** | **[Wiki](../../wiki)**
 
 </div>
 
@@ -54,9 +54,13 @@ std::fs::write("output.pdf", pdf).unwrap();
 let pdf = ironpress::markdown_to_pdf("# Hello\n\nWorld").unwrap();
 ```
 
-See the practical guide to [HTML-to-PDF rendering in Rust without Headless
+Choose a complete [getting-started
+guide](https://gastongouron.github.io/ironpress/get-started/) for Rust, the CLI,
+Python, Ruby, browser JavaScript, or Node.js. For a deeper Rust walkthrough, see
+[HTML-to-PDF rendering without Headless
 Chrome](https://gastongouron.github.io/ironpress/guides/html-to-pdf-rust/), or
-paste a document into the [browser playground](https://gastongouron.github.io/ironpress/playground/).
+paste a document into the [browser
+playground](https://gastongouron.github.io/ironpress/playground/).
 
 ## Performance
 

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -41,8 +41,11 @@ the Python and Ruby artifacts before a release can publish them. The generated
 npm tarball is installed, type-checked, and rendered through Node.js 22 and 24;
 the browser entry remains a separate required check.
 
-See the runtime guides for language-specific examples:
+Start with the guide for your runtime:
 
-- [Python](python/README.md)
-- [Ruby](ruby/README.md)
-- [WebAssembly and playground](https://github.com/gastongouron/ironpress/wiki/WASM-Playground)
+- [Rust](https://gastongouron.github.io/ironpress/get-started/rust/)
+- [CLI](https://gastongouron.github.io/ironpress/get-started/cli/)
+- [Python](https://gastongouron.github.io/ironpress/get-started/python/)
+- [Ruby](https://gastongouron.github.io/ironpress/get-started/ruby/)
+- [Browser JavaScript](https://gastongouron.github.io/ironpress/get-started/browser/)
+- [Node.js](https://gastongouron.github.io/ironpress/get-started/node/)

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,62 +1,82 @@
-# Ironpress for Python
+# ironpress for Python
 
-Generate PDF bytes from HTML or Markdown without launching a browser.
+Generate PDF bytes from HTML or Markdown with a native Rust renderer. No
+browser process or system PDF dependency is required.
 
-## Installation
+[Read the complete Python getting-started guide](https://gastongouron.github.io/ironpress/get-started/python/).
+
+## Requirements
+
+- CPython 3.8 or later
+- Linux, macOS, or Windows
+
+Published ABI3 wheels do not require a Rust toolchain.
+
+## Install
 
 ```bash
-pip install ironpress
+python -m pip install ironpress
 ```
 
-Ironpress publishes ABI3 wheels for CPython 3.8 and later on Linux, macOS, and
-Windows.
-
-## Usage
+## Create your first PDF
 
 ```python
+from pathlib import Path
 import ironpress
 
-pdf = ironpress.html_to_pdf("<h1>Hello</h1>")
-with open("output.pdf", "wb") as output:
-    output.write(pdf)
+pdf = ironpress.html_to_pdf("<h1>Hello from Python</h1>")
+Path("output.pdf").write_bytes(pdf)
 ```
 
-Use a converter when several options must compose or multiple documents share
-the same policy:
+The result is a Python `bytes` value. Write it to a file, return it from a web
+response, or store it in your application.
+
+## Render Markdown
+
+```python
+pdf = ironpress.markdown_to_pdf("# Release notes\n\nEverything shipped.")
+```
+
+## Configure and reuse a converter
 
 ```python
 converter = ironpress.HtmlConverter()
 converter.page_size("Letter")
-converter.margin_sides(36, 54, 36, 54)
+converter.margin_sides(36, 48, 36, 48)
 converter.header("Quarterly report")
 converter.footer("Page {page} of {pages}")
-converter.sanitize(True)
 
 pdf = converter.convert("<h1>Results</h1>")
+markdown_pdf = converter.convert_markdown("# Results")
 ```
 
-The converter supports page geometry, PDF and image quality, sanitization,
-headers and footers, custom TTF fonts, and optional CJK or emoji packs. Native
-Python also supports constrained local resources through `base_path()` and
-`resource_root()`, plus direct file output.
+Python configuration methods mutate the converter. Use `convert_to_file` or
+`convert_markdown_to_file` when direct output is more convenient than bytes.
 
-See the [binding capability matrix](../README.md) for the contract shared with
-Rust, Ruby, and WebAssembly.
+## Local resources and fonts
 
-## Font packs
-
-Ironpress never downloads fallback fonts while rendering. Download the artifact
-your application needs, verify it as part of deployment, then install its bytes:
+Local URLs are denied until a canonical boundary is configured:
 
 ```python
 from pathlib import Path
 
 converter = ironpress.HtmlConverter()
-converter.add_font_pack(
-    "cjk-jp",
-    Path("ironpress-font-cjk-jp.ttf").read_bytes(),
-)
-pdf = converter.convert("<p lang='ja'>日本語</p>")
+converter.base_path("templates")
+converter.resource_root(".")
+converter.add_font("Inter", Path("assets/Inter.ttf").read_bytes())
 ```
 
-Valid pack names are `cjk-jp`, `cjk-kr`, `cjk-sc`, `cjk-tc`, and `emoji`.
+Optional fallback packs enter through `add_font_pack`. Valid names are
+`cjk-jp`, `cjk-kr`, `cjk-sc`, `cjk-tc`, and `emoji`. Rendering never downloads
+a font pack.
+
+## Limits and errors
+
+- Invalid configuration and conversion failures raise `ValueError`.
+- HTML sanitization is enabled by default.
+- The binding has no async or streaming conversion API.
+- Remote HTTP document resources are not available.
+- JavaScript and browser DOM execution are not supported.
+
+See the [binding capability matrix](../README.md) for the contract shared with
+Rust, Ruby, browser WebAssembly, and Node.js.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -22,6 +22,7 @@ keywords = ["pdf", "html", "css", "markdown", "converter"]
 
 [project.urls]
 Homepage = "https://github.com/gastongouron/ironpress"
+Documentation = "https://gastongouron.github.io/ironpress/get-started/python/"
 Repository = "https://github.com/gastongouron/ironpress"
 
 [tool.maturin]

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -1,58 +1,86 @@
-# Ironpress for Ruby
+# ironpress for Ruby
 
-Generate PDF bytes from HTML or Markdown without launching a browser.
+Generate PDF output from HTML or Markdown with a native Rust renderer. No
+browser process or system PDF dependency is required.
 
-## Installation
+[Read the complete Ruby getting-started guide](https://gastongouron.github.io/ironpress/get-started/ruby/).
 
-```ruby
-gem "ironpress"
+## Requirements
+
+- Ruby 3.0 or later
+- Linux, macOS, or Windows
+
+Releases include supported native gems plus a source gem.
+
+## Install
+
+```bash
+bundle add ironpress
 ```
 
-Ironpress supports Ruby 3.0 and later. Releases include a source gem and native
-gems for Linux, macOS, and Windows.
+Or install the gem globally:
 
-## Usage
+```bash
+gem install ironpress
+```
+
+## Create your first PDF
 
 ```ruby
 require "ironpress"
 
-pdf = Ironpress.html_to_pdf("<h1>Hello</h1>")
+pdf = Ironpress.html_to_pdf("<h1>Hello from Ruby</h1>")
 File.binwrite("output.pdf", pdf)
 ```
 
-Configuration methods return the converter, so policies can be composed in an
-idiomatic chain:
+The result is a binary Ruby `String`. Write it with `File.binwrite`, return it
+from a web response, or store it in your application.
+
+## Render Markdown
+
+```ruby
+pdf = Ironpress.markdown_to_pdf("# Release notes\n\nEverything shipped.")
+```
+
+## Configure and reuse a converter
 
 ```ruby
 converter = Ironpress::HtmlConverter.new
   .page_size("Letter")
-  .margin_sides(36, 54, 36, 54)
+  .margin_sides(36, 48, 36, 48)
   .header("Quarterly report")
   .footer("Page {page} of {pages}")
-  .sanitize(true)
 
 pdf = converter.convert("<h1>Results</h1>")
+markdown_pdf = converter.convert_markdown("# Results")
 ```
 
-The converter supports page geometry, PDF and image quality, sanitization,
-headers and footers, custom TTF fonts, and optional CJK or emoji packs. Native
-Ruby also supports constrained local resources through `base_path` and
-`resource_root`, plus direct file output.
+Configuration methods return the converter, so policies compose in an idiomatic
+chain. Use `convert_to_file` or `convert_markdown_to_file` for direct output.
 
-See the [binding capability matrix](../README.md) for the contract shared with
-Rust, Python, and WebAssembly.
+## Local resources and fonts
 
-## Font packs
-
-Ironpress never downloads fallback fonts while rendering. Download the artifact
-your application needs, verify it as part of deployment, then install its bytes:
+Local URLs are denied until a canonical boundary is configured:
 
 ```ruby
-converter = Ironpress::HtmlConverter.new.add_font_pack(
-  "cjk-jp",
-  File.binread("ironpress-font-cjk-jp.ttf")
-)
-pdf = converter.convert("<p lang='ja'>日本語</p>")
+converter = Ironpress::HtmlConverter.new
+  .base_path("templates")
+  .resource_root(".")
+  .add_font("Inter", File.binread("assets/Inter.ttf"))
 ```
 
-Valid pack names are `cjk-jp`, `cjk-kr`, `cjk-sc`, `cjk-tc`, and `emoji`.
+Optional fallback packs enter through `add_font_pack`. Valid names are
+`cjk-jp`, `cjk-kr`, `cjk-sc`, `cjk-tc`, and `emoji`. Rendering never downloads
+a font pack.
+
+## Limits and errors
+
+- Invalid named settings raise `ArgumentError`.
+- Conversion failures raise `RuntimeError`.
+- HTML sanitization is enabled by default.
+- The binding has no async or streaming conversion API.
+- Remote HTTP document resources are not available.
+- JavaScript and browser DOM execution are not supported.
+
+See the [binding capability matrix](../README.md) for the contract shared with
+Rust, Python, browser WebAssembly, and Node.js.

--- a/bindings/ruby/ironpress.gemspec
+++ b/bindings/ruby/ironpress.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
     dependencies. Native Rust extension for maximum performance.
   DESCRIPTION
   spec.homepage = "https://github.com/gastongouron/ironpress"
+  spec.metadata["documentation_uri"] = "https://gastongouron.github.io/ironpress/get-started/ruby/"
+  spec.metadata["source_code_uri"] = "https://github.com/gastongouron/ironpress"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.0"
 

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -253,11 +253,29 @@ if (readme !== null) {
   }
   for (const url of [
     "https://gastongouron.github.io/ironpress/",
+    "https://gastongouron.github.io/ironpress/get-started/",
     "https://gastongouron.github.io/ironpress/playground/",
     "https://gastongouron.github.io/ironpress/guides/html-to-pdf-rust/",
   ]) {
     if (!readme.includes(url)) {
       report("README.md", `must link to ${url}`);
+    }
+  }
+}
+
+const bindingsReadme = await load("bindings/README.md");
+if (bindingsReadme !== null) {
+  for (const runtime of [
+    "rust",
+    "cli",
+    "python",
+    "ruby",
+    "browser",
+    "node",
+  ]) {
+    const url = `https://gastongouron.github.io/ironpress/get-started/${runtime}/`;
+    if (!bindingsReadme.includes(url)) {
+      report("bindings/README.md", `must link to ${url}`);
     }
   }
 }

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -19,6 +19,35 @@ const pages = [
       "https://gastongouron.github.io/ironpress/guides/html-to-pdf-rust/",
   },
   {
+    path: "site/get-started/index.html",
+    canonical: "https://gastongouron.github.io/ironpress/get-started/",
+    structuredDataTypes: ["CollectionPage", "ItemList"],
+    requiredSections: ["choose-runtime", "capabilities"],
+  },
+  ...[
+    ["rust", ["cargo add ironpress", "use ironpress::html_to_pdf;"]],
+    ["cli", ["cargo install ironpress", "ironpress invoice.html invoice.pdf"]],
+    ["python", ["python -m pip install ironpress", "ironpress.html_to_pdf"]],
+    ["ruby", ["gem install ironpress", "Ironpress.html_to_pdf"]],
+    ["browser", ["npm install ironpress", 'from "ironpress";', "await init();", "converter.free();"]],
+    ["node", ['from "ironpress/node";', "await init();", "converter.free();"]],
+  ].map(([runtime, requiredText]) => ({
+      path: `site/get-started/${runtime}/index.html`,
+      canonical: `https://gastongouron.github.io/ironpress/get-started/${runtime}/`,
+      structuredDataTypes: ["TechArticle"],
+      requiredText,
+      requiredSections: [
+        "install",
+        "first-pdf",
+        "markdown",
+        "configure",
+        "resources",
+        "limits",
+        "next",
+      ],
+    }),
+  ),
+  {
     path: "playground/index.html",
     canonical: "https://gastongouron.github.io/ironpress/playground/",
   },
@@ -58,6 +87,9 @@ for (const page of pages) {
   const documentMarkup = html
     .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
     .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
+  const proseMarkup = documentMarkup
+    .replace(/<pre\b[^>]*>[\s\S]*?<\/pre>/gi, "")
+    .replace(/<code\b[^>]*>[\s\S]*?<\/code>/gi, "");
 
   if (!/^<!doctype html>/i.test(html.trimStart())) {
     report(page.path, "must start with an HTML5 doctype");
@@ -108,6 +140,12 @@ for (const page of pages) {
   if (matches(documentMarkup, /<main\b/gi).length !== 1) {
     report(page.path, "must contain exactly one main landmark");
   }
+  if (/IronPress|Ironpress/.test(proseMarkup)) {
+    report(page.path, 'must use the lowercase "ironpress" brand in prose');
+  }
+  if (proseMarkup.includes("—")) {
+    report(page.path, "must not use em dashes in prose");
+  }
   for (const image of matches(documentMarkup, /<img\b[^>]*>/gi)) {
     if (!/\balt=["'][^"']+["']/i.test(image[0])) {
       report(page.path, "every image must have non-empty alt text");
@@ -128,6 +166,11 @@ for (const page of pages) {
       report(page.path, `must expose ${type} JSON-LD structured data`);
     }
   }
+  for (const text of page.requiredText ?? []) {
+    if (!html.includes(text)) {
+      report(page.path, `must include the tested consumer contract: ${text}`);
+    }
+  }
 
   const structuredData = matches(
     html,
@@ -146,6 +189,11 @@ for (const page of pages) {
     const id = idAttribute[1];
     if (seenIds.has(id)) report(page.path, `contains duplicate id="${id}"`);
     seenIds.add(id);
+  }
+  for (const id of page.requiredSections ?? []) {
+    if (!seenIds.has(id)) {
+      report(page.path, `must contain the standard #${id} section`);
+    }
   }
 }
 
@@ -194,6 +242,7 @@ if (
 
 await load("site/assets/styles.css");
 await load("site/assets/guide.css");
+await load("site/assets/get-started.css");
 await requireFile("site/assets/ironpress-logo.png");
 
 const readme = await load("README.md");

--- a/site/assets/get-started.css
+++ b/site/assets/get-started.css
@@ -127,7 +127,7 @@
 }
 
 .runtime-package {
-  color: #777160;
+  color: #686253;
   text-transform: none;
 }
 

--- a/site/assets/get-started.css
+++ b/site/assets/get-started.css
@@ -1,0 +1,285 @@
+.get-started-main {
+  padding: clamp(64px, 9vw, 118px) 0 clamp(90px, 11vw, 150px);
+}
+
+.get-started-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.62fr);
+  gap: clamp(48px, 8vw, 110px);
+  align-items: end;
+  margin-bottom: clamp(72px, 10vw, 126px);
+}
+
+.get-started-hero h1 {
+  max-width: 820px;
+  margin-bottom: 28px;
+  font-family: var(--serif);
+  font-size: clamp(56px, 7.4vw, 94px);
+  font-weight: 600;
+  letter-spacing: -0.06em;
+  line-height: 0.94;
+}
+
+.get-started-hero h1 em {
+  color: var(--blue);
+  font-weight: inherit;
+}
+
+.get-started-lede {
+  max-width: 720px;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: clamp(18px, 2vw, 21px);
+}
+
+.start-promise {
+  padding: 28px;
+  border: 1px solid var(--ink);
+  background: var(--white);
+  box-shadow: 7px 7px 0 var(--ink);
+}
+
+.start-promise strong,
+.start-promise span {
+  display: block;
+}
+
+.start-promise strong {
+  margin-bottom: 8px;
+  font-family: var(--serif);
+  font-size: 28px;
+  line-height: 1.1;
+}
+
+.start-promise span {
+  color: var(--ink-soft);
+  font-size: 14px;
+}
+
+.runtime-section + .runtime-section {
+  margin-top: clamp(80px, 11vw, 132px);
+}
+
+.runtime-section-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 0.65fr) minmax(260px, 0.35fr);
+  gap: 48px;
+  align-items: end;
+  margin-bottom: 38px;
+  padding-bottom: 28px;
+  border-bottom: 1px solid var(--line);
+}
+
+.runtime-section-heading h2 {
+  margin-bottom: 0;
+  font-family: var(--serif);
+  font-size: clamp(38px, 5vw, 58px);
+  font-weight: 600;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.runtime-section-heading > p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.runtime-paths {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.runtime-path {
+  position: relative;
+  min-height: 248px;
+  display: flex;
+  flex-direction: column;
+  padding: 30px;
+  border: 1px solid var(--line);
+  background: rgb(255 253 248 / 45%);
+}
+
+.runtime-path:hover {
+  border-color: var(--ink);
+  background: var(--white);
+}
+
+.runtime-path-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.runtime-label,
+.runtime-package,
+.runtime-type {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.runtime-label {
+  color: var(--rust);
+}
+
+.runtime-package {
+  color: #777160;
+  text-transform: none;
+}
+
+.runtime-path h3 {
+  margin: 38px 0 10px;
+  font-family: var(--serif);
+  font-size: 31px;
+  letter-spacing: -0.035em;
+}
+
+.runtime-path > p {
+  max-width: 520px;
+  margin-bottom: 30px;
+  color: var(--ink-soft);
+  font-size: 14px;
+}
+
+.runtime-path > a {
+  margin-top: auto;
+  color: var(--blue-dark);
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.runtime-path > a::after {
+  content: " →";
+}
+
+.capability-table td:first-child {
+  color: var(--ink);
+  font-weight: 750;
+}
+
+.capability-yes {
+  color: #286b22;
+  font-weight: 800;
+}
+
+.capability-no {
+  color: #984526;
+}
+
+.guide-hero .runtime-type {
+  display: inline-flex;
+  margin-top: 24px;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  background: var(--white);
+  color: var(--ink-soft);
+}
+
+.install-choice {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin: 28px 0;
+}
+
+.install-choice article {
+  padding: 22px;
+  border: 1px solid var(--line);
+  background: var(--white);
+}
+
+.install-choice h3 {
+  margin: 0 0 8px;
+  font-family: var(--sans);
+  font-size: 14px;
+  letter-spacing: 0;
+}
+
+.install-choice p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13px;
+}
+
+.guide-checklist {
+  margin: 30px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.guide-checklist li {
+  position: relative;
+  padding: 13px 0 13px 34px;
+  border-bottom: 1px solid var(--line);
+}
+
+.guide-checklist li:first-child {
+  border-top: 1px solid var(--line);
+}
+
+.guide-checklist li::before {
+  content: "✓";
+  position: absolute;
+  left: 4px;
+  color: #286b22;
+  font-family: var(--sans);
+  font-weight: 900;
+}
+
+.guide-links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.guide-links a {
+  padding: 17px 18px;
+  border: 1px solid var(--line);
+  background: var(--white);
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.guide-links a:hover {
+  border-color: var(--blue);
+}
+
+@media (max-width: 920px) {
+  .get-started-hero,
+  .runtime-section-heading {
+    grid-template-columns: 1fr;
+  }
+
+  .get-started-hero {
+    align-items: start;
+  }
+
+  .start-promise {
+    max-width: 520px;
+  }
+}
+
+@media (max-width: 680px) {
+  .get-started-main {
+    padding-top: 56px;
+  }
+
+  .runtime-paths,
+  .install-choice,
+  .guide-links {
+    grid-template-columns: 1fr;
+  }
+
+  .runtime-path {
+    min-height: 226px;
+    padding: 25px;
+  }
+}

--- a/site/get-started/browser/index.html
+++ b/site/get-started/browser/index.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Browser JavaScript Getting Started: HTML to PDF | ironpress</title>
+    <meta
+      name="description"
+      content="Install the ironpress npm package, initialize WebAssembly in a browser, generate a PDF Uint8Array, and configure pages, fonts, and lifecycle."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/browser/">
+    <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png"><meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="article"><meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with ironpress in the Browser">
+    <meta property="og:description" content="Generate PDF bytes locally in a browser through the portable WebAssembly package.">
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/browser/">
+    <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png"><meta property="og:image:alt" content="ironpress logo"><meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../../assets/styles.css"><link rel="stylesheet" href="../../assets/guide.css"><link rel="stylesheet" href="../../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Get Started with ironpress in the Browser",
+        "description": "Initialize ironpress WebAssembly and generate PDF bytes in browser JavaScript or TypeScript.",
+        "author": { "@type": "Person", "name": "Gaston Gouron", "url": "https://github.com/gastongouron" },
+        "publisher": { "@type": "Organization", "name": "ironpress", "url": "https://gastongouron.github.io/ironpress/" },
+        "mainEntityOfPage": "https://gastongouron.github.io/ironpress/get-started/browser/",
+        "inLanguage": "en"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#article">Skip to article</a>
+    <header class="site-header"><div class="shell header-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="44" height="44"><span>ironpress</span></a><nav aria-label="Primary navigation"><a href="../" aria-current="page">Get started</a><a href="../../guides/html-to-pdf-rust/">Guide</a><a href="../../playground/">Playground</a><a class="nav-github" href="https://github.com/gastongouron/ironpress">GitHub <span aria-hidden="true">↗</span></a></nav></div></header>
+
+    <main class="guide-main" id="article">
+      <div class="shell">
+        <header class="guide-hero">
+          <p class="eyebrow"><span></span> Browser getting started</p>
+          <h1>Generate a PDF<br><em>without leaving the browser</em></h1>
+          <p>Load the WebAssembly renderer once, convert locally, and keep document content inside the user's browser.</p>
+          <span class="runtime-type">ES modules · JavaScript and TypeScript</span>
+        </header>
+
+        <div class="guide-layout">
+          <aside class="guide-toc" aria-label="Article contents"><p>In this guide</p><ol><li><a href="#install">Install</a></li><li><a href="#first-pdf">First PDF</a></li><li><a href="#markdown">Markdown</a></li><li><a href="#configure">Configure</a></li><li><a href="#resources">Resources</a></li><li><a href="#limits">Limits and lifecycle</a></li><li><a href="#next">Next steps</a></li></ol></aside>
+
+          <article class="prose">
+            <h2 id="install">Install the npm package</h2>
+            <pre><code>npm install ironpress</code></pre>
+            <p>The package root is the browser entry point. Your bundler must support ES modules and WebAssembly assets.</p>
+
+            <h2 id="first-pdf">Create and download an HTML PDF</h2>
+            <p>Initialize the WASM module before calling exported conversion functions:</p>
+            <pre><code>import init, { htmlToPdf } from "ironpress";
+
+await init();
+
+const pdf = htmlToPdf("&lt;h1&gt;Hello from the browser&lt;/h1&gt;");
+const url = URL.createObjectURL(
+  new Blob([pdf], { type: "application/pdf" }),
+);
+
+const link = document.createElement("a");
+link.href = url;
+link.download = "output.pdf";
+link.click();
+URL.revokeObjectURL(url);</code></pre>
+            <div class="guide-callout"><strong>Returned type</strong><p>Browser conversion returns <code>Uint8Array</code>. Wrap it in a Blob for preview, download, upload, or IndexedDB storage.</p></div>
+
+            <h2 id="markdown">Render Markdown</h2>
+            <pre><code>import init, { markdownToPdf } from "ironpress";
+
+await init();
+const pdf = markdownToPdf("# Release notes\n\nEverything shipped.");</code></pre>
+
+            <h2 id="configure">Use a configured converter</h2>
+            <p>A converter keeps page and rendering settings across calls. WASM-owned objects must be freed when they are no longer needed.</p>
+            <pre><code>import init, { HtmlConverter } from "ironpress";
+
+await init();
+const converter = new HtmlConverter();
+
+try {
+  converter.pageSize("Letter");
+  converter.marginSides(36, 48, 36, 48);
+  converter.header("Quarterly report");
+  converter.footer("Page {page} of {pages}");
+
+  const pdf = converter.htmlToPdf("&lt;h1&gt;Results&lt;/h1&gt;");
+} finally {
+  converter.free();
+}</code></pre>
+
+            <h2 id="resources">Provide fonts and document assets</h2>
+            <p>The WASM renderer does not read paths. Fetch or import resource bytes in your host application, then pass them to the converter.</p>
+            <pre><code>const response = await fetch("/fonts/Inter.ttf");
+const font = new Uint8Array(await response.arrayBuffer());
+
+const converter = new HtmlConverter();
+try {
+  converter.addFont("Inter", font);
+  const pdf = converter.htmlToPdf(
+    '&lt;p style="font-family: Inter"&gt;Custom type&lt;/p&gt;',
+  );
+} finally {
+  converter.free();
+}</code></pre>
+            <p>Provide images as data URLs in the HTML. Optional CJK and emoji font packs enter through <code>addFontPack</code> as downloaded bytes.</p>
+
+            <h2 id="limits">Manage initialization, errors, and memory</h2>
+            <ul class="guide-checklist">
+              <li>Await the default initializer before the first conversion.</li>
+              <li>Call <code>free()</code> for every reusable converter.</li>
+              <li>Local paths, direct file output, streaming, and remote fetching are unavailable.</li>
+              <li>Conversion is synchronous after asynchronous WASM initialization.</li>
+            </ul>
+            <p>Initialization and conversion failures surface as JavaScript errors. Catch them at the UI boundary and keep raw untrusted document details out of user-facing messages.</p>
+
+            <h2 id="next">Go further</h2>
+            <div class="guide-links">
+              <a href="../../playground/">Try the browser playground</a><a href="https://www.npmjs.com/package/ironpress">Package on npm</a><a href="../node/">Use the Node.js entry</a><a href="https://github.com/gastongouron/ironpress/blob/main/bindings/README.md">Capability matrix</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site-footer"><div class="shell footer-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="36" height="36"><span>ironpress</span></a><p>Pure-Rust document rendering. Open source under MIT.</p><nav aria-label="Footer navigation"><a href="../">All runtimes</a><a href="https://www.npmjs.com/package/ironpress">npm</a><a href="../../parity/reports/">Parity</a></nav></div></footer>
+  </body>
+</html>

--- a/site/get-started/cli/index.html
+++ b/site/get-started/cli/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CLI Getting Started: Convert HTML or Markdown to PDF | ironpress</title>
+    <meta
+      name="description"
+      content="Install the ironpress command-line tool, convert HTML and Markdown files to PDF, and configure pages, margins, headers, and local resources."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/cli/">
+    <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png">
+    <meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with the ironpress CLI">
+    <meta property="og:description" content="Turn an HTML or Markdown file into PDF from your terminal without a browser.">
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/cli/">
+    <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png">
+    <meta property="og:image:alt" content="ironpress logo">
+    <meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../../assets/styles.css">
+    <link rel="stylesheet" href="../../assets/guide.css">
+    <link rel="stylesheet" href="../../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Get Started with the ironpress CLI",
+        "description": "Install ironpress and convert HTML or Markdown files to PDF from the command line.",
+        "author": { "@type": "Person", "name": "Gaston Gouron", "url": "https://github.com/gastongouron" },
+        "publisher": { "@type": "Organization", "name": "ironpress", "url": "https://gastongouron.github.io/ironpress/" },
+        "mainEntityOfPage": "https://gastongouron.github.io/ironpress/get-started/cli/",
+        "inLanguage": "en"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#article">Skip to article</a>
+    <header class="site-header">
+      <div class="shell header-inner">
+        <a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="44" height="44"><span>ironpress</span></a>
+        <nav aria-label="Primary navigation">
+          <a href="../" aria-current="page">Get started</a><a href="../../guides/html-to-pdf-rust/">Guide</a><a href="../../playground/">Playground</a>
+          <a class="nav-github" href="https://github.com/gastongouron/ironpress">GitHub <span aria-hidden="true">↗</span></a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="guide-main" id="article">
+      <div class="shell">
+        <header class="guide-hero">
+          <p class="eyebrow"><span></span> Command-line getting started</p>
+          <h1>Turn a document into PDF<br><em>from one command</em></h1>
+          <p>Use the Rust renderer from a shell, CI job, build script, or local automation without writing integration code.</p>
+          <span class="runtime-type">Native binary · HTML and Markdown</span>
+        </header>
+
+        <div class="guide-layout">
+          <aside class="guide-toc" aria-label="Article contents">
+            <p>In this guide</p>
+            <ol>
+              <li><a href="#install">Install</a></li><li><a href="#first-pdf">First PDF</a></li><li><a href="#markdown">Markdown</a></li>
+              <li><a href="#configure">Configure</a></li><li><a href="#resources">Resources</a></li><li><a href="#limits">Limits and errors</a></li><li><a href="#next">Next steps</a></li>
+            </ol>
+          </aside>
+
+          <article class="prose">
+            <h2 id="install">Install the binary</h2>
+            <p>Install the current release from crates.io with a Rust toolchain:</p>
+            <pre><code>cargo install ironpress</code></pre>
+            <p>Confirm the executable is available:</p>
+            <pre><code>ironpress --version</code></pre>
+
+            <h2 id="first-pdf">Convert an HTML file</h2>
+            <p>Create <code>invoice.html</code>, then provide the input and output paths:</p>
+            <pre><code>ironpress invoice.html invoice.pdf</code></pre>
+            <p>The command writes <code>invoice.pdf</code> and reports the completed path on standard error.</p>
+            <div class="guide-callout">
+              <strong>Pipe HTML from another command</strong>
+              <p><code>printf '&lt;h1&gt;Hello&lt;/h1&gt;' | ironpress --stdin output.pdf</code></p>
+            </div>
+
+            <h2 id="markdown">Convert Markdown</h2>
+            <p>Files ending in <code>.md</code> or <code>.markdown</code> are detected automatically:</p>
+            <pre><code>ironpress release-notes.md release-notes.pdf</code></pre>
+            <p>Standard input is treated as HTML. Use a temporary <code>.md</code> file when your pipeline starts with Markdown.</p>
+
+            <h2 id="configure">Set page and output options</h2>
+            <p>Compose flags to apply one document policy:</p>
+            <pre><code>ironpress report.html report.pdf \
+  --page-size letter \
+  --landscape \
+  --margin 36 \
+  --header "Quarterly report" \
+  --footer "Page {page} of {pages}"</code></pre>
+            <p>
+              Named sizes are <code>a4</code>, <code>letter</code>, and
+              <code>legal</code>. Margins and page geometry use PDF points.
+              Run <code>ironpress --help</code> for image quality, compression,
+              sanitization, and raster controls.
+            </p>
+
+            <h2 id="resources">Resolve local images, CSS, and fonts</h2>
+            <p>Grant a base directory before a document can resolve relative URLs:</p>
+            <pre><code>ironpress templates/invoice.html invoice.pdf \
+  --base-path templates</code></pre>
+            <p>
+              Relative <code>&lt;img&gt;</code>, CSS <code>@import</code>, and
+              <code>@font-face</code> URLs resolve below that canonical directory.
+              Traversal and symlink escapes are rejected.
+            </p>
+
+            <h2 id="limits">Understand CLI behavior</h2>
+            <ul class="guide-checklist">
+              <li>The CLI writes one complete output file per invocation.</li>
+              <li>HTML sanitization is enabled unless explicitly disabled.</li>
+              <li>The published binary does not fetch remote document resources.</li>
+              <li>JavaScript and browser DOM execution are outside the renderer's scope.</li>
+            </ul>
+            <p>Invalid flags, unreadable input, conversion failures, and output errors print a diagnostic and return a nonzero exit status.</p>
+
+            <h2 id="next">Go further</h2>
+            <p>Move to a language binding when your application needs PDF bytes in memory or a reusable converter instance.</p>
+            <div class="guide-links">
+              <a href="../rust/">Use the Rust crate</a><a href="../python/">Use Python</a><a href="../ruby/">Use Ruby</a><a href="https://github.com/gastongouron/ironpress#cli">CLI reference</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="shell footer-inner">
+        <a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="36" height="36"><span>ironpress</span></a>
+        <p>Pure-Rust document rendering. Open source under MIT.</p>
+        <nav aria-label="Footer navigation"><a href="../">All runtimes</a><a href="https://docs.rs/ironpress">Docs</a><a href="../../parity/reports/">Parity</a></nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/get-started/index.html
+++ b/site/get-started/index.html
@@ -102,25 +102,25 @@
               <div class="runtime-path-top"><span class="runtime-label">Library</span><span class="runtime-package">crates.io</span></div>
               <h3>Rust</h3>
               <p>The full API: byte output, writers, async file conversion, local resources, and opt-in remote fetching.</p>
-              <a href="./rust/" aria-label="Get started with Rust">Start with Rust</a>
+              <a href="./rust/">Start with Rust</a>
             </article>
             <article class="runtime-path">
               <div class="runtime-path-top"><span class="runtime-label">Binary</span><span class="runtime-package">cargo install</span></div>
               <h3>Command line</h3>
               <p>Convert HTML or Markdown files from a shell, a script, or standard input without writing application code.</p>
-              <a href="./cli/" aria-label="Get started with the command line">Start with the CLI</a>
+              <a href="./cli/">Start with the CLI</a>
             </article>
             <article class="runtime-path">
               <div class="runtime-path-top"><span class="runtime-label">Binding</span><span class="runtime-package">PyPI</span></div>
               <h3>Python</h3>
               <p>Install an ABI3 wheel and receive Python bytes from a native Rust renderer on Linux, macOS, or Windows.</p>
-              <a href="./python/" aria-label="Get started with Python">Start with Python</a>
+              <a href="./python/">Start with Python</a>
             </article>
             <article class="runtime-path">
               <div class="runtime-path-top"><span class="runtime-label">Binding</span><span class="runtime-package">RubyGems</span></div>
               <h3>Ruby</h3>
               <p>Use an idiomatic chainable converter backed by the same native Rust engine and package contract.</p>
-              <a href="./ruby/" aria-label="Get started with Ruby">Start with Ruby</a>
+              <a href="./ruby/">Start with Ruby</a>
             </article>
           </div>
         </section>
@@ -141,13 +141,13 @@
               <div class="runtime-path-top"><span class="runtime-label">Client side</span><span class="runtime-package">ironpress</span></div>
               <h3>Browser JavaScript</h3>
               <p>Initialize the WASM module, render locally, and turn the returned Uint8Array into a Blob for download or preview.</p>
-              <a href="./browser/" aria-label="Get started in the browser">Start in the browser</a>
+              <a href="./browser/">Start in the browser</a>
             </article>
             <article class="runtime-path">
               <div class="runtime-path-top"><span class="runtime-label">Server side</span><span class="runtime-package">ironpress/node</span></div>
               <h3>Node.js</h3>
               <p>Use the package-owned WASM asset from Node.js 22 or 24 with ESM and write the returned Uint8Array where you need it.</p>
-              <a href="./node/" aria-label="Get started with Node.js">Start with Node.js</a>
+              <a href="./node/">Start with Node.js</a>
             </article>
           </div>
         </section>

--- a/site/get-started/index.html
+++ b/site/get-started/index.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Get Started with ironpress in Your Runtime</title>
+    <meta
+      name="description"
+      content="Choose a complete ironpress getting-started guide for Rust, the CLI, Python, Ruby, browser JavaScript, TypeScript, or Node.js."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/">
+    <link rel="icon" type="image/png" href="../assets/ironpress-logo.png">
+    <meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with ironpress">
+    <meta
+      property="og:description"
+      content="Install ironpress and generate your first PDF in the runtime you already use."
+    >
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/">
+    <meta
+      property="og:image"
+      content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png"
+    >
+    <meta property="og:image:alt" content="ironpress logo">
+    <meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../assets/styles.css">
+    <link rel="stylesheet" href="../assets/guide.css">
+    <link rel="stylesheet" href="../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "Get Started with ironpress",
+        "url": "https://gastongouron.github.io/ironpress/get-started/",
+        "mainEntity": {
+          "@type": "ItemList",
+          "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Rust", "url": "https://gastongouron.github.io/ironpress/get-started/rust/" },
+            { "@type": "ListItem", "position": 2, "name": "CLI", "url": "https://gastongouron.github.io/ironpress/get-started/cli/" },
+            { "@type": "ListItem", "position": 3, "name": "Python", "url": "https://gastongouron.github.io/ironpress/get-started/python/" },
+            { "@type": "ListItem", "position": 4, "name": "Ruby", "url": "https://gastongouron.github.io/ironpress/get-started/ruby/" },
+            { "@type": "ListItem", "position": 5, "name": "Browser JavaScript", "url": "https://gastongouron.github.io/ironpress/get-started/browser/" },
+            { "@type": "ListItem", "position": 6, "name": "Node.js", "url": "https://gastongouron.github.io/ironpress/get-started/node/" }
+          ]
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+
+    <header class="site-header">
+      <div class="shell header-inner">
+        <a class="brand" href="../" aria-label="ironpress home">
+          <img src="../assets/ironpress-logo.png" alt="ironpress" width="44" height="44">
+          <span>ironpress</span>
+        </a>
+        <nav aria-label="Primary navigation">
+          <a href="./" aria-current="page">Get started</a>
+          <a href="../guides/html-to-pdf-rust/">Guide</a>
+          <a href="../playground/">Playground</a>
+          <a class="nav-github" href="https://github.com/gastongouron/ironpress">
+            GitHub <span aria-hidden="true">↗</span>
+          </a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="get-started-main" id="main-content">
+      <div class="shell">
+        <header class="get-started-hero">
+          <div>
+            <p class="eyebrow"><span></span> One engine, six paths</p>
+            <h1>Your first PDF.<br><em>Your runtime.</em></h1>
+            <p class="get-started-lede">
+              Pick the environment you already ship. Every guide starts from a
+              clean project, produces a real PDF, then explains configuration,
+              resources, lifecycle, and runtime limits.
+            </p>
+          </div>
+          <aside class="start-promise" aria-label="Getting-started goal">
+            <strong>HTML to PDF in under five minutes.</strong>
+            <span>No browser process, subprocess manager, or system package checklist.</span>
+          </aside>
+        </header>
+
+        <section class="runtime-section" id="choose-runtime" aria-labelledby="native-title">
+          <div class="runtime-section-heading">
+            <div>
+              <p class="eyebrow"><span></span> Native entry points</p>
+              <h2 id="native-title">Run inside your application.</h2>
+            </div>
+            <p>
+              Use native bindings when your service needs local resources,
+              direct file output, or the smallest runtime overhead.
+            </p>
+          </div>
+          <div class="runtime-paths">
+            <article class="runtime-path">
+              <div class="runtime-path-top"><span class="runtime-label">Library</span><span class="runtime-package">crates.io</span></div>
+              <h3>Rust</h3>
+              <p>The full API: byte output, writers, async file conversion, local resources, and opt-in remote fetching.</p>
+              <a href="./rust/" aria-label="Get started with Rust">Start with Rust</a>
+            </article>
+            <article class="runtime-path">
+              <div class="runtime-path-top"><span class="runtime-label">Binary</span><span class="runtime-package">cargo install</span></div>
+              <h3>Command line</h3>
+              <p>Convert HTML or Markdown files from a shell, a script, or standard input without writing application code.</p>
+              <a href="./cli/" aria-label="Get started with the command line">Start with the CLI</a>
+            </article>
+            <article class="runtime-path">
+              <div class="runtime-path-top"><span class="runtime-label">Binding</span><span class="runtime-package">PyPI</span></div>
+              <h3>Python</h3>
+              <p>Install an ABI3 wheel and receive Python bytes from a native Rust renderer on Linux, macOS, or Windows.</p>
+              <a href="./python/" aria-label="Get started with Python">Start with Python</a>
+            </article>
+            <article class="runtime-path">
+              <div class="runtime-path-top"><span class="runtime-label">Binding</span><span class="runtime-package">RubyGems</span></div>
+              <h3>Ruby</h3>
+              <p>Use an idiomatic chainable converter backed by the same native Rust engine and package contract.</p>
+              <a href="./ruby/" aria-label="Get started with Ruby">Start with Ruby</a>
+            </article>
+          </div>
+        </section>
+
+        <section class="runtime-section" aria-labelledby="wasm-title">
+          <div class="runtime-section-heading">
+            <div>
+              <p class="eyebrow"><span></span> Portable WebAssembly</p>
+              <h2 id="wasm-title">One npm package, two hosts.</h2>
+            </div>
+            <p>
+              Browser and Node.js use the same WebAssembly renderer. Supply
+              fonts and document resources as bytes from the host application.
+            </p>
+          </div>
+          <div class="runtime-paths">
+            <article class="runtime-path">
+              <div class="runtime-path-top"><span class="runtime-label">Client side</span><span class="runtime-package">ironpress</span></div>
+              <h3>Browser JavaScript</h3>
+              <p>Initialize the WASM module, render locally, and turn the returned Uint8Array into a Blob for download or preview.</p>
+              <a href="./browser/" aria-label="Get started in the browser">Start in the browser</a>
+            </article>
+            <article class="runtime-path">
+              <div class="runtime-path-top"><span class="runtime-label">Server side</span><span class="runtime-package">ironpress/node</span></div>
+              <h3>Node.js</h3>
+              <p>Use the package-owned WASM asset from Node.js 22 or 24 with ESM and write the returned Uint8Array where you need it.</p>
+              <a href="./node/" aria-label="Get started with Node.js">Start with Node.js</a>
+            </article>
+          </div>
+        </section>
+
+        <section class="runtime-section" id="capabilities" aria-labelledby="capabilities-title">
+          <div class="runtime-section-heading">
+            <div>
+              <p class="eyebrow"><span></span> Choose by capability</p>
+              <h2 id="capabilities-title">The important differences.</h2>
+            </div>
+            <p>All paths render HTML and Markdown with reusable converter settings. Host integration is what differs.</p>
+          </div>
+          <div class="prose">
+            <table class="capability-table">
+              <thead>
+                <tr><th>Capability</th><th>Rust</th><th>CLI</th><th>Python</th><th>Ruby</th><th>WASM</th></tr>
+              </thead>
+              <tbody>
+                <tr><td>PDF bytes</td><td class="capability-yes">Yes</td><td class="capability-no">File</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td></tr>
+                <tr><td>Local resources</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td></tr>
+                <tr><td>Direct file output</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td></tr>
+                <tr><td>Streaming or async</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
+                <tr><td>Remote HTTP</td><td>Opt-in</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="shell footer-inner">
+        <a class="brand" href="../" aria-label="ironpress home">
+          <img src="../assets/ironpress-logo.png" alt="ironpress" width="36" height="36">
+          <span>ironpress</span>
+        </a>
+        <p>Pure-Rust document rendering. Open source under MIT.</p>
+        <nav aria-label="Footer navigation">
+          <a href="https://github.com/gastongouron/ironpress">GitHub</a>
+          <a href="https://docs.rs/ironpress">Docs</a>
+          <a href="../parity/reports/">Parity</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/get-started/node/index.html
+++ b/site/get-started/node/index.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Node.js Getting Started: HTML and Markdown to PDF | ironpress</title>
+    <meta
+      name="description"
+      content="Install ironpress for Node.js, initialize its packaged WebAssembly module, generate PDF bytes, and configure pages, fonts, errors, and lifecycle."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/node/">
+    <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png"><meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="article"><meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with ironpress in Node.js">
+    <meta property="og:description" content="Use the first-class Node.js entry point to render PDFs with the portable WebAssembly engine.">
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/node/">
+    <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png"><meta property="og:image:alt" content="ironpress logo"><meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../../assets/styles.css"><link rel="stylesheet" href="../../assets/guide.css"><link rel="stylesheet" href="../../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Get Started with ironpress in Node.js",
+        "description": "Initialize the ironpress Node.js WebAssembly entry and generate PDF bytes from HTML or Markdown.",
+        "author": { "@type": "Person", "name": "Gaston Gouron", "url": "https://github.com/gastongouron" },
+        "publisher": { "@type": "Organization", "name": "ironpress", "url": "https://gastongouron.github.io/ironpress/" },
+        "mainEntityOfPage": "https://gastongouron.github.io/ironpress/get-started/node/",
+        "inLanguage": "en"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#article">Skip to article</a>
+    <header class="site-header"><div class="shell header-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="44" height="44"><span>ironpress</span></a><nav aria-label="Primary navigation"><a href="../" aria-current="page">Get started</a><a href="../../guides/html-to-pdf-rust/">Guide</a><a href="../../playground/">Playground</a><a class="nav-github" href="https://github.com/gastongouron/ironpress">GitHub <span aria-hidden="true">↗</span></a></nav></div></header>
+
+    <main class="guide-main" id="article">
+      <div class="shell">
+        <header class="guide-hero">
+          <p class="eyebrow"><span></span> Node.js getting started</p>
+          <h1>Generate PDFs<br><em>from Node.js</em></h1>
+          <p>Use the package-owned WebAssembly asset through one explicit ESM entry point, with no browser process or native addon.</p>
+          <span class="runtime-type">Node.js 22 and 24 · ESM · TypeScript</span>
+        </header>
+
+        <div class="guide-layout">
+          <aside class="guide-toc" aria-label="Article contents"><p>In this guide</p><ol><li><a href="#install">Install</a></li><li><a href="#first-pdf">First PDF</a></li><li><a href="#markdown">Markdown</a></li><li><a href="#configure">Configure</a></li><li><a href="#resources">Resources</a></li><li><a href="#limits">Limits and lifecycle</a></li><li><a href="#next">Next steps</a></li></ol></aside>
+
+          <article class="prose">
+            <h2 id="install">Install the npm package</h2>
+            <p>Create an ESM project and install the shared browser and Node.js package:</p>
+            <pre><code>npm init -y
+npm pkg set type=module
+npm install ironpress</code></pre>
+            <p>Import server-side code from <code>ironpress/node</code>. The root <code>ironpress</code> entry remains browser-oriented.</p>
+
+            <h2 id="first-pdf">Create an HTML PDF</h2>
+            <p>The Node.js initializer locates the WASM asset shipped inside the package. Your application does not resolve or read that asset.</p>
+            <pre><code>import { writeFile } from "node:fs/promises";
+import init, { htmlToPdf } from "ironpress/node";
+
+await init();
+
+const pdf = htmlToPdf("&lt;h1&gt;Hello from Node.js&lt;/h1&gt;");
+await writeFile("output.pdf", pdf);</code></pre>
+            <div class="guide-callout"><strong>Returned type</strong><p>Conversion returns <code>Uint8Array</code>. Node.js can write it directly or convert it with <code>Buffer.from(pdf)</code>.</p></div>
+
+            <h2 id="markdown">Render Markdown</h2>
+            <pre><code>import { writeFile } from "node:fs/promises";
+import init, { markdownToPdf } from "ironpress/node";
+
+await init();
+const pdf = markdownToPdf("# Release notes\n\nEverything shipped.");
+await writeFile("release-notes.pdf", pdf);</code></pre>
+
+            <h2 id="configure">Use a configured converter</h2>
+            <p>Initialize once, then create reusable converter policies. Always free WASM-owned converter objects.</p>
+            <pre><code>import init, { HtmlConverter } from "ironpress/node";
+
+await init();
+const converter = new HtmlConverter();
+
+try {
+  converter.pageSize("Letter");
+  converter.marginSides(36, 48, 36, 48);
+  converter.header("Quarterly report");
+  converter.footer("Page {page} of {pages}");
+
+  const pdf = converter.htmlToPdf("&lt;h1&gt;Results&lt;/h1&gt;");
+} finally {
+  converter.free();
+}</code></pre>
+            <p>The initializer is idempotent. Concurrent or repeated calls resolve to the same initialized runtime.</p>
+
+            <h2 id="resources">Provide fonts and assets as bytes</h2>
+            <p>Node.js may read application files, but the portable converter accepts document resources as caller-provided data rather than paths.</p>
+            <pre><code>import { readFile } from "node:fs/promises";
+
+const font = await readFile("assets/Inter.ttf");
+const converter = new HtmlConverter();
+
+try {
+  converter.addFont("Inter", font);
+  const pdf = converter.htmlToPdf(
+    '&lt;p style="font-family: Inter"&gt;Custom type&lt;/p&gt;',
+  );
+} finally {
+  converter.free();
+}</code></pre>
+            <p>Encode image bytes as data URLs in the HTML. Optional CJK and emoji packs enter through <code>addFontPack</code>.</p>
+
+            <h2 id="limits">Understand the portable WASM contract</h2>
+            <ul class="guide-checklist">
+              <li>The Node.js entry loads only the package's own WASM binary.</li>
+              <li>Document local paths and remote HTTP resources are unavailable.</li>
+              <li>The converter has no direct file output, streaming writer, or async render call.</li>
+              <li>Host code may write returned bytes with normal Node.js APIs.</li>
+            </ul>
+            <p>Initialization errors identify a missing or invalid packaged WASM asset and preserve the underlying cause. Conversion failures surface as JavaScript errors.</p>
+
+            <h2 id="next">Go further</h2>
+            <div class="guide-links">
+              <a href="https://www.npmjs.com/package/ironpress">Package on npm</a><a href="../browser/">Use the browser entry</a><a href="https://github.com/gastongouron/ironpress/blob/main/bindings/README.md">Capability matrix</a><a href="https://github.com/gastongouron/ironpress/pull/231">Node.js implementation</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site-footer"><div class="shell footer-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="36" height="36"><span>ironpress</span></a><p>Pure-Rust document rendering. Open source under MIT.</p><nav aria-label="Footer navigation"><a href="../">All runtimes</a><a href="https://www.npmjs.com/package/ironpress">npm</a><a href="../../parity/reports/">Parity</a></nav></div></footer>
+  </body>
+</html>

--- a/site/get-started/python/index.html
+++ b/site/get-started/python/index.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Python Getting Started: HTML and Markdown to PDF | ironpress</title>
+    <meta
+      name="description"
+      content="Install ironpress from PyPI, generate PDF bytes from Python, configure reusable converters, and safely load local images, CSS, and fonts."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/python/">
+    <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png">
+    <meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="article"><meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with ironpress in Python">
+    <meta property="og:description" content="From pip install to a configured native PDF converter in one practical Python guide.">
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/python/">
+    <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png">
+    <meta property="og:image:alt" content="ironpress logo"><meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../../assets/styles.css"><link rel="stylesheet" href="../../assets/guide.css"><link rel="stylesheet" href="../../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Get Started with ironpress in Python",
+        "description": "Install ironpress and generate PDF bytes from HTML or Markdown in Python.",
+        "author": { "@type": "Person", "name": "Gaston Gouron", "url": "https://github.com/gastongouron" },
+        "publisher": { "@type": "Organization", "name": "ironpress", "url": "https://gastongouron.github.io/ironpress/" },
+        "mainEntityOfPage": "https://gastongouron.github.io/ironpress/get-started/python/",
+        "inLanguage": "en"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#article">Skip to article</a>
+    <header class="site-header">
+      <div class="shell header-inner">
+        <a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="44" height="44"><span>ironpress</span></a>
+        <nav aria-label="Primary navigation"><a href="../" aria-current="page">Get started</a><a href="../../guides/html-to-pdf-rust/">Guide</a><a href="../../playground/">Playground</a><a class="nav-github" href="https://github.com/gastongouron/ironpress">GitHub <span aria-hidden="true">↗</span></a></nav>
+      </div>
+    </header>
+
+    <main class="guide-main" id="article">
+      <div class="shell">
+        <header class="guide-hero">
+          <p class="eyebrow"><span></span> Python getting started</p>
+          <h1>Generate PDF bytes<br><em>from Python</em></h1>
+          <p>Install a native wheel, keep the Python API small, and let the Rust engine handle rendering in process.</p>
+          <span class="runtime-type">CPython 3.8+ · Linux, macOS, Windows</span>
+        </header>
+
+        <div class="guide-layout">
+          <aside class="guide-toc" aria-label="Article contents"><p>In this guide</p><ol><li><a href="#install">Install</a></li><li><a href="#first-pdf">First PDF</a></li><li><a href="#markdown">Markdown</a></li><li><a href="#configure">Configure</a></li><li><a href="#resources">Resources</a></li><li><a href="#limits">Limits and errors</a></li><li><a href="#next">Next steps</a></li></ol></aside>
+
+          <article class="prose">
+            <h2 id="install">Install the Python package</h2>
+            <pre><code>python -m pip install ironpress</code></pre>
+            <p>
+              PyPI provides CPython ABI3 wheels for supported Linux, macOS, and
+              Windows targets. An installed wheel does not need a Rust toolchain,
+              browser executable, or system PDF library.
+            </p>
+
+            <h2 id="first-pdf">Create an HTML PDF</h2>
+            <p>The convenience function returns a Python <code>bytes</code> value:</p>
+            <pre><code>from pathlib import Path
+import ironpress
+
+html = """
+&lt;style&gt;
+  @page { size: A4; margin: 18mm; }
+  h1 { color: #295dff; }
+&lt;/style&gt;
+&lt;h1&gt;Hello from Python&lt;/h1&gt;
+"""
+
+pdf = ironpress.html_to_pdf(html)
+Path("output.pdf").write_bytes(pdf)</code></pre>
+            <div class="guide-callout"><strong>Returned type</strong><p>Store the bytes, return them from a web response, or write them with <code>Path.write_bytes</code>.</p></div>
+
+            <h2 id="markdown">Render Markdown</h2>
+            <pre><code>pdf = ironpress.markdown_to_pdf(
+    "# Release notes\n\nEverything shipped."
+)
+Path("release-notes.pdf").write_bytes(pdf)</code></pre>
+
+            <h2 id="configure">Reuse a configured converter</h2>
+            <p>Python configuration methods mutate the converter and return <code>None</code>. Configure once, then reuse the object.</p>
+            <pre><code>converter = ironpress.HtmlConverter()
+converter.page_size("Letter")
+converter.margin_sides(36, 48, 36, 48)
+converter.header("Quarterly report")
+converter.footer("Page {page} of {pages}")
+
+pdf = converter.convert("&lt;h1&gt;Results&lt;/h1&gt;")
+markdown_pdf = converter.convert_markdown("# Results")</code></pre>
+            <p>Use <code>convert_to_file</code> or <code>convert_markdown_to_file</code> when direct output is more convenient than receiving bytes.</p>
+
+            <h2 id="resources">Load local resources and fonts</h2>
+            <p>Grant a canonical directory before relative document URLs can access local files:</p>
+            <pre><code>from pathlib import Path
+
+converter = ironpress.HtmlConverter()
+converter.base_path("templates")
+converter.resource_root(".")
+converter.add_font("Inter", Path("assets/Inter.ttf").read_bytes())
+
+pdf = converter.convert("""
+  &lt;style&gt;body { font-family: Inter }&lt;/style&gt;
+  &lt;img src="assets/logo.png"&gt;
+""")</code></pre>
+            <p>Optional CJK and emoji font packs also enter as verified bytes through <code>add_font_pack</code>. Rendering never downloads a font pack.</p>
+
+            <h2 id="limits">Handle failures and runtime limits</h2>
+            <p>Invalid configuration and conversion failures raise <code>ValueError</code>. File writes can also raise normal Python I/O exceptions.</p>
+            <ul class="guide-checklist">
+              <li>HTML sanitization is enabled by default.</li>
+              <li>The Python binding has no async or streaming conversion API.</li>
+              <li>Remote HTTP document resources are not available from the binding.</li>
+              <li>Use a browser renderer for JavaScript-driven pages or exact Chrome output.</li>
+            </ul>
+
+            <h2 id="next">Go further</h2>
+            <div class="guide-links">
+              <a href="https://pypi.org/project/ironpress/">Package on PyPI</a><a href="https://github.com/gastongouron/ironpress/tree/main/bindings/python">Python binding reference</a><a href="https://github.com/gastongouron/ironpress/blob/main/bindings/README.md">Capability matrix</a><a href="../../guides/html-to-pdf-rust/">Rendering architecture guide</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site-footer"><div class="shell footer-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="36" height="36"><span>ironpress</span></a><p>Pure-Rust document rendering. Open source under MIT.</p><nav aria-label="Footer navigation"><a href="../">All runtimes</a><a href="https://pypi.org/project/ironpress/">PyPI</a><a href="../../parity/reports/">Parity</a></nav></div></footer>
+  </body>
+</html>

--- a/site/get-started/ruby/index.html
+++ b/site/get-started/ruby/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Ruby Getting Started: HTML and Markdown to PDF | ironpress</title>
+    <meta
+      name="description"
+      content="Install the ironpress gem, generate binary PDF strings from Ruby, configure a chainable converter, and safely load local images, CSS, and fonts."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/ruby/">
+    <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png">
+    <meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="article"><meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with ironpress in Ruby">
+    <meta property="og:description" content="From gem install to a configured native PDF converter in one practical Ruby guide.">
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/ruby/">
+    <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png">
+    <meta property="og:image:alt" content="ironpress logo"><meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../../assets/styles.css"><link rel="stylesheet" href="../../assets/guide.css"><link rel="stylesheet" href="../../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Get Started with ironpress in Ruby",
+        "description": "Install ironpress and generate PDF output from HTML or Markdown in Ruby.",
+        "author": { "@type": "Person", "name": "Gaston Gouron", "url": "https://github.com/gastongouron" },
+        "publisher": { "@type": "Organization", "name": "ironpress", "url": "https://gastongouron.github.io/ironpress/" },
+        "mainEntityOfPage": "https://gastongouron.github.io/ironpress/get-started/ruby/",
+        "inLanguage": "en"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#article">Skip to article</a>
+    <header class="site-header"><div class="shell header-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="44" height="44"><span>ironpress</span></a><nav aria-label="Primary navigation"><a href="../" aria-current="page">Get started</a><a href="../../guides/html-to-pdf-rust/">Guide</a><a href="../../playground/">Playground</a><a class="nav-github" href="https://github.com/gastongouron/ironpress">GitHub <span aria-hidden="true">↗</span></a></nav></div></header>
+
+    <main class="guide-main" id="article">
+      <div class="shell">
+        <header class="guide-hero">
+          <p class="eyebrow"><span></span> Ruby getting started</p>
+          <h1>Generate PDFs<br><em>from Ruby</em></h1>
+          <p>Install a native gem and use a small, chainable Ruby API backed by the same Rust rendering engine.</p>
+          <span class="runtime-type">Ruby 3.0+ · Linux, macOS, Windows</span>
+        </header>
+
+        <div class="guide-layout">
+          <aside class="guide-toc" aria-label="Article contents"><p>In this guide</p><ol><li><a href="#install">Install</a></li><li><a href="#first-pdf">First PDF</a></li><li><a href="#markdown">Markdown</a></li><li><a href="#configure">Configure</a></li><li><a href="#resources">Resources</a></li><li><a href="#limits">Limits and errors</a></li><li><a href="#next">Next steps</a></li></ol></aside>
+
+          <article class="prose">
+            <h2 id="install">Install the Ruby gem</h2>
+            <p>Add the package to your application:</p>
+            <pre><code>bundle add ironpress</code></pre>
+            <p>Or install it globally:</p>
+            <pre><code>gem install ironpress</code></pre>
+            <p>Releases include native gems for supported Linux, macOS, and Windows targets, plus a source gem.</p>
+
+            <h2 id="first-pdf">Create an HTML PDF</h2>
+            <p>The module function returns a binary Ruby <code>String</code> containing the complete PDF:</p>
+            <pre><code>require "ironpress"
+
+html = &lt;&lt;~HTML
+  &lt;style&gt;
+    @page { size: A4; margin: 18mm; }
+    h1 { color: #295dff; }
+  &lt;/style&gt;
+  &lt;h1&gt;Hello from Ruby&lt;/h1&gt;
+HTML
+
+pdf = Ironpress.html_to_pdf(html)
+File.binwrite("output.pdf", pdf)</code></pre>
+            <div class="guide-callout"><strong>Returned type</strong><p>Keep the string in binary form and send it as <code>application/pdf</code> or write it with <code>File.binwrite</code>.</p></div>
+
+            <h2 id="markdown">Render Markdown</h2>
+            <pre><code>pdf = Ironpress.markdown_to_pdf(
+  "# Release notes\n\nEverything shipped."
+)
+File.binwrite("release-notes.pdf", pdf)</code></pre>
+
+            <h2 id="configure">Build a reusable policy</h2>
+            <p>Each configuration call returns a new converter value, so settings compose naturally in a chain:</p>
+            <pre><code>converter = Ironpress::HtmlConverter.new
+  .page_size("Letter")
+  .margin_sides(36, 48, 36, 48)
+  .header("Quarterly report")
+  .footer("Page {page} of {pages}")
+
+pdf = converter.convert("&lt;h1&gt;Results&lt;/h1&gt;")
+markdown_pdf = converter.convert_markdown("# Results")</code></pre>
+            <p>Use <code>convert_to_file</code> or <code>convert_markdown_to_file</code> for direct file output.</p>
+
+            <h2 id="resources">Load local resources and fonts</h2>
+            <p>Grant a resource boundary, then pass custom font data as a binary string:</p>
+            <pre><code>converter = Ironpress::HtmlConverter.new
+  .base_path("templates")
+  .resource_root(".")
+  .add_font("Inter", File.binread("assets/Inter.ttf"))
+
+pdf = converter.convert(&lt;&lt;~HTML)
+  &lt;style&gt;body { font-family: Inter }&lt;/style&gt;
+  &lt;img src="assets/logo.png"&gt;
+HTML</code></pre>
+            <p>Optional CJK and emoji font packs also enter as caller-provided bytes. The renderer never downloads them.</p>
+
+            <h2 id="limits">Handle failures and runtime limits</h2>
+            <p>Invalid named settings raise <code>ArgumentError</code>. Conversion failures raise <code>RuntimeError</code>, while file operations keep Ruby's normal I/O errors.</p>
+            <ul class="guide-checklist">
+              <li>HTML sanitization is enabled by default.</li>
+              <li>The Ruby binding has no async or streaming conversion API.</li>
+              <li>Remote HTTP document resources are not available from the gem.</li>
+              <li>Use a browser renderer for JavaScript-driven pages or exact Chrome output.</li>
+            </ul>
+
+            <h2 id="next">Go further</h2>
+            <div class="guide-links">
+              <a href="https://rubygems.org/gems/ironpress">Package on RubyGems</a><a href="https://github.com/gastongouron/ironpress/tree/main/bindings/ruby">Ruby binding reference</a><a href="https://github.com/gastongouron/ironpress/blob/main/bindings/README.md">Capability matrix</a><a href="../../guides/html-to-pdf-rust/">Rendering architecture guide</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site-footer"><div class="shell footer-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="36" height="36"><span>ironpress</span></a><p>Pure-Rust document rendering. Open source under MIT.</p><nav aria-label="Footer navigation"><a href="../">All runtimes</a><a href="https://rubygems.org/gems/ironpress">RubyGems</a><a href="../../parity/reports/">Parity</a></nav></div></footer>
+  </body>
+</html>

--- a/site/get-started/rust/index.html
+++ b/site/get-started/rust/index.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rust Getting Started: HTML and Markdown to PDF | ironpress</title>
+    <meta
+      name="description"
+      content="Install the ironpress Rust crate, generate PDF bytes from HTML or Markdown, configure pages, and safely load fonts and document resources."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/rust/">
+    <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png">
+    <meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with ironpress in Rust">
+    <meta property="og:description" content="From cargo add to a configured PDF converter in one practical Rust guide.">
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/rust/">
+    <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png">
+    <meta property="og:image:alt" content="ironpress logo">
+    <meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../../assets/styles.css">
+    <link rel="stylesheet" href="../../assets/guide.css">
+    <link rel="stylesheet" href="../../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Get Started with ironpress in Rust",
+        "description": "Install ironpress and generate PDF bytes from HTML or Markdown in Rust.",
+        "author": { "@type": "Person", "name": "Gaston Gouron", "url": "https://github.com/gastongouron" },
+        "publisher": { "@type": "Organization", "name": "ironpress", "url": "https://gastongouron.github.io/ironpress/" },
+        "mainEntityOfPage": "https://gastongouron.github.io/ironpress/get-started/rust/",
+        "inLanguage": "en"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#article">Skip to article</a>
+    <header class="site-header">
+      <div class="shell header-inner">
+        <a class="brand" href="../../" aria-label="ironpress home">
+          <img src="../../assets/ironpress-logo.png" alt="ironpress" width="44" height="44">
+          <span>ironpress</span>
+        </a>
+        <nav aria-label="Primary navigation">
+          <a href="../" aria-current="page">Get started</a>
+          <a href="../../guides/html-to-pdf-rust/">Guide</a>
+          <a href="../../playground/">Playground</a>
+          <a class="nav-github" href="https://github.com/gastongouron/ironpress">GitHub <span aria-hidden="true">↗</span></a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="guide-main" id="article">
+      <div class="shell">
+        <header class="guide-hero">
+          <p class="eyebrow"><span></span> Rust getting started</p>
+          <h1>Generate your first PDF<br><em>inside the Rust process</em></h1>
+          <p>Add one crate, call one function, and keep the full rendering pipeline inside your application.</p>
+          <span class="runtime-type">Rust 1.88+ · crates.io</span>
+        </header>
+
+        <div class="guide-layout">
+          <aside class="guide-toc" aria-label="Article contents">
+            <p>In this guide</p>
+            <ol>
+              <li><a href="#install">Install</a></li>
+              <li><a href="#first-pdf">First PDF</a></li>
+              <li><a href="#markdown">Markdown</a></li>
+              <li><a href="#configure">Configure</a></li>
+              <li><a href="#resources">Resources</a></li>
+              <li><a href="#limits">Limits and errors</a></li>
+              <li><a href="#next">Next steps</a></li>
+            </ol>
+          </aside>
+
+          <article class="prose">
+            <h2 id="install">Install the crate</h2>
+            <p>From an existing Cargo project, add the current ironpress release:</p>
+            <pre><code>cargo add ironpress</code></pre>
+            <p>
+              The default build needs no browser executable or system library.
+              Your project must use Rust 1.88 or later.
+            </p>
+
+            <h2 id="first-pdf">Create an HTML PDF</h2>
+            <p>The convenience function returns the complete PDF as <code>Vec&lt;u8&gt;</code>. Your application decides where those bytes go.</p>
+            <pre><code>use ironpress::html_to_pdf;
+
+fn main() -&gt; Result&lt;(), Box&lt;dyn std::error::Error&gt;&gt; {
+    let html = r#"
+        &lt;style&gt;
+          @page { size: A4; margin: 18mm; }
+          h1 { color: #295dff; }
+        &lt;/style&gt;
+        &lt;h1&gt;Hello from Rust&lt;/h1&gt;
+    "#;
+
+    let pdf = html_to_pdf(html)?;
+    std::fs::write("output.pdf", pdf)?;
+    Ok(())
+}</code></pre>
+            <div class="guide-callout">
+              <strong>Result</strong>
+              <p>Running <code>cargo run</code> writes a complete <code>output.pdf</code> without starting a subprocess.</p>
+            </div>
+
+            <h2 id="markdown">Render Markdown</h2>
+            <p>Markdown uses the same renderer and returns the same byte type:</p>
+            <pre><code>use ironpress::markdown_to_pdf;
+
+let pdf = markdown_to_pdf("# Release notes\n\nEverything shipped.")?;
+std::fs::write("release-notes.pdf", pdf)?;</code></pre>
+
+            <h2 id="configure">Reuse a configured converter</h2>
+            <p>Use <code>HtmlConverter</code> when several settings must compose or multiple documents share one policy.</p>
+            <pre><code>use ironpress::{HtmlConverter, Margin, PageSize};
+
+let converter = HtmlConverter::new()
+    .page_size(PageSize::LETTER)
+    .margin(Margin::new(36.0, 48.0, 36.0, 48.0))
+    .header("Quarterly report")
+    .footer("Page {page} of {pages}");
+
+let pdf = converter.convert("&lt;h1&gt;Results&lt;/h1&gt;")?;</code></pre>
+            <p>
+              The builder is immutable from the caller's perspective: each method
+              returns the configured value. Reuse the final converter for repeated
+              <code>convert</code> or <code>convert_markdown</code> calls.
+            </p>
+
+            <h2 id="resources">Load fonts, images, and styles safely</h2>
+            <p>
+              Relative URLs are denied until you establish a local boundary.
+              <code>base_path</code> resolves URLs and also becomes the default
+              authorization root. Use <code>resource_root</code> only when shared
+              assets live in a broader parent directory.
+            </p>
+            <pre><code>use ironpress::HtmlConverter;
+use std::path::Path;
+
+let font = std::fs::read("assets/Inter.ttf")?;
+let pdf = HtmlConverter::new()
+    .base_path(Path::new("templates"))
+    .resource_root(Path::new("."))
+    .add_font("Inter", font)
+    .convert(r#"
+      &lt;style&gt;body { font-family: Inter }&lt;/style&gt;
+      &lt;img src="assets/logo.png"&gt;
+    "#)?;</code></pre>
+            <p>
+              Remote HTTP resources require <code>cargo add ironpress --features remote</code>
+              plus an explicit <code>NetworkPolicy</code>. They are not enabled by default.
+            </p>
+
+            <h2 id="limits">Handle errors and choose the right renderer</h2>
+            <p>
+              Conversion methods return <code>Result</code>. Propagate or map
+              <code>IronpressError</code> at your application boundary instead of
+              assuming every template is valid.
+            </p>
+            <ul class="guide-checklist">
+              <li>HTML sanitization is enabled by default.</li>
+              <li>JavaScript and live browser DOM behavior are not supported.</li>
+              <li>Local paths stay inside the canonical resource boundary.</li>
+              <li>Use a headless browser when exact Chrome print behavior is required.</li>
+            </ul>
+
+            <h2 id="next">Go further</h2>
+            <p>Move from the first conversion to the API surface that fits your service.</p>
+            <div class="guide-links">
+              <a href="https://docs.rs/ironpress">Rust API on docs.rs</a>
+              <a href="../../guides/html-to-pdf-rust/">Rendering architecture guide</a>
+              <a href="https://github.com/gastongouron/ironpress#streaming-output">Streaming output</a>
+              <a href="https://github.com/gastongouron/ironpress#security">Security controls</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="shell footer-inner">
+        <a class="brand" href="../../" aria-label="ironpress home">
+          <img src="../../assets/ironpress-logo.png" alt="ironpress" width="36" height="36">
+          <span>ironpress</span>
+        </a>
+        <p>Pure-Rust document rendering. Open source under MIT.</p>
+        <nav aria-label="Footer navigation">
+          <a href="../">All runtimes</a><a href="https://docs.rs/ironpress">Docs</a><a href="../../parity/reports/">Parity</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/guides/html-to-pdf-rust/index.html
+++ b/site/guides/html-to-pdf-rust/index.html
@@ -69,7 +69,7 @@
           <span>ironpress</span>
         </a>
         <nav aria-label="Primary navigation">
-          <a href="../../#features">Features</a>
+          <a href="../../get-started/">Get started</a>
           <a href="./" aria-current="page">Guide</a>
           <a href="../../playground/">Playground</a>
           <a class="nav-github" href="https://github.com/gastongouron/ironpress">

--- a/site/index.html
+++ b/site/index.html
@@ -48,7 +48,7 @@
             "name": "ironpress",
             "codeRepository": "https://github.com/gastongouron/ironpress",
             "programmingLanguage": "Rust",
-            "runtimePlatform": ["Rust", "Python", "Ruby", "WebAssembly"],
+            "runtimePlatform": ["Rust", "Command line", "Python", "Ruby", "Web browser", "Node.js"],
             "license": "https://opensource.org/license/mit",
             "description": "An in-process HTML, CSS, and Markdown to PDF engine written in Rust."
           }
@@ -72,7 +72,7 @@
         </a>
         <nav aria-label="Primary navigation">
           <a href="#features">Features</a>
-          <a href="./guides/html-to-pdf-rust/">Guide</a>
+          <a href="./get-started/">Get started</a>
           <a href="./playground/">Playground</a>
           <a
             class="nav-github"
@@ -93,13 +93,13 @@
               a subprocess, or system dependencies.
             </p>
             <div class="button-row">
-              <a class="button button-primary" href="./playground/">
-                Try the playground <span aria-hidden="true">→</span>
+              <a class="button button-primary" href="./get-started/">
+                Get started <span aria-hidden="true">→</span>
               </a>
               <a
                 class="button button-secondary"
-                href="https://github.com/gastongouron/ironpress"
-              >View on GitHub</a>
+                href="./playground/"
+              >Try the playground</a>
             </div>
             <p class="install-line">
               <span aria-hidden="true">$</span>
@@ -148,7 +148,7 @@
           <p><strong>0.93 ms</strong><span>simple HTML median</span></p>
           <p><strong>3,200+</strong><span>tests</span></p>
           <p><strong>1,664</strong><span>parity fixtures</span></p>
-          <p><strong>4</strong><span>language targets</span></p>
+          <p><strong>6</strong><span>runtime paths</span></p>
         </div>
       </section>
 
@@ -198,11 +198,11 @@
               <span class="feature-number">04</span>
               <h3>Multiple runtimes</h3>
               <p>
-                Use the same core from Rust, Python, Ruby, or WebAssembly. The
-                browser playground runs completely client-side.
+                Use the same core from Rust, the CLI, Python, Ruby, browser
+                WebAssembly, or Node.js.
               </p>
               <ul class="runtime-list" aria-label="Supported runtimes">
-                <li>Rust</li><li>Python</li><li>Ruby</li><li>WASM</li>
+                <li>Rust</li><li>CLI</li><li>Python</li><li>Ruby</li><li>Browser</li><li>Node.js</li>
               </ul>
             </article>
             <article class="feature-card">
@@ -221,13 +221,13 @@
         <div class="shell">
           <div class="section-heading section-heading-light">
             <div>
-              <p class="eyebrow"><span></span> One core, four entry points</p>
+              <p class="eyebrow"><span></span> One core, six paths</p>
               <h2>Start in the language<br>you already ship.</h2>
             </div>
             <p>
               The rendering engine is Rust. Every runtime shares the same
               portable converter controls for pages, quality, fonts, and safety.
-              <a href="https://github.com/gastongouron/ironpress/blob/main/bindings/README.md">Compare bindings.</a>
+              <a href="./get-started/">Choose your runtime.</a>
             </p>
           </div>
           <div class="code-grid">
@@ -238,6 +238,12 @@
 <b>let</b> pdf = html_to_pdf(
     <em>"&lt;h1&gt;Hello&lt;/h1&gt;"</em>
 )?;</code></pre>
+            </article>
+            <article class="code-card">
+              <p><span>CLI</span><a href="./get-started/cli/">guide →</a></p>
+              <pre><code>ironpress invoice.html \
+  invoice.pdf \
+  --page-size a4</code></pre>
             </article>
             <article class="code-card">
               <p><span>Python</span><a href="https://pypi.org/project/ironpress/">PyPI ↗</a></p>
@@ -256,12 +262,22 @@ pdf = Ironpress.html_to_pdf(
 )</code></pre>
             </article>
             <article class="code-card">
-              <p><span>WebAssembly</span><a href="https://www.npmjs.com/package/ironpress">npm ↗</a></p>
-              <pre><code><b>import</b> { htmlToPdf } <b>from</b> <em>"ironpress"</em>;
+              <p><span>Browser</span><a href="./get-started/browser/">guide →</a></p>
+              <pre><code><b>import</b> init, { htmlToPdf } <b>from</b> <em>"ironpress"</em>;
+
+<b>await</b> init();
 
 <b>const</b> pdf = htmlToPdf(
   <em>"&lt;h1&gt;Hello&lt;/h1&gt;"</em>
 );</code></pre>
+            </article>
+            <article class="code-card">
+              <p><span>Node.js</span><a href="./get-started/node/">guide →</a></p>
+              <pre><code><b>import</b> init, { htmlToPdf }
+  <b>from</b> <em>"ironpress/node"</em>;
+
+<b>await</b> init();
+<b>const</b> pdf = htmlToPdf(html);</code></pre>
             </article>
           </div>
         </div>
@@ -300,10 +316,10 @@ pdf = Ironpress.html_to_pdf(
             <h2>Give your HTML<br>the press treatment.</h2>
           </div>
           <div>
-            <p>Load the WebAssembly build and generate a PDF locally in your browser.</p>
+            <p>Install the package for your runtime and generate a PDF in your own process.</p>
             <div class="button-row">
-              <a class="button button-primary" href="./playground/">Open playground <span aria-hidden="true">→</span></a>
-              <a class="button button-secondary" href="https://docs.rs/ironpress">Read the API docs</a>
+              <a class="button button-primary" href="./get-started/">Choose your runtime <span aria-hidden="true">→</span></a>
+              <a class="button button-secondary" href="./playground/">Open playground</a>
             </div>
           </div>
         </div>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -11,6 +11,41 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/rust/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/cli/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/python/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/ruby/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/browser/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/node/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://gastongouron.github.io/ironpress/playground/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>


### PR DESCRIPTION
## Summary

- add one Get Started hub for Rust, CLI, Python, Ruby, browser JavaScript, and Node.js
- give every runtime the same install, first PDF, Markdown, configuration, resources,
  limits, and next-steps structure
- route users from the website, root README, and binding matrix
- publish focused onboarding in the Python and Ruby package READMEs
- document the `ironpress/node` contract added by #231
- check routes, guide structure, imports, branding, prose, and public README links in CI

## Validation

- `node scripts/check-site.mjs`
- all website and guide routes return HTTP 200 locally
- clean browser console and network panel
- Lighthouse desktop: accessibility 100, best practices 100, SEO 100
- Lighthouse mobile: accessibility 100, best practices 100, SEO 100

Related to #228 and #231.
