### PR TITLE
Replace regexp HTML filtering in site checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,15 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
+      - name: Install site tooling
+        working-directory: scripts
+        run: npm ci --ignore-scripts
+      - name: Test site tooling
+        working-directory: scripts
+        run: npm test
       - name: Validate static site
-        run: node scripts/check-site.mjs
+        working-directory: scripts
+        run: npm run check
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -42,7 +42,9 @@ jobs:
           while IFS= read -r changed_path; do
             [[ -z "$changed_path" ]] && continue
             case "$changed_path" in
-              site/*|playground/*|scripts/check-site.mjs|.github/workflows/playground.yml) ;;
+              site/*|playground/*) ;;
+              scripts/check-site.mjs|scripts/site-document*.mjs|scripts/package*.json) ;;
+              .github/workflows/playground.yml) ;;
               *) run_parity=true; break ;;
             esac
           done <<< "$changed_paths"

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -13,6 +13,8 @@ on:
       - 'tests/feature_parity.rs'
       - 'scripts/parity*.sh'
       - 'scripts/check-site.mjs'
+      - 'scripts/site-document*.mjs'
+      - 'scripts/package*.json'
       - 'scripts/build-font-packs.sh'
       - 'scripts/build-wasm-package.sh'
       - 'scripts/prepare-wasm-package.mjs'
@@ -44,8 +46,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Install site tooling
+        working-directory: scripts
+        run: npm ci --ignore-scripts
+
+      - name: Test site tooling
+        working-directory: scripts
+        run: npm test
+
       - name: Validate static site
-        run: node scripts/check-site.mjs
+        working-directory: scripts
+        run: npm run check
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bindings/ruby/target/
 bindings/ruby/pkg/
 bindings/ruby/tmp/
 bindings/ruby/lib/ironpress/ironpress_ruby.*
+/scripts/node_modules/
 # Visual parity harness scratch. Browser PDFs under tests/parity/oracles are the
 # committed source of truth; all PNGs are generated previews.
 tests/parity/diffs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - The packed npm artifact is installed, type-checked, and rendered through every
   supported Node.js LTS line before that exact artifact can be published.
+- Static site checks parse HTML through a standards-compliant tree instead of
+  filtering source markup with regular expressions.
 
 ## [1.5.3] — 2026-08-20
 

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -4,6 +4,8 @@ import { access, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { HtmlDocument } from "./site-document.mjs";
+
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const errors = [];
 
@@ -64,6 +66,21 @@ function matches(content, pattern) {
   return [...content.matchAll(pattern)];
 }
 
+function containsJsonLdType(value, type) {
+  if (Array.isArray(value)) {
+    return value.some((item) => containsJsonLdType(item, type));
+  }
+  if (value === null || typeof value !== "object") return false;
+
+  const declaredTypes = Array.isArray(value["@type"])
+    ? value["@type"]
+    : [value["@type"]];
+  return (
+    declaredTypes.includes(type) ||
+    Object.values(value).some((item) => containsJsonLdType(item, type))
+  );
+}
+
 async function load(path) {
   try {
     return await readFile(resolve(repositoryRoot, path), "utf8");
@@ -84,27 +101,27 @@ async function requireFile(path) {
 for (const page of pages) {
   const html = await load(page.path);
   if (html === null) continue;
-  const documentMarkup = html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
-  const proseMarkup = documentMarkup
-    .replace(/<pre\b[^>]*>[\s\S]*?<\/pre>/gi, "")
-    .replace(/<code\b[^>]*>[\s\S]*?<\/code>/gi, "");
+  const document = HtmlDocument.parse(html);
+  const proseText = document.proseText();
 
   if (!/^<!doctype html>/i.test(html.trimStart())) {
     report(page.path, "must start with an HTML5 doctype");
   }
-  if (!/<html\b[^>]*\blang=["']en["']/i.test(html)) {
+  if (document.rootLanguage()?.toLowerCase() !== "en") {
     report(page.path, 'must declare <html lang="en">');
   }
-  if (!/<meta\b[^>]*charset=["']?utf-8/i.test(html)) {
+  if (
+    !document
+      .elements("meta")
+      .some((element) => element.attribute("charset")?.toLowerCase() === "utf-8")
+  ) {
     report(page.path, "must declare UTF-8");
   }
-  if (!/<meta\b[^>]*name=["']viewport["'][^>]*>/i.test(html)) {
+  if (document.metaContent("viewport") === undefined) {
     report(page.path, "must include a viewport meta tag");
   }
 
-  const title = html.match(/<title>([^<]+)<\/title>/i)?.[1]?.trim();
+  const title = document.elements("title")[0]?.text().trim();
   if (!title) {
     report(page.path, "must include a non-empty title");
   } else if (titles.has(title)) {
@@ -113,9 +130,7 @@ for (const page of pages) {
     titles.set(title, page.path);
   }
 
-  const description = html.match(
-    /<meta\b[^>]*name=["']description["'][^>]*content=["']([^"']+)["'][^>]*>/i,
-  )?.[1]?.trim();
+  const description = document.metaContent("description")?.trim();
   if (!description || description.length < 70 || description.length > 170) {
     report(page.path, "meta description must contain 70 to 170 characters");
   } else if (descriptions.has(description)) {
@@ -127,66 +142,59 @@ for (const page of pages) {
     descriptions.set(description, page.path);
   }
 
-  const canonical = html.match(
-    /<link\b[^>]*rel=["']canonical["'][^>]*href=["']([^"']+)["'][^>]*>/i,
-  )?.[1];
+  const canonical = document.linkHref("canonical");
   if (canonical !== page.canonical) {
     report(page.path, `canonical URL must be ${page.canonical}`);
   }
 
-  if (matches(documentMarkup, /<h1\b/gi).length !== 1) {
+  if (document.elements("h1").length !== 1) {
     report(page.path, "must contain exactly one h1");
   }
-  if (matches(documentMarkup, /<main\b/gi).length !== 1) {
+  if (document.elements("main").length !== 1) {
     report(page.path, "must contain exactly one main landmark");
   }
-  if (/IronPress|Ironpress/.test(proseMarkup)) {
+  if (/IronPress|Ironpress/.test(proseText)) {
     report(page.path, 'must use the lowercase "ironpress" brand in prose');
   }
-  if (proseMarkup.includes("—")) {
+  if (proseText.includes("—")) {
     report(page.path, "must not use em dashes in prose");
   }
-  for (const image of matches(documentMarkup, /<img\b[^>]*>/gi)) {
-    if (!/\balt=["'][^"']+["']/i.test(image[0])) {
+  for (const image of document.elements("img")) {
+    if (!image.attribute("alt")?.trim()) {
       report(page.path, "every image must have non-empty alt text");
     }
   }
-  for (const link of matches(
-    documentMarkup,
-    /<a\b[^>]*target=["']_blank["'][^>]*>/gi,
-  )) {
-    if (!/\brel=["'][^"']*noopener[^"']*["']/i.test(link[0])) {
+  for (const link of document.elements("a")) {
+    if (
+      link.attribute("target")?.toLowerCase() === "_blank" &&
+      !link.attributeTokens("rel").includes("noopener")
+    ) {
       report(page.path, 'target="_blank" links must use rel="noopener"');
     }
   }
 
-  for (const type of page.structuredDataTypes ?? []) {
-    const encodedType = new RegExp(`"@type"\\s*:\\s*"${type}"`);
-    if (!encodedType.test(html)) {
-      report(page.path, `must expose ${type} JSON-LD structured data`);
-    }
-  }
   for (const text of page.requiredText ?? []) {
     if (!html.includes(text)) {
       report(page.path, `must include the tested consumer contract: ${text}`);
     }
   }
 
-  const structuredData = matches(
-    html,
-    /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
-  );
-  for (const script of structuredData) {
+  const structuredData = [];
+  for (const source of document.jsonLdText()) {
     try {
-      JSON.parse(script[1]);
+      structuredData.push(JSON.parse(source));
     } catch (error) {
       report(page.path, `contains invalid JSON-LD (${error.message})`);
     }
   }
+  for (const type of page.structuredDataTypes ?? []) {
+    if (!structuredData.some((value) => containsJsonLdType(value, type))) {
+      report(page.path, `must expose ${type} JSON-LD structured data`);
+    }
+  }
 
   const seenIds = new Set();
-  for (const idAttribute of matches(documentMarkup, /\bid=["']([^"']+)["']/gi)) {
-    const id = idAttribute[1];
+  for (const id of document.ids()) {
     if (seenIds.has(id)) report(page.path, `contains duplicate id="${id}"`);
     seenIds.add(id);
   }
@@ -199,13 +207,22 @@ for (const page of pages) {
 
 const playground = await load("playground/index.html");
 if (playground !== null) {
+  const document = HtmlDocument.parse(playground);
   for (const id of ["mode", "examples", "input", "preview"]) {
-    const label = new RegExp(`<label\\b[^>]*for=["']${id}["']`, "i");
-    const labelledControl = new RegExp(
-      `<(?:select|textarea|iframe)\\b[^>]*id=["']${id}["'][^>]*aria-label(?:ledby)?=["'][^"']+["']`,
-      "i",
+    const hasLabel = document
+      .elements("label")
+      .some((label) => label.attribute("for") === id);
+    const control = document
+      .elements()
+      .find(
+        (element) =>
+          ["iframe", "select", "textarea"].includes(element.tagName()) &&
+          element.attribute("id") === id,
+      );
+    const hasAccessibleAttribute = ["aria-label", "aria-labelledby"].some(
+      (name) => control?.attribute(name)?.trim(),
     );
-    if (!label.test(playground) && !labelledControl.test(playground)) {
+    if (!hasLabel && !hasAccessibleAttribute) {
       report("playground/index.html", `#${id} needs an accessible name`);
     }
   }

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "ironpress-site-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ironpress-site-tooling",
+      "devDependencies": {
+        "parse5": "8.0.1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ironpress-site-tooling",
+  "private": true,
+  "type": "module",
+  "packageManager": "npm@11.12.1",
+  "scripts": {
+    "check": "node check-site.mjs",
+    "test": "node --test site-document.test.mjs"
+  },
+  "devDependencies": {
+    "parse5": "8.0.1"
+  }
+}

--- a/scripts/site-document.mjs
+++ b/scripts/site-document.mjs
@@ -1,0 +1,118 @@
+import { parse } from "parse5";
+
+const proseExcludedElements = new Set(["code", "pre", "script", "style"]);
+
+class HtmlElement {
+  #node;
+
+  constructor(node) {
+    this.#node = node;
+  }
+
+  tagName() {
+    return this.#node.tagName;
+  }
+
+  attribute(name) {
+    return this.#node.attrs?.find((attribute) => attribute.name === name)?.value;
+  }
+
+  attributeTokens(name) {
+    return (this.attribute(name) ?? "")
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(Boolean);
+  }
+
+  text() {
+    return descendantText(this.#node);
+  }
+}
+
+export class HtmlDocument {
+  #root;
+  #elements;
+
+  static parse(markup) {
+    return new HtmlDocument(parse(markup));
+  }
+
+  constructor(root) {
+    this.#root = root;
+    this.#elements = descendantElements(root).map(
+      (element) => new HtmlElement(element),
+    );
+  }
+
+  elements(tagName) {
+    const normalizedTagName = tagName?.toLowerCase();
+    return normalizedTagName === undefined
+      ? [...this.#elements]
+      : this.#elements.filter(
+          (element) => element.tagName() === normalizedTagName,
+        );
+  }
+
+  rootLanguage() {
+    return this.elements("html")[0]?.attribute("lang");
+  }
+
+  metaContent(name) {
+    const normalizedName = name.toLowerCase();
+    return this.elements("meta")
+      .find(
+        (element) =>
+          element.attribute("name")?.toLowerCase() === normalizedName,
+      )
+      ?.attribute("content");
+  }
+
+  linkHref(relation) {
+    const normalizedRelation = relation.toLowerCase();
+    return this.elements("link")
+      .find((element) =>
+        element.attributeTokens("rel").includes(normalizedRelation),
+      )
+      ?.attribute("href");
+  }
+
+  proseText() {
+    return descendantText(this.#root, proseExcludedElements);
+  }
+
+  ids() {
+    return this.#elements
+      .map((element) => element.attribute("id"))
+      .filter((id) => id !== undefined && id !== "");
+  }
+
+  jsonLdText() {
+    return this.elements("script")
+      .filter(
+        (element) =>
+          element.attribute("type")?.toLowerCase() === "application/ld+json",
+      )
+      .map((element) => element.text());
+  }
+}
+
+function descendantElements(root) {
+  const elements = [];
+  const pending = [...(root.childNodes ?? [])].reverse();
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (node.tagName !== undefined) {
+      elements.push(node);
+    }
+    pending.push(...[...(node.childNodes ?? [])].reverse());
+  }
+  return elements;
+}
+
+function descendantText(root, excludedElements = new Set()) {
+  if (root.tagName !== undefined && excludedElements.has(root.tagName)) return "";
+  if (root.nodeName === "#text") return root.value;
+  return (root.childNodes ?? [])
+    .map((child) => descendantText(child, excludedElements))
+    .join("");
+}

--- a/scripts/site-document.test.mjs
+++ b/scripts/site-document.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { HtmlDocument } from "./site-document.mjs";
+
+test("parses permissive raw-text end tags without manufacturing markup", () => {
+  const document = HtmlDocument.parse(`<!doctype html>
+    <html lang="en"><body>
+      <script>const sample = "<h1>not a heading</h1>";</script data-check>
+      <style>.sample::after { content: "Ironpress —"; }</style data-check>
+      <main id="content"><h1>Real heading</h1><p>ironpress docs</p></main>
+    </body></html>`);
+
+  assert.equal(document.elements("script").length, 1);
+  assert.equal(document.elements("style").length, 1);
+  assert.equal(document.elements("h1").length, 1);
+  assert.equal(document.elements("main").length, 1);
+  assert.equal(document.proseText().trim(), "Real headingironpress docs");
+});
+
+test("keeps code examples out of prose without altering their text", () => {
+  const document = HtmlDocument.parse(`<!doctype html>
+    <html><body><main>
+      <p>Use ironpress.</p>
+      <pre><code>Ironpress — &lt;script&gt;example&lt;/script&gt;</code></pre>
+    </main></body></html>`);
+
+  assert.equal(document.proseText().trim(), "Use ironpress.");
+  assert.equal(
+    document.elements("code")[0].text(),
+    "Ironpress — <script>example</script>",
+  );
+});
+
+test("exposes decoded attributes and JSON-LD text", () => {
+  const document = HtmlDocument.parse(`<!doctype html>
+    <html lang="en"><head>
+      <meta name="description" content="Fast &amp; deterministic">
+      <link rel="canonical alternate" href="https://example.test/docs/">
+      <script type="application/ld+json">{"@type":"TechArticle"}</script>
+    </head><body><img alt="A &amp; B" id="logo"></body></html>`);
+
+  assert.equal(document.rootLanguage(), "en");
+  assert.equal(document.metaContent("description"), "Fast & deterministic");
+  assert.equal(document.linkHref("canonical"), "https://example.test/docs/");
+  assert.equal(document.elements("img")[0].attribute("alt"), "A & B");
+  assert.deepEqual(document.ids(), ["logo"]);
+  assert.deepEqual(document.jsonLdText(), ['{"@type":"TechArticle"}']);
+});
+
+test("preserves document order when resolving metadata and identifiers", () => {
+  const document = HtmlDocument.parse(`<!doctype html>
+    <html><head>
+      <meta name="description" content="Primary description">
+      <meta name="description" content="Later duplicate">
+    </head><body><p id="first"></p><p id="second"></p></body></html>`);
+
+  assert.equal(document.metaContent("description"), "Primary description");
+  assert.deepEqual(document.ids(), ["first", "second"]);
+});


### PR DESCRIPTION
## Summary

- parse site HTML with `parse5` instead of removing tags with regular expressions
- query the parsed tree for headings, landmarks, metadata, links, IDs, prose, and JSON-LD
- cover permissive raw-text end tags, code blocks, decoded attributes, and document order
- install locked site tooling without lifecycle scripts in CI and website deployment

## Security assessment

CodeQL alerts #9, #10, and #11 share one source. The repository HTML is read only
for CI linting and is never rendered from the transformed value, so there was no
exploitable HTML injection sink. The regexp was still the wrong abstraction and
could make the checker misread crafted or malformed markup. A standards-compliant
parser removes that correctness gap instead of suppressing the alerts.

## Validation

- `npm ci --ignore-scripts`
- `npm test` — 4 passed
- `npm run check` — 10 public pages passed
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm audit signatures` — 2 verified signatures and 1 verified attestation
- JavaScript syntax checks
- workflow YAML parsing
