### PR TITLE
docs: remove stale Chrome parity caveat

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -312,7 +312,7 @@ pdf = Ironpress.html_to_pdf(
             </article>
             <article>
               <span class="decision-no" aria-hidden="true">×</span>
-              <div><h3>Choose a browser for</h3><p>JavaScript-driven pages, browser screenshots, or exact Chrome print parity.</p></div>
+              <div><h3>Choose a browser for</h3><p>JavaScript-driven pages or browser screenshots.</p></div>
             </article>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- remove the obsolete claim that exact Chrome print parity requires a browser
- keep browser guidance focused on JavaScript and screenshots

## Verification

- static site contract
- whitespace diff check