### PR TITLE
Prepare the 1.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ## Unreleased
 
+## [1.5.4] — 2026-08-22
+
 ### Added
 
 - The existing npm package now exposes `ironpress/node`, an ESM entry point that
   loads its packaged WebAssembly binary without consumer-side file handling.
+
+### Fixed
+
+- Ruby native gems load their extension from the directory for the active Ruby
+  API version on every supported platform.
 
 ### CI
 
@@ -13,6 +20,19 @@
   supported Node.js LTS line before that exact artifact can be published.
 - Static site checks parse HTML through a standards-compliant tree instead of
   filtering source markup with regular expressions.
+- Ruby native-gem builds use the crate-aware extension task and a writable Ruby
+  environment.
+- Crates.io availability checks identify the release workflow instead of timing
+  out on an anonymous request.
+- Font-pack assets target the current repository explicitly when attached to a
+  GitHub release.
+
+### Documentation
+
+- A canonical Get Started hub now covers Rust, the CLI, Python, Ruby, browser
+  JavaScript, and Node.js with the same task-oriented structure.
+- The website, root README, binding matrix, and package READMEs route users to
+  the guide for their runtime.
 
 ## [1.5.3] — 2026-08-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress"
-version = "1.5.3"
+version = "1.5.4"
 edition = "2024"
 rust-version = "1.88"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter with layout engine, LaTeX math, tables, images, custom fonts, and streaming output. No browser, no system dependencies."

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-python"
-version = "1.5.3"
+version = "1.5.4"
 edition = "2024"
 publish = false
 description = "Python bindings for the Ironpress HTML-to-PDF engine"
@@ -12,5 +12,5 @@ name = "ironpress_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-ironpress-core = { version = "=1.5.3", path = "../..", package = "ironpress" }
+ironpress-core = { version = "=1.5.4", path = "../..", package = "ironpress" }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ironpress"
-version = "1.5.3"
+version = "1.5.4"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter. No browser, no system dependencies."
 readme = "README.md"
 license = "MIT"

--- a/bindings/ruby/Gemfile.lock
+++ b/bindings/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ironpress (1.5.3)
+    ironpress (1.5.4)
       rb_sys (~> 0.9)
 
 GEM

--- a/bindings/ruby/ext/ironpress/Cargo.toml
+++ b/bindings/ruby/ext/ironpress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-ruby"
-version = "1.5.3"
+version = "1.5.4"
 edition = "2024"
 publish = false
 description = "Ruby bindings for the Ironpress HTML-to-PDF engine"
@@ -12,6 +12,6 @@ name = "ironpress_ruby"
 crate-type = ["cdylib"]
 
 [dependencies]
-ironpress-core = { version = "=1.5.3", package = "ironpress" }
+ironpress-core = { version = "=1.5.4", package = "ironpress" }
 magnus = "0.7"
 rb-sys = { version = "0.9", default-features = false, features = ["stable-api-compiled-fallback"] }

--- a/bindings/ruby/lib/ironpress/version.rb
+++ b/bindings/ruby/lib/ironpress/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ironpress
-  VERSION = "1.5.3"
+  VERSION = "1.5.4"
 end

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -8,6 +8,7 @@
 #   bindings/python/Cargo.toml          (ironpress-python internal crate)
 #   bindings/ruby/lib/ironpress/version.rb
 #   bindings/ruby/ext/ironpress/Cargo.toml
+#   bindings/ruby/Gemfile.lock
 #
 set -euo pipefail
 
@@ -45,6 +46,11 @@ update_ruby_version() {
     perl -i -pe 's/(VERSION\s*=\s*)"[^"]+"/$1"'"$NEW"'"/' "$file"
 }
 
+update_ruby_lock_version() {
+    local file="$1"
+    perl -i -pe 's/^(\s*ironpress \()[^)]*(\))$/${1}'"$NEW"'${2}/' "$file"
+}
+
 update_core_requirement() {
     local file="$1"
     perl -i -pe 'if (/^ironpress-core\s*=/) { s/version\s*=\s*"=[^"]+"/version = "='"$NEW"'"/ }' "$file"
@@ -59,6 +65,7 @@ update_core_requirement "bindings/python/Cargo.toml"   && echo "  Python core re
 bump_toml_version  "bindings/ruby/ext/ironpress/Cargo.toml" && echo "  bindings/ruby/ext/ironpress/Cargo.toml"
 update_core_requirement "bindings/ruby/ext/ironpress/Cargo.toml" && echo "  Ruby core requirement"
 update_ruby_version "bindings/ruby/lib/ironpress/version.rb" && echo "  bindings/ruby/lib/ironpress/version.rb"
+update_ruby_lock_version "bindings/ruby/Gemfile.lock" && echo "  bindings/ruby/Gemfile.lock"
 
 echo ""
 scripts/check-release-versions.sh "$NEW"

--- a/scripts/check-release-versions.sh
+++ b/scripts/check-release-versions.sh
@@ -16,6 +16,11 @@ ruby_runtime_version() {
     head -n 1
 }
 
+ruby_lock_version() {
+  sed -n 's/^[[:space:]]*ironpress (\([^)]*\))$/\1/p' "$1" |
+    head -n 1
+}
+
 core_requirement() {
   sed -n 's/^ironpress-core.*version[[:space:]]*=[[:space:]]*"=\([^"]*\)".*/\1/p' "$1"
 }
@@ -46,6 +51,7 @@ check_version "Python core requirement" "$(core_requirement bindings/python/Carg
 check_version "Ruby crate" "$(package_version bindings/ruby/ext/ironpress/Cargo.toml)"
 check_version "Ruby core requirement" "$(core_requirement bindings/ruby/ext/ironpress/Cargo.toml)"
 check_version "Ruby runtime" "$(ruby_runtime_version bindings/ruby/lib/ironpress/version.rb)"
+check_version "Ruby lockfile" "$(ruby_lock_version bindings/ruby/Gemfile.lock)"
 
 if ((MISMATCHES > 0)); then
   exit 1


### PR DESCRIPTION
## Summary

- release the first-class `ironpress/node` entry point and runtime guides as 1.5.4
- synchronize the Rust crate, Python wheel, Ruby gem, and binding crate versions
- include the Ruby lockfile in the bump command and the CI version contract
- include the standards-based site parser from #234 and close its CodeQL findings
- publish a curated changelog for every change since 1.5.3

## Validation

- `scripts/bump-version.sh 1.5.4`
- `scripts/check-release-versions.sh 1.5.4`
- `cargo check --all-targets --all-features`
- `cargo test --lib` — 3,321 passed
- `cargo test --features remote --lib` — 3,334 passed
- `cargo package --allow-dirty`
- `cargo fmt --check`
- `npm test` and `npm run check` in `scripts/`
- all required checks passed on `main` after #234

## After merge

Create the `v1.5.4` release only after the required checks pass again on `main`.
The tag will trigger publication to crates.io, npm, PyPI, RubyGems, and the
versioned GitHub release assets.
