### PR TITLE
feat: add the .NET binding and NuGet package

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,6 +16,7 @@ on:
       - 'bindings/c/**'
       - 'bindings/dotnet/**'
       - 'tests/fonts/IronpressCjkVertical.ttf'
+      - 'tests/parity/fonts/ParitySans.ttf'
       - 'scripts/bump-version.sh'
       - 'scripts/check-release-versions.sh'
       - '.github/workflows/dotnet.yml'
@@ -27,6 +28,7 @@ on:
       - 'bindings/c/**'
       - 'bindings/dotnet/**'
       - 'tests/fonts/IronpressCjkVertical.ttf'
+      - 'tests/parity/fonts/ParitySans.ttf'
       - 'scripts/bump-version.sh'
       - 'scripts/check-release-versions.sh'
       - '.github/workflows/dotnet.yml'
@@ -203,6 +205,7 @@ jobs:
           --property:IronpressVersion=${{ needs.pack.outputs.version }}
           "--property:IronpressPackageSource=${{ github.workspace }}/bindings/dotnet/artifacts"
           --
+          tests/parity/fonts/ParitySans.ttf
           tests/fonts/IronpressCjkVertical.ttf
 
   verify-publisher:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,250 @@
+name: .NET
+
+on:
+  workflow_dispatch:
+    inputs:
+      verify_publisher:
+        description: Verify the NuGet trusted-publishing policy without publishing
+        required: false
+        default: false
+        type: boolean
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'src/**'
+      - 'bindings/c/**'
+      - 'bindings/dotnet/**'
+      - 'tests/fonts/IronpressCjkVertical.ttf'
+      - 'scripts/bump-version.sh'
+      - 'scripts/check-release-versions.sh'
+      - '.github/workflows/dotnet.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'src/**'
+      - 'bindings/c/**'
+      - 'bindings/dotnet/**'
+      - 'tests/fonts/IronpressCjkVertical.ttf'
+      - 'scripts/bump-version.sh'
+      - 'scripts/check-release-versions.sh'
+      - '.github/workflows/dotnet.yml'
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+  DOTNET_NOLOGO: '1'
+  DOTNET_VERSION: '8.0.x'
+  RUST_VERSION: '1.88.0'
+
+jobs:
+  native-linux:
+    name: Native library - ${{ matrix.rid }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-x64
+            runner: ubuntu-24.04
+            image: quay.io/pypa/manylinux_2_28_x86_64:2026.05.07-2@sha256:443eabd378e140996780a772e12c1a1ef10551da933fe76d74a1bab61f68a7b7
+          - rid: linux-arm64
+            runner: ubuntu-24.04-arm
+            image: quay.io/pypa/manylinux_2_28_aarch64:2026.05.07-2@sha256:a435288af93def166dc59b5d052fa20ce59d76c6f38e8ad105767262d36843f0
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Build the native library
+        run: cargo build --release -p ironpress-ffi
+      - name: Verify the glibc compatibility floor
+        run: bindings/c/verify-glibc-floor.sh target/release/libironpress_ffi.so 2.28
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ironpress-dotnet-${{ matrix.rid }}
+          path: target/release/libironpress_ffi.so
+          if-no-files-found: error
+          retention-days: 1
+
+  native-desktop:
+    name: Native library - ${{ matrix.rid }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: osx-x64
+            runner: macos-15-intel
+            library: target/release/libironpress_ffi.dylib
+          - rid: osx-arm64
+            runner: macos-15
+            library: target/release/libironpress_ffi.dylib
+          - rid: win-x64
+            runner: windows-2022
+            library: target/release/ironpress_ffi.dll
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Build the native library
+        run: cargo build --release -p ironpress-ffi
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ironpress-dotnet-${{ matrix.rid }}
+          path: ${{ matrix.library }}
+          if-no-files-found: error
+          retention-days: 1
+
+  pack:
+    name: Pack NuGet artifact
+    needs: [native-linux, native-desktop]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: ironpress-dotnet-linux-x64
+          path: bindings/dotnet/native/linux-x64
+      - uses: actions/download-artifact@v8
+        with:
+          name: ironpress-dotnet-linux-arm64
+          path: bindings/dotnet/native/linux-arm64
+      - uses: actions/download-artifact@v8
+        with:
+          name: ironpress-dotnet-osx-x64
+          path: bindings/dotnet/native/osx-x64
+      - uses: actions/download-artifact@v8
+        with:
+          name: ironpress-dotnet-osx-arm64
+          path: bindings/dotnet/native/osx-arm64
+      - uses: actions/download-artifact@v8
+        with:
+          name: ironpress-dotnet-win-x64
+          path: bindings/dotnet/native/win-x64
+      - name: Read the package version
+        id: version
+        shell: bash
+        run: |
+          value="$(sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' \
+            bindings/dotnet/src/Ironpress/Ironpress.csproj | head -n 1)"
+          echo "value=${value}" >> "${GITHUB_OUTPUT}"
+      - name: Verify release metadata
+        run: scripts/check-release-versions.sh
+      - name: Pack the managed and native assets
+        run: >-
+          dotnet pack bindings/dotnet/src/Ironpress/Ironpress.csproj
+          --configuration Release
+          --output bindings/dotnet/artifacts
+      - name: Verify the NuGet layout
+        run: >-
+          bindings/dotnet/verify-package.sh
+          bindings/dotnet/artifacts/Ironpress.${{ steps.version.outputs.value }}.nupkg
+          ${{ steps.version.outputs.value }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ironpress-nuget-${{ steps.version.outputs.value }}
+          path: bindings/dotnet/artifacts/*.*nupkg
+          if-no-files-found: error
+          retention-days: 1
+
+  consumer:
+    name: Packed consumer - ${{ matrix.rid }}
+    needs: pack
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-x64
+            runner: ubuntu-24.04
+          - rid: linux-arm64
+            runner: ubuntu-24.04-arm
+          - rid: osx-x64
+            runner: macos-15-intel
+          - rid: osx-arm64
+            runner: macos-15
+          - rid: win-x64
+            runner: windows-2022
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: ironpress-nuget-${{ needs.pack.outputs.version }}
+          path: bindings/dotnet/artifacts
+      - name: Install and exercise the packed package
+        env:
+          IRONPRESS_EXPECTED_VERSION: ${{ needs.pack.outputs.version }}
+        run: >-
+          dotnet run
+          --project bindings/dotnet/tests/Ironpress.Contract/Ironpress.Contract.csproj
+          --configuration Release
+          --property:UsePackedIronpress=true
+          --property:IronpressVersion=${{ needs.pack.outputs.version }}
+          "--property:IronpressPackageSource=${{ github.workspace }}/bindings/dotnet/artifacts"
+          --
+          tests/fonts/IronpressCjkVertical.ttf
+
+  verify-publisher:
+    name: Verify NuGet trusted publisher
+    if: github.event_name == 'workflow_dispatch' && inputs.verify_publisher
+    needs: consumer
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Exchange the GitHub identity for a temporary NuGet key
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+  publish:
+    name: Publish NuGet package
+    if: github.event_name == 'release'
+    needs: [pack, consumer]
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: ironpress-nuget-${{ needs.pack.outputs.version }}
+          path: artifacts
+      - name: Exchange the GitHub identity for a temporary NuGet key
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - name: Publish the tested package and symbols
+        run: >-
+          dotnet nuget push artifacts/Ironpress.*.nupkg
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - A versioned C ABI exposes the portable converter contract through opaque
   handles and ships native libraries for Linux, macOS, and Windows.
+- A .NET 8+ `HtmlConverter` package uses the stable C ABI through `SafeHandle`
+  ownership and ships native assets for five initial runtime identifiers.
+
+### CI
+
+- NuGet artifacts are installed and rendered on Linux, macOS, and Windows
+  before OIDC trusted publishing can run.
 
 ## [1.5.4] — 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ subprocess, or system dependencies.
 [![PyPI](https://img.shields.io/pypi/v/ironpress.svg)](https://pypi.org/project/ironpress/)
 [![Gem](https://img.shields.io/gem/v/ironpress.svg)](https://rubygems.org/gems/ironpress)
 [![npm](https://img.shields.io/npm/v/ironpress.svg)](https://www.npmjs.com/package/ironpress)
+[![NuGet](https://img.shields.io/nuget/v/Ironpress.svg)](https://www.nuget.org/packages/Ironpress)
 [![docs.rs](https://docs.rs/ironpress/badge.svg)](https://docs.rs/ironpress)
 [![CI](https://github.com/gastongouron/ironpress/actions/workflows/ci.yml/badge.svg)](https://github.com/gastongouron/ironpress/actions)
 [![codecov](https://codecov.io/gh/gastongouron/ironpress/branch/main/graph/badge.svg?token=w36XIAwRxG)](https://codecov.io/gh/gastongouron/ironpress)
@@ -30,8 +31,8 @@ subprocess, or system dependencies.
 
 ironpress turns HTML, CSS, or Markdown into PDF bytes inside your application.
 Its rendering engine handles document layout, font shaping, SVG, math, and PDF
-serialization without launching Chrome. Use it from Rust, C, the CLI, Python,
-Ruby, Node.js, or browser WebAssembly.
+serialization without launching Chrome. Use it from Rust, C, .NET, the CLI,
+Python, Ruby, Node.js, or browser WebAssembly.
 
 ## Why ironpress?
 
@@ -133,6 +134,7 @@ does not change page geometry. The CLI exposes the same controls through
 | **Images** | JPEG + PNG, data URIs, local files, remote URLs (`remote` feature) | [Architecture](../../wiki/Architecture) |
 | **PDF** | PDF 1.4, bookmarks, link annotations, headers/footers, gradients, streaming output | [PDF Rendering](../../wiki/PDF-Rendering) |
 | **C ABI** | Stable native API with versioned Linux, macOS, and Windows libraries | [C binding](bindings/c/README.md) |
+| **.NET** | Managed `HtmlConverter`, typed failures, and RID-native assets | [.NET binding](bindings/dotnet/README.md) |
 | **WASM** | `npm install ironpress` - runs in browsers and Node.js | [WASM & Playground](../../wiki/WASM-Playground) |
 | **Testing** | 3,200+ unit tests, property-based tests, 6 fuzz targets, 1,664-fixture parity corpus | [Testing Strategy](../../wiki/Testing-Strategy) |
 
@@ -191,6 +193,19 @@ Python and Ruby expose the same reusable converter controls as WebAssembly:
 page geometry, quality settings, sanitization, headers and footers, custom
 fonts, and optional CJK or emoji packs. See the complete
 [binding capability matrix](bindings/README.md).
+
+```bash
+dotnet add package Ironpress
+```
+
+```csharp
+using Ironpress;
+
+using var converter = new HtmlConverter()
+    .SetPageSize(PageSize.Letter)
+    .SetFooter("Page {page} of {pages}");
+byte[] pdf = converter.ConvertHtml("<h1>Hello</h1>");
+```
 
 ```bash
 pip install ironpress

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -1,25 +1,25 @@
 # Language bindings
 
-Ironpress exposes one rendering engine through Rust, C, Python, Ruby, browser
-WebAssembly, and Node.js WebAssembly. Each binding keeps the conventions of its
-runtime while sharing the portable converter contract below.
+Ironpress exposes one rendering engine through Rust, C, .NET, Python, Ruby,
+browser WebAssembly, and Node.js WebAssembly. Each binding keeps the conventions
+of its runtime while sharing the portable converter contract below.
 
 ## Capability matrix
 
-| Capability | Rust | C ABI | Python | Ruby | Browser WASM | Node.js WASM |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|
-| HTML and Markdown to PDF bytes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Reusable configured converter | Yes | Yes | Yes | Yes | Yes | Yes |
-| Page size and margins | Yes | Yes | Yes | Yes | Yes | Yes |
-| PDF and raster quality controls | Yes | Yes | Yes | Yes | Yes | Yes |
-| Sanitization | Yes | Yes | Yes | Yes | Yes | Yes |
-| Headers and footers | Yes | Yes | Yes | Yes | Yes | Yes |
-| Custom TTF fonts | Yes | Yes | Yes | Yes | Yes | Yes |
-| Optional CJK and emoji packs | Yes | Yes | Yes | Yes | Yes | Yes |
-| Local resource boundary | Yes | No | Yes | Yes | No | No |
-| Direct file output | Yes | No | Yes | Yes | No | No |
-| Streaming writer and async API | Yes | No | No | No | No | No |
-| Remote HTTP resources | Opt-in | No | No | No | No | No |
+| Capability | Rust | C ABI | .NET | Python | Ruby | Browser WASM | Node.js WASM |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| HTML and Markdown to PDF bytes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Reusable configured converter | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Page size and margins | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| PDF and raster quality controls | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Sanitization | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Headers and footers | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Custom TTF fonts | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Optional CJK and emoji packs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Local resource boundary | Yes | No | No | Yes | Yes | No | No |
+| Direct file output | Yes | No | No | Yes | Yes | No | No |
+| Streaming writer and async API | Yes | No | No | No | No | No | No |
+| Remote HTTP resources | Opt-in | No | No | No | No | No | No |
 
 WebAssembly receives font and document bytes from the host application. It does
 not read local paths. Remote resource loading remains available only through the
@@ -32,21 +32,24 @@ network access.
 |---|---|---|
 | Rust | [`ironpress`](https://crates.io/crates/ironpress) | Source crate, Rust 1.88+ |
 | C | [GitHub Releases](https://github.com/gastongouron/ironpress/releases) | Header, static library, and shared library for Linux, macOS, and Windows |
+| .NET | [`Ironpress`](https://www.nuget.org/packages/Ironpress) | .NET 8+ managed assembly with Linux, macOS, and Windows native assets |
 | Python | [`ironpress`](https://pypi.org/project/ironpress/) | CPython 3.8+ ABI3 wheels for Linux, macOS, and Windows |
 | Ruby | [`ironpress`](https://rubygems.org/gems/ironpress) | Ruby 3.0+ source gem and native gems for Linux, macOS, and Windows |
 | Browser WebAssembly | [`ironpress`](https://www.npmjs.com/package/ironpress) | Browser ESM entry and WebAssembly binary |
 | Node.js WebAssembly | [`ironpress/node`](https://www.npmjs.com/package/ironpress) | Node.js 22/24 ESM entry using the same WebAssembly binary |
 
 All published packages use the same Ironpress version. CI builds and exercises
-the C, Python, and Ruby artifacts before a release can publish them. The
-generated npm tarball is installed, type-checked, and rendered through Node.js
-22 and 24; the browser entry remains a separate required check.
+the C, .NET, Python, and Ruby artifacts before a release can publish them. The
+NuGet package is installed and rendered on every advertised RID without Rust.
+The generated npm tarball is installed, type-checked, and rendered through
+Node.js 22 and 24; the browser entry remains a separate required check.
 
 Start with the guide for your runtime:
 
 - [Rust](https://gastongouron.github.io/ironpress/get-started/rust/)
 - [CLI](https://gastongouron.github.io/ironpress/get-started/cli/)
 - [C](c/README.md)
+- [.NET](https://gastongouron.github.io/ironpress/get-started/dotnet/)
 - [Python](https://gastongouron.github.io/ironpress/get-started/python/)
 - [Ruby](https://gastongouron.github.io/ironpress/get-started/ruby/)
 - [Browser JavaScript](https://gastongouron.github.io/ironpress/get-started/browser/)

--- a/bindings/dotnet/.gitignore
+++ b/bindings/dotnet/.gitignore
@@ -1,0 +1,4 @@
+**/bin/
+**/obj/
+artifacts/
+native/

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -1,0 +1,75 @@
+# Ironpress for .NET
+
+Ironpress renders HTML, CSS, and Markdown to PDF bytes inside a .NET process.
+The NuGet package contains the managed facade and its native Ironpress library;
+consumers do not need Rust, Chrome, or a subprocess.
+
+## Install
+
+```bash
+dotnet add package Ironpress --version 1.5.4
+```
+
+The initial package targets .NET 8 or newer and includes native assets for:
+
+- Linux x64 and ARM64 with glibc 2.28 or newer
+- macOS x64 and ARM64
+- Windows x64
+
+## Convert HTML
+
+```csharp
+using Ironpress;
+
+using var converter = new HtmlConverter()
+    .SetPageSize(PageSize.Letter)
+    .SetMargin(36)
+    .SetFooter("Page {page} of {pages}");
+
+byte[] pdf = converter.ConvertHtml("<h1>Hello from .NET</h1>");
+File.WriteAllBytes("output.pdf", pdf);
+```
+
+`ConvertMarkdown` accepts Markdown and returns the same owned `byte[]` result.
+
+## Configure rendering
+
+The managed facade covers the portable C ABI contract:
+
+- named or custom page dimensions and per-side margins
+- compression, JPEG quality, image resizing, and raster resolutions
+- sanitization, headers, and footers
+- custom TrueType font bytes
+- optional Japanese, Korean, Simplified Chinese, Traditional Chinese, and emoji packs
+
+Every mutating method returns the same converter for fluent configuration.
+`HtmlConverter` owns a native resource and implements `IDisposable`; use a
+`using` declaration or call `Dispose` deterministically. A converter may move
+between threads while idle, but it must not be used or disposed concurrently.
+
+## Errors
+
+Native failures throw `IronpressException`. Its `Kind` property retains the
+stable parser, layout, render, font, security, or argument category. Ordinary
+.NET contract violations, such as invalid custom page dimensions or use after
+disposal, use the standard argument and disposal exception types.
+
+## Fonts and security
+
+The package never downloads fonts. Load an optional pack from an Ironpress
+release and pass its bytes explicitly:
+
+```csharp
+using var converter = new HtmlConverter()
+    .AddFontPack(
+        FontPackKind.CjkJapanese,
+        File.ReadAllBytes("ironpress-font-cjk-jp.ttf"));
+```
+
+The first .NET contract accepts document and font bytes only. It does not expose
+local paths, direct file output, streaming, asynchronous conversion, or remote
+resource access. HTML sanitization remains enabled by default.
+
+The managed assembly verifies ABI generation 1 before allocating a converter.
+See the shared [binding matrix](../README.md) and the native
+[ABI contract](../c/ABI.md) for the complete ownership model.

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -7,7 +7,7 @@ consumers do not need Rust, Chrome, or a subprocess.
 ## Install
 
 ```bash
-dotnet add package Ironpress --version 1.5.4
+dotnet add package Ironpress
 ```
 
 The initial package targets .NET 8 or newer and includes native assets for:

--- a/bindings/dotnet/src/Ironpress/FontPackKind.cs
+++ b/bindings/dotnet/src/Ironpress/FontPackKind.cs
@@ -1,0 +1,20 @@
+namespace Ironpress;
+
+/// <summary>The role of an optional Ironpress fallback-font pack.</summary>
+public enum FontPackKind
+{
+    /// <summary>Japanese CJK fallback glyphs.</summary>
+    CjkJapanese = 1,
+
+    /// <summary>Korean CJK and Hangul fallback glyphs.</summary>
+    CjkKorean = 2,
+
+    /// <summary>Simplified Chinese CJK fallback glyphs.</summary>
+    CjkSimplifiedChinese = 3,
+
+    /// <summary>Traditional Chinese CJK fallback glyphs.</summary>
+    CjkTraditionalChinese = 4,
+
+    /// <summary>Monochrome outline emoji fallback glyphs.</summary>
+    Emoji = 5,
+}

--- a/bindings/dotnet/src/Ironpress/HtmlConverter.Configuration.cs
+++ b/bindings/dotnet/src/Ironpress/HtmlConverter.Configuration.cs
@@ -30,7 +30,16 @@ public sealed partial class HtmlConverter
     }
 
     /// <summary>Use one finite physical margin on every page side.</summary>
-    public HtmlConverter SetMargin(float points) => SetMargins(PageMargins.Uniform(points));
+    public HtmlConverter SetMargin(float points)
+    {
+        var margin = PageMargins.Uniform(points);
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_margin(
+            converter,
+            margin.Top,
+            out var error);
+        return Complete(status, error);
+    }
 
     /// <summary>Use validated physical page margins in CSS clockwise order.</summary>
     public HtmlConverter SetMargins(PageMargins margins)

--- a/bindings/dotnet/src/Ironpress/HtmlConverter.Configuration.cs
+++ b/bindings/dotnet/src/Ironpress/HtmlConverter.Configuration.cs
@@ -1,0 +1,181 @@
+using System.Diagnostics;
+using Ironpress.Interop;
+
+namespace Ironpress;
+
+public sealed partial class HtmlConverter
+{
+    /// <summary>Use a named physical page size.</summary>
+    public HtmlConverter SetPageSize(PageSize pageSize)
+    {
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_page_size(
+            converter,
+            (uint)pageSize,
+            out var error);
+        return Complete(status, error);
+    }
+
+    /// <summary>Use validated custom physical page dimensions.</summary>
+    public HtmlConverter SetCustomPageSize(PageDimensions dimensions)
+    {
+        ArgumentNullException.ThrowIfNull(dimensions);
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_page_size_custom(
+            converter,
+            dimensions.Width,
+            dimensions.Height,
+            out var error);
+        return Complete(status, error);
+    }
+
+    /// <summary>Use one finite physical margin on every page side.</summary>
+    public HtmlConverter SetMargin(float points) => SetMargins(PageMargins.Uniform(points));
+
+    /// <summary>Use validated physical page margins in CSS clockwise order.</summary>
+    public HtmlConverter SetMargins(PageMargins margins)
+    {
+        ArgumentNullException.ThrowIfNull(margins);
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_margins(
+            converter,
+            margins.Top,
+            margins.Right,
+            margins.Bottom,
+            margins.Left,
+            out var error);
+        return Complete(status, error);
+    }
+
+    /// <summary>Enable or disable FlateDecode compression.</summary>
+    public HtmlConverter SetCompression(bool enabled)
+    {
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_compress(
+            converter,
+            ToNativeBoolean(enabled),
+            out var error);
+        return Complete(status, error);
+    }
+
+    /// <summary>Set JPEG quality from 0 to 100; larger values are clamped.</summary>
+    public HtmlConverter SetJpegQuality(byte quality)
+    {
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_jpeg_quality(
+            converter,
+            quality,
+            out var error);
+        return Complete(status, error);
+    }
+
+    /// <summary>Enable or disable automatic downscaling of oversized images.</summary>
+    public HtmlConverter SetAutomaticImageResize(bool enabled)
+    {
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_auto_resize_images(
+            converter,
+            ToNativeBoolean(enabled),
+            out var error);
+        return Complete(status, error);
+    }
+
+    /// <summary>Set target source-image resolution in dots per inch.</summary>
+    public HtmlConverter SetImageResolution(float dotsPerInch) =>
+        SetResolution(ResolutionKind.Image, dotsPerInch);
+
+    /// <summary>Set CSS filter rasterization resolution in dots per inch.</summary>
+    public HtmlConverter SetFilterResolution(float dotsPerInch) =>
+        SetResolution(ResolutionKind.Filter, dotsPerInch);
+
+    /// <summary>Set CSS mask rasterization resolution in dots per inch.</summary>
+    public HtmlConverter SetMaskResolution(float dotsPerInch) =>
+        SetResolution(ResolutionKind.Mask, dotsPerInch);
+
+    /// <summary>Set flattened-background resolution in dots per inch.</summary>
+    public HtmlConverter SetBackgroundResolution(float dotsPerInch) =>
+        SetResolution(ResolutionKind.Background, dotsPerInch);
+
+    /// <summary>Enable or disable conservative raster occlusion culling.</summary>
+    public HtmlConverter SetOcclusionCulling(bool enabled)
+    {
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_occlusion_cull(
+            converter,
+            ToNativeBoolean(enabled),
+            out var error);
+        return Complete(status, error);
+    }
+
+    /// <summary>Enable or disable HTML sanitization.</summary>
+    public HtmlConverter SetSanitization(bool enabled)
+    {
+        EnsureOpen();
+        var status = NativeMethods.ironpress_converter_set_sanitize(
+            converter,
+            ToNativeBoolean(enabled),
+            out var error);
+        return Complete(status, error);
+    }
+
+    /// <summary>Set plain text rendered in the top page margin.</summary>
+    public HtmlConverter SetHeader(string text) => SetPageText(PageTextKind.Header, text);
+
+    /// <summary>Set footer text, with optional {page} and {pages} placeholders.</summary>
+    public HtmlConverter SetFooter(string text) => SetPageText(PageTextKind.Footer, text);
+
+    private HtmlConverter SetResolution(ResolutionKind kind, float dotsPerInch)
+    {
+        EnsureOpen();
+        nint error;
+        var status = kind switch
+        {
+            ResolutionKind.Image => NativeMethods.ironpress_converter_set_image_dpi(
+                converter, dotsPerInch, out error),
+            ResolutionKind.Filter => NativeMethods.ironpress_converter_set_filter_dpi(
+                converter, dotsPerInch, out error),
+            ResolutionKind.Mask => NativeMethods.ironpress_converter_set_mask_dpi(
+                converter, dotsPerInch, out error),
+            ResolutionKind.Background => NativeMethods.ironpress_converter_set_background_raster_dpi(
+                converter, dotsPerInch, out error),
+            _ => throw new UnreachableException(),
+        };
+        return Complete(status, error);
+    }
+
+    private unsafe HtmlConverter SetPageText(PageTextKind kind, string text)
+    {
+        EnsureOpen();
+        var encoded = Utf8Input.Encode(text, nameof(text));
+        fixed (byte* data = encoded)
+        {
+            var input = new NativeBytes((nint)data, (nuint)encoded.Length);
+            nint error;
+            var status = kind switch
+            {
+                PageTextKind.Header => NativeMethods.ironpress_converter_set_header(
+                    converter, input, out error),
+                PageTextKind.Footer => NativeMethods.ironpress_converter_set_footer(
+                    converter, input, out error),
+                _ => throw new UnreachableException(),
+            };
+            return Complete(status, error);
+        }
+    }
+
+    private static byte ToNativeBoolean(bool value) => value ? (byte)1 : (byte)0;
+
+    private enum ResolutionKind
+    {
+        Image,
+        Filter,
+        Mask,
+        Background,
+    }
+
+    private enum PageTextKind
+    {
+        Header,
+        Footer,
+    }
+}

--- a/bindings/dotnet/src/Ironpress/HtmlConverter.Conversion.cs
+++ b/bindings/dotnet/src/Ironpress/HtmlConverter.Conversion.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using Ironpress.Interop;
+
+namespace Ironpress;
+
+public sealed partial class HtmlConverter
+{
+    /// <summary>Convert UTF-16 .NET HTML text to owned PDF bytes.</summary>
+    public byte[] ConvertHtml(string html) => Convert(DocumentKind.Html, html, nameof(html));
+
+    /// <summary>Convert UTF-16 .NET Markdown text to owned PDF bytes.</summary>
+    public byte[] ConvertMarkdown(string markdown) =>
+        Convert(DocumentKind.Markdown, markdown, nameof(markdown));
+
+    private unsafe byte[] Convert(DocumentKind kind, string source, string parameterName)
+    {
+        EnsureOpen();
+        var encoded = Utf8Input.Encode(source, parameterName);
+        fixed (byte* data = encoded)
+        {
+            var input = new NativeBytes((nint)data, (nuint)encoded.Length);
+            nint pdf;
+            nint error;
+            var status = kind switch
+            {
+                DocumentKind.Html => NativeMethods.ironpress_converter_convert_html(
+                    converter, input, out pdf, out error),
+                DocumentKind.Markdown => NativeMethods.ironpress_converter_convert_markdown(
+                    converter, input, out pdf, out error),
+                _ => throw new UnreachableException(),
+            };
+            return NativeResult.TakePdf(status, pdf, error);
+        }
+    }
+
+    private enum DocumentKind
+    {
+        Html,
+        Markdown,
+    }
+}

--- a/bindings/dotnet/src/Ironpress/HtmlConverter.Fonts.cs
+++ b/bindings/dotnet/src/Ironpress/HtmlConverter.Fonts.cs
@@ -1,0 +1,46 @@
+using Ironpress.Interop;
+
+namespace Ironpress;
+
+public sealed partial class HtmlConverter
+{
+    /// <summary>Add or replace one custom TrueType font family.</summary>
+    /// <param name="family">The CSS font-family name.</param>
+    /// <param name="fontData">Raw TrueType font bytes.</param>
+    public unsafe HtmlConverter AddFont(string family, ReadOnlySpan<byte> fontData)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(family);
+        if (fontData.IsEmpty)
+        {
+            throw new ArgumentException("Font data must not be empty.", nameof(fontData));
+        }
+        EnsureOpen();
+
+        var encodedFamily = Utf8Input.Encode(family, nameof(family));
+        fixed (byte* familyData = encodedFamily)
+        fixed (byte* fontBytes = fontData)
+        {
+            var status = NativeMethods.ironpress_converter_add_font(
+                converter,
+                new NativeBytes((nint)familyData, (nuint)encodedFamily.Length),
+                new NativeBytes((nint)fontBytes, (nuint)fontData.Length),
+                out var error);
+            return Complete(status, error);
+        }
+    }
+
+    /// <summary>Parse and install one optional CJK or emoji fallback pack.</summary>
+    public unsafe HtmlConverter AddFontPack(FontPackKind kind, ReadOnlySpan<byte> fontData)
+    {
+        EnsureOpen();
+        fixed (byte* fontBytes = fontData)
+        {
+            var status = NativeMethods.ironpress_converter_add_font_pack(
+                converter,
+                (uint)kind,
+                new NativeBytes((nint)fontBytes, (nuint)fontData.Length),
+                out var error);
+            return Complete(status, error);
+        }
+    }
+}

--- a/bindings/dotnet/src/Ironpress/HtmlConverter.cs
+++ b/bindings/dotnet/src/Ironpress/HtmlConverter.cs
@@ -1,0 +1,34 @@
+using Ironpress.Interop;
+
+namespace Ironpress;
+
+/// <summary>A reusable, configured HTML and Markdown to PDF converter.</summary>
+/// <remarks>
+/// A converter owns one native handle. It may move between threads while idle,
+/// but its methods and <see cref="Dispose"/> must not run concurrently.
+/// </remarks>
+public sealed partial class HtmlConverter : IDisposable
+{
+    private readonly ConverterHandle converter;
+
+    /// <summary>Create a converter with safe defaults and no resource access.</summary>
+    public HtmlConverter()
+    {
+        SupportedPlatform.EnsureCurrent();
+        IronpressInfo.EnsureCompatibleAbi();
+        var status = NativeMethods.ironpress_converter_new(out var owner, out var error);
+        converter = NativeResult.TakeConverter(status, owner, error);
+    }
+
+    /// <summary>Release the native converter deterministically.</summary>
+    public void Dispose() => converter.Dispose();
+
+    private void EnsureOpen() =>
+        ObjectDisposedException.ThrowIf(converter.IsClosed, this);
+
+    private HtmlConverter Complete(NativeStatus status, nint error)
+    {
+        NativeResult.EnsureSuccess(status, error);
+        return this;
+    }
+}

--- a/bindings/dotnet/src/Ironpress/Interop/NativeBytes.cs
+++ b/bindings/dotnet/src/Ironpress/Interop/NativeBytes.cs
@@ -1,0 +1,17 @@
+using System.Runtime.InteropServices;
+
+namespace Ironpress.Interop;
+
+[StructLayout(LayoutKind.Sequential)]
+internal readonly struct NativeBytes
+{
+    internal NativeBytes(nint data, nuint length)
+    {
+        Data = data;
+        Length = length;
+    }
+
+    internal readonly nint Data;
+
+    internal readonly nuint Length;
+}

--- a/bindings/dotnet/src/Ironpress/Interop/NativeMethods.cs
+++ b/bindings/dotnet/src/Ironpress/Interop/NativeMethods.cs
@@ -1,0 +1,192 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Ironpress.Interop;
+
+internal static partial class NativeMethods
+{
+    private const string LibraryName = "ironpress_ffi";
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial uint ironpress_abi_version();
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial nint ironpress_version();
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_new(
+        out nint converter,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_free(ref nint converter);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_page_size(
+        ConverterHandle converter,
+        uint pageSize,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_page_size_custom(
+        ConverterHandle converter,
+        float width,
+        float height,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_margin(
+        ConverterHandle converter,
+        float points,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_margins(
+        ConverterHandle converter,
+        float top,
+        float right,
+        float bottom,
+        float left,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_compress(
+        ConverterHandle converter,
+        byte enabled,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_jpeg_quality(
+        ConverterHandle converter,
+        byte quality,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_auto_resize_images(
+        ConverterHandle converter,
+        byte enabled,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_image_dpi(
+        ConverterHandle converter,
+        float dpi,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_filter_dpi(
+        ConverterHandle converter,
+        float dpi,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_mask_dpi(
+        ConverterHandle converter,
+        float dpi,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_background_raster_dpi(
+        ConverterHandle converter,
+        float dpi,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_occlusion_cull(
+        ConverterHandle converter,
+        byte enabled,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_sanitize(
+        ConverterHandle converter,
+        byte enabled,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_header(
+        ConverterHandle converter,
+        NativeBytes header,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_set_footer(
+        ConverterHandle converter,
+        NativeBytes footer,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_add_font(
+        ConverterHandle converter,
+        NativeBytes family,
+        NativeBytes fontData,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_add_font_pack(
+        ConverterHandle converter,
+        uint kind,
+        NativeBytes fontData,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_convert_html(
+        ConverterHandle converter,
+        NativeBytes html,
+        out nint pdf,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_converter_convert_markdown(
+        ConverterHandle converter,
+        NativeBytes markdown,
+        out nint pdf,
+        out nint error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial nint ironpress_buffer_data(BufferHandle buffer);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial nuint ironpress_buffer_len(BufferHandle buffer);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_buffer_free(ref nint buffer);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial nint ironpress_error_message_data(ErrorHandle error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial nuint ironpress_error_message_len(ErrorHandle error);
+
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial NativeStatus ironpress_error_free(ref nint error);
+}

--- a/bindings/dotnet/src/Ironpress/Interop/NativeResult.cs
+++ b/bindings/dotnet/src/Ironpress/Interop/NativeResult.cs
@@ -1,0 +1,126 @@
+using System.Runtime.InteropServices;
+
+namespace Ironpress.Interop;
+
+internal static class NativeResult
+{
+    internal static void EnsureSuccess(NativeStatus status, nint error)
+    {
+        using var errorOwner = ErrorHandle.Take(error);
+
+        if (status == NativeStatus.Ok && errorOwner.IsInvalid)
+        {
+            return;
+        }
+
+        if (status == NativeStatus.Ok)
+        {
+            throw ContractViolation("A successful native call returned an error owner.");
+        }
+
+        var message = errorOwner.IsInvalid
+            ? $"Ironpress failed with native status {(int)status}."
+            : ReadErrorMessage(errorOwner);
+        throw new IronpressException(ToPublicKind(status), (int)status, message);
+    }
+
+    internal static ConverterHandle TakeConverter(
+        NativeStatus status,
+        nint converter,
+        nint error)
+    {
+        var converterOwner = ConverterHandle.Take(converter);
+        try
+        {
+            EnsureSuccess(status, error);
+            if (converterOwner.IsInvalid)
+            {
+                throw ContractViolation("Native converter allocation returned no owner.");
+            }
+
+            return converterOwner;
+        }
+        catch
+        {
+            converterOwner.Dispose();
+            throw;
+        }
+    }
+
+    internal static byte[] TakePdf(NativeStatus status, nint pdf, nint error)
+    {
+        using var pdfOwner = BufferHandle.Take(pdf);
+        EnsureSuccess(status, error);
+
+        if (pdfOwner.IsInvalid)
+        {
+            throw ContractViolation("Native conversion returned no PDF owner.");
+        }
+
+        return CopyBytes(pdfOwner);
+    }
+
+    private static byte[] CopyBytes(BufferHandle buffer)
+    {
+        var length = NativeMethods.ironpress_buffer_len(buffer);
+        if (length > int.MaxValue)
+        {
+            throw ContractViolation("Native PDF exceeds the managed array limit.");
+        }
+
+        var byteCount = (int)length;
+        var data = NativeMethods.ironpress_buffer_data(buffer);
+        if (byteCount > 0 && data == nint.Zero)
+        {
+            throw ContractViolation("Native PDF bytes are absent.");
+        }
+
+        var bytes = new byte[byteCount];
+        if (byteCount > 0)
+        {
+            Marshal.Copy(data, bytes, 0, byteCount);
+        }
+
+        return bytes;
+    }
+
+    private static string ReadErrorMessage(ErrorHandle error)
+    {
+        var length = NativeMethods.ironpress_error_message_len(error);
+        if (length > int.MaxValue)
+        {
+            return "Ironpress returned an oversized native diagnostic.";
+        }
+
+        var byteCount = (int)length;
+        var data = NativeMethods.ironpress_error_message_data(error);
+        if (byteCount == 0 || data == nint.Zero)
+        {
+            return "Ironpress returned an empty native diagnostic.";
+        }
+
+        return Marshal.PtrToStringUTF8(data, byteCount)
+            ?? "Ironpress returned an invalid native diagnostic.";
+    }
+
+    private static IronpressErrorKind ToPublicKind(NativeStatus status) => status switch
+    {
+        NativeStatus.InvalidArgument => IronpressErrorKind.InvalidArgument,
+        NativeStatus.InvalidUtf8 => IronpressErrorKind.InvalidUtf8,
+        NativeStatus.InvalidEnum => IronpressErrorKind.InvalidEnum,
+        NativeStatus.InvalidHandle => IronpressErrorKind.InvalidHandle,
+        NativeStatus.OutputNotEmpty => IronpressErrorKind.OutputNotEmpty,
+        NativeStatus.Parse => IronpressErrorKind.Parse,
+        NativeStatus.Css => IronpressErrorKind.Css,
+        NativeStatus.Layout => IronpressErrorKind.Layout,
+        NativeStatus.Render => IronpressErrorKind.Render,
+        NativeStatus.Font => IronpressErrorKind.Font,
+        NativeStatus.Io => IronpressErrorKind.Io,
+        NativeStatus.Security => IronpressErrorKind.Security,
+        NativeStatus.Internal => IronpressErrorKind.Internal,
+        _ => IronpressErrorKind.Unknown,
+    };
+
+    private static IronpressException ContractViolation(string message) =>
+        new(IronpressErrorKind.Internal, (int)NativeStatus.Internal, message);
+}

--- a/bindings/dotnet/src/Ironpress/Interop/NativeStatus.cs
+++ b/bindings/dotnet/src/Ironpress/Interop/NativeStatus.cs
@@ -1,0 +1,19 @@
+namespace Ironpress.Interop;
+
+internal enum NativeStatus
+{
+    Ok = 0,
+    InvalidArgument = 1,
+    InvalidUtf8 = 2,
+    InvalidEnum = 3,
+    InvalidHandle = 4,
+    OutputNotEmpty = 5,
+    Parse = 10,
+    Css = 11,
+    Layout = 12,
+    Render = 13,
+    Font = 14,
+    Io = 15,
+    Security = 16,
+    Internal = 255,
+}

--- a/bindings/dotnet/src/Ironpress/Interop/OwnedHandles.cs
+++ b/bindings/dotnet/src/Ironpress/Interop/OwnedHandles.cs
@@ -1,0 +1,68 @@
+using System.Runtime.InteropServices;
+
+namespace Ironpress.Interop;
+
+internal abstract class OwnedHandle : SafeHandle
+{
+    protected OwnedHandle(nint ownedHandle)
+        : base(nint.Zero, true)
+    {
+        SetHandle(ownedHandle);
+    }
+
+    public sealed override bool IsInvalid => handle == nint.Zero;
+}
+
+internal sealed class ConverterHandle : OwnedHandle
+{
+    private ConverterHandle(nint ownedHandle)
+        : base(ownedHandle)
+    {
+    }
+
+    internal static ConverterHandle Take(nint ownedHandle) => new(ownedHandle);
+
+    protected override bool ReleaseHandle()
+    {
+        var ownedHandle = handle;
+        var status = NativeMethods.ironpress_converter_free(ref ownedHandle);
+        handle = ownedHandle;
+        return status == NativeStatus.Ok && IsInvalid;
+    }
+}
+
+internal sealed class BufferHandle : OwnedHandle
+{
+    private BufferHandle(nint ownedHandle)
+        : base(ownedHandle)
+    {
+    }
+
+    internal static BufferHandle Take(nint ownedHandle) => new(ownedHandle);
+
+    protected override bool ReleaseHandle()
+    {
+        var ownedHandle = handle;
+        var status = NativeMethods.ironpress_buffer_free(ref ownedHandle);
+        handle = ownedHandle;
+        return status == NativeStatus.Ok && IsInvalid;
+    }
+}
+
+internal sealed class ErrorHandle : OwnedHandle
+{
+    private ErrorHandle(nint ownedHandle)
+        : base(ownedHandle)
+    {
+    }
+
+    internal static ErrorHandle Take(nint ownedHandle) => new(ownedHandle);
+
+    protected override bool ReleaseHandle()
+    {
+        var ownedHandle = handle;
+        var status = NativeMethods.ironpress_error_free(ref ownedHandle);
+        handle = ownedHandle;
+        return status == NativeStatus.Ok && IsInvalid;
+    }
+}

--- a/bindings/dotnet/src/Ironpress/Interop/SupportedPlatform.cs
+++ b/bindings/dotnet/src/Ironpress/Interop/SupportedPlatform.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+
+namespace Ironpress.Interop;
+
+internal static class SupportedPlatform
+{
+    internal static void EnsureCurrent()
+    {
+        var architecture = RuntimeInformation.ProcessArchitecture;
+        var supported =
+            (OperatingSystem.IsLinux() && architecture is Architecture.X64 or Architecture.Arm64)
+            || (OperatingSystem.IsMacOS() && architecture is Architecture.X64 or Architecture.Arm64)
+            || (OperatingSystem.IsWindows() && architecture == Architecture.X64);
+
+        if (!supported)
+        {
+            throw new PlatformNotSupportedException(
+                $"Ironpress does not ship native assets for {RuntimeInformation.RuntimeIdentifier}.");
+        }
+    }
+}

--- a/bindings/dotnet/src/Ironpress/Interop/Utf8Input.cs
+++ b/bindings/dotnet/src/Ironpress/Interop/Utf8Input.cs
@@ -1,0 +1,25 @@
+using System.Text;
+
+namespace Ironpress.Interop;
+
+internal static class Utf8Input
+{
+    private static readonly Encoding StrictEncoding = new UTF8Encoding(false, true);
+
+    internal static byte[] Encode(string value, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(value, parameterName);
+
+        try
+        {
+            return StrictEncoding.GetBytes(value);
+        }
+        catch (EncoderFallbackException error)
+        {
+            throw new ArgumentException(
+                "Text must contain valid Unicode scalar values.",
+                parameterName,
+                error);
+        }
+    }
+}

--- a/bindings/dotnet/src/Ironpress/Ironpress.csproj
+++ b/bindings/dotnet/src/Ironpress/Ironpress.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <PackageId>Ironpress</PackageId>
+    <Version>1.5.4</Version>
+    <Authors>Paul Gaston Gouron and Ironpress contributors</Authors>
+    <Description>In-process HTML, CSS, and Markdown to PDF rendering for .NET.</Description>
+    <PackageTags>pdf;html;css;markdown;converter</PackageTags>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/gastongouron/ironpress</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/gastongouron/ironpress</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../../../LICENSE" Pack="true" PackagePath="/" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/src/Ironpress/Ironpress.csproj
+++ b/bindings/dotnet/src/Ironpress/Ironpress.csproj
@@ -10,6 +10,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <PackageId>Ironpress</PackageId>
+    <Title>Ironpress for .NET</Title>
     <Version>1.5.4</Version>
     <Authors>Paul Gaston Gouron and Ironpress contributors</Authors>
     <Description>In-process HTML, CSS, and Markdown to PDF rendering for .NET.</Description>
@@ -20,10 +21,35 @@
     <RepositoryUrl>https://github.com/gastongouron/ironpress</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <NativeAssetsRoot Condition="'$(NativeAssetsRoot)' == ''">$(MSBuildThisFileDirectory)../../native</NativeAssetsRoot>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="../../../../LICENSE" Pack="true" PackagePath="/" />
     <None Include="../../README.md" Pack="true" PackagePath="/" />
+    <None Include="$(NativeAssetsRoot)/linux-x64/libironpress_ffi.so"
+          Pack="true" PackagePath="runtimes/linux-x64/native/" />
+    <None Include="$(NativeAssetsRoot)/linux-arm64/libironpress_ffi.so"
+          Pack="true" PackagePath="runtimes/linux-arm64/native/" />
+    <None Include="$(NativeAssetsRoot)/osx-x64/libironpress_ffi.dylib"
+          Pack="true" PackagePath="runtimes/osx-x64/native/" />
+    <None Include="$(NativeAssetsRoot)/osx-arm64/libironpress_ffi.dylib"
+          Pack="true" PackagePath="runtimes/osx-arm64/native/" />
+    <None Include="$(NativeAssetsRoot)/win-x64/ironpress_ffi.dll"
+          Pack="true" PackagePath="runtimes/win-x64/native/" />
   </ItemGroup>
+
+  <Target Name="ValidateNativeAssets" BeforeTargets="Pack">
+    <ItemGroup>
+      <RequiredNativeAsset Include="$(NativeAssetsRoot)/linux-x64/libironpress_ffi.so" />
+      <RequiredNativeAsset Include="$(NativeAssetsRoot)/linux-arm64/libironpress_ffi.so" />
+      <RequiredNativeAsset Include="$(NativeAssetsRoot)/osx-x64/libironpress_ffi.dylib" />
+      <RequiredNativeAsset Include="$(NativeAssetsRoot)/osx-arm64/libironpress_ffi.dylib" />
+      <RequiredNativeAsset Include="$(NativeAssetsRoot)/win-x64/ironpress_ffi.dll" />
+    </ItemGroup>
+    <Error Condition="!Exists('%(RequiredNativeAsset.Identity)')"
+           Text="Required native asset is missing: %(RequiredNativeAsset.Identity)" />
+  </Target>
 </Project>

--- a/bindings/dotnet/src/Ironpress/IronpressErrorKind.cs
+++ b/bindings/dotnet/src/Ironpress/IronpressErrorKind.cs
@@ -1,0 +1,47 @@
+namespace Ironpress;
+
+/// <summary>A stable machine-readable Ironpress failure category.</summary>
+public enum IronpressErrorKind
+{
+    /// <summary>An unknown status from an incompatible native library.</summary>
+    Unknown = -1,
+
+    /// <summary>An argument violates the native contract.</summary>
+    InvalidArgument = 1,
+
+    /// <summary>Text is not valid UTF-8.</summary>
+    InvalidUtf8 = 2,
+
+    /// <summary>An integer does not identify a documented value.</summary>
+    InvalidEnum = 3,
+
+    /// <summary>A required native owner is absent.</summary>
+    InvalidHandle = 4,
+
+    /// <summary>An output owner was not empty.</summary>
+    OutputNotEmpty = 5,
+
+    /// <summary>The HTML parser rejected the document.</summary>
+    Parse = 10,
+
+    /// <summary>The CSS parser rejected the document.</summary>
+    Css = 11,
+
+    /// <summary>The layout engine could not lay out the document.</summary>
+    Layout = 12,
+
+    /// <summary>The PDF renderer could not produce the document.</summary>
+    Render = 13,
+
+    /// <summary>A font or fallback pack could not be parsed or embedded.</summary>
+    Font = 14,
+
+    /// <summary>A filesystem operation failed.</summary>
+    Io = 15,
+
+    /// <summary>The resource-security policy rejected the document.</summary>
+    Security = 16,
+
+    /// <summary>The native boundary caught an unexpected internal failure.</summary>
+    Internal = 255,
+}

--- a/bindings/dotnet/src/Ironpress/IronpressException.cs
+++ b/bindings/dotnet/src/Ironpress/IronpressException.cs
@@ -1,0 +1,18 @@
+namespace Ironpress;
+
+/// <summary>A categorized failure returned by the Ironpress renderer.</summary>
+public sealed class IronpressException : Exception
+{
+    internal IronpressException(IronpressErrorKind kind, int nativeStatus, string message)
+        : base(message)
+    {
+        Kind = kind;
+        NativeStatus = nativeStatus;
+    }
+
+    /// <summary>Gets the stable failure category.</summary>
+    public IronpressErrorKind Kind { get; }
+
+    /// <summary>Gets the numeric status returned by the native ABI.</summary>
+    public int NativeStatus { get; }
+}

--- a/bindings/dotnet/src/Ironpress/IronpressInfo.cs
+++ b/bindings/dotnet/src/Ironpress/IronpressInfo.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+using Ironpress.Interop;
+
+namespace Ironpress;
+
+/// <summary>Version information for the packaged Ironpress native library.</summary>
+public static class IronpressInfo
+{
+    /// <summary>The C ABI generation required by this managed package.</summary>
+    public const uint RequiredAbiVersion = 1;
+
+    /// <summary>Gets the C ABI generation implemented by the loaded native library.</summary>
+    public static uint AbiVersion => NativeMethods.ironpress_abi_version();
+
+    /// <summary>Gets the Ironpress package version from the loaded native library.</summary>
+    public static string Version
+    {
+        get
+        {
+            var version = Marshal.PtrToStringUTF8(NativeMethods.ironpress_version());
+            return version ?? throw new IronpressException(
+                IronpressErrorKind.Internal,
+                (int)NativeStatus.Internal,
+                "The native library returned no package version.");
+        }
+    }
+
+    internal static void EnsureCompatibleAbi()
+    {
+        var actual = AbiVersion;
+        if (actual != RequiredAbiVersion)
+        {
+            throw new PlatformNotSupportedException(
+                $"Ironpress ABI {RequiredAbiVersion} is required, but ABI {actual} was loaded.");
+        }
+    }
+}

--- a/bindings/dotnet/src/Ironpress/PageDimensions.cs
+++ b/bindings/dotnet/src/Ironpress/PageDimensions.cs
@@ -1,0 +1,42 @@
+namespace Ironpress;
+
+/// <summary>A positive finite custom page size measured in points.</summary>
+public sealed class PageDimensions
+{
+    private PageDimensions(float width, float height)
+    {
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>Gets the page width in points.</summary>
+    public float Width { get; }
+
+    /// <summary>Gets the page height in points.</summary>
+    public float Height { get; }
+
+    /// <summary>Create a custom page size from physical point dimensions.</summary>
+    /// <param name="width">Positive finite width in points.</param>
+    /// <param name="height">Positive finite height in points.</param>
+    /// <returns>A validated page-size value.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// A dimension is zero, negative, NaN, or infinite.
+    /// </exception>
+    public static PageDimensions FromPoints(float width, float height)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        if (!float.IsFinite(width))
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), "Page width must be finite.");
+        }
+
+        if (!float.IsFinite(height))
+        {
+            throw new ArgumentOutOfRangeException(nameof(height), "Page height must be finite.");
+        }
+
+        return new PageDimensions(width, height);
+    }
+}

--- a/bindings/dotnet/src/Ironpress/PageMargins.cs
+++ b/bindings/dotnet/src/Ironpress/PageMargins.cs
@@ -1,0 +1,47 @@
+namespace Ironpress;
+
+/// <summary>Finite physical page margins measured in points.</summary>
+public sealed class PageMargins
+{
+    private PageMargins(float top, float right, float bottom, float left)
+    {
+        Top = top;
+        Right = right;
+        Bottom = bottom;
+        Left = left;
+    }
+
+    /// <summary>Gets the top margin in points.</summary>
+    public float Top { get; }
+
+    /// <summary>Gets the right margin in points.</summary>
+    public float Right { get; }
+
+    /// <summary>Gets the bottom margin in points.</summary>
+    public float Bottom { get; }
+
+    /// <summary>Gets the left margin in points.</summary>
+    public float Left { get; }
+
+    /// <summary>Create four equal physical margins.</summary>
+    public static PageMargins Uniform(float points) =>
+        FromPoints(points, points, points, points);
+
+    /// <summary>Create physical margins in CSS clockwise order.</summary>
+    public static PageMargins FromPoints(float top, float right, float bottom, float left)
+    {
+        EnsureFinite(top, nameof(top));
+        EnsureFinite(right, nameof(right));
+        EnsureFinite(bottom, nameof(bottom));
+        EnsureFinite(left, nameof(left));
+        return new PageMargins(top, right, bottom, left);
+    }
+
+    private static void EnsureFinite(float value, string parameterName)
+    {
+        if (!float.IsFinite(value))
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "Page margins must be finite.");
+        }
+    }
+}

--- a/bindings/dotnet/src/Ironpress/PageSize.cs
+++ b/bindings/dotnet/src/Ironpress/PageSize.cs
@@ -1,0 +1,14 @@
+namespace Ironpress;
+
+/// <summary>Named physical page sizes understood by Ironpress.</summary>
+public enum PageSize
+{
+    /// <summary>ISO A4, 210 by 297 millimetres.</summary>
+    A4 = 1,
+
+    /// <summary>US Letter, 8.5 by 11 inches.</summary>
+    Letter = 2,
+
+    /// <summary>US Legal, 8.5 by 14 inches.</summary>
+    Legal = 3,
+}

--- a/bindings/dotnet/tests/Ironpress.Contract/Ironpress.Contract.csproj
+++ b/bindings/dotnet/tests/Ironpress.Contract/Ironpress.Contract.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UsePackedIronpress Condition="'$(UsePackedIronpress)' == ''">false</UsePackedIronpress>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UsePackedIronpress)' != 'true'">
+    <ProjectReference Include="../../src/Ironpress/Ironpress.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UsePackedIronpress)' == 'true'">
+    <PackageReference Include="Ironpress" Version="$(IronpressVersion)" />
+  </ItemGroup>
+
+  <Target Name="CopyDevelopmentNativeLibrary"
+          AfterTargets="Build"
+          Condition="'$(IronpressNativeLibrary)' != ''">
+    <Copy SourceFiles="$(IronpressNativeLibrary)" DestinationFolder="$(OutDir)" />
+  </Target>
+</Project>

--- a/bindings/dotnet/tests/Ironpress.Contract/Ironpress.Contract.csproj
+++ b/bindings/dotnet/tests/Ironpress.Contract/Ironpress.Contract.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UsePackedIronpress Condition="'$(UsePackedIronpress)' == ''">false</UsePackedIronpress>
+    <RestoreSources Condition="'$(UsePackedIronpress)' == 'true'">$(IronpressPackageSource)</RestoreSources>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePackedIronpress)' != 'true'">

--- a/bindings/dotnet/tests/Ironpress.Contract/Program.cs
+++ b/bindings/dotnet/tests/Ironpress.Contract/Program.cs
@@ -1,0 +1,170 @@
+using System.Text;
+using Ironpress;
+
+internal static class Program
+{
+    private static readonly (string Name, Action<string> Run)[] Tests =
+    [
+        ("native contract identifies the package and ABI", NativeContractMatchesPackage),
+        ("portable options compose into one conversion", PortableOptionsCompose),
+        ("font packs cross the managed boundary", FontPacksCrossManagedBoundary),
+        ("native failures retain their category", NativeFailuresRetainCategory),
+        ("disposed converters reject further work", DisposedConvertersRejectWork),
+        ("equivalent converters produce identical bytes", EquivalentConvertersMatch),
+        ("repeated ownership cycles remain valid", RepeatedOwnershipCyclesRemainValid),
+    ];
+
+    private static int Main(string[] arguments)
+    {
+        if (arguments.Length != 1)
+        {
+            Console.Error.WriteLine("Expected the font-pack fixture path.");
+            return 2;
+        }
+
+        foreach (var test in Tests)
+        {
+            try
+            {
+                test.Run(arguments[0]);
+                Console.WriteLine($"PASS: {test.Name}");
+            }
+            catch (Exception error)
+            {
+                Console.Error.WriteLine($"FAIL: {test.Name}\n{error}");
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    private static void NativeContractMatchesPackage(string _)
+    {
+        Equal(1u, IronpressInfo.AbiVersion, "Unexpected native ABI generation.");
+
+        var expectedVersion = Environment.GetEnvironmentVariable("IRONPRESS_EXPECTED_VERSION");
+        if (expectedVersion is not null)
+        {
+            Equal(expectedVersion, IronpressInfo.Version, "Native package version differs.");
+        }
+    }
+
+    private static void PortableOptionsCompose(string _)
+    {
+        using var converter = new HtmlConverter()
+            .SetPageSize(PageSize.Letter)
+            .SetCustomPageSize(PageDimensions.FromPoints(320, 480))
+            .SetMargins(PageMargins.FromPoints(12, 13, 14, 15))
+            .SetCompression(false)
+            .SetJpegQuality(82)
+            .SetAutomaticImageResize(false)
+            .SetImageResolution(144)
+            .SetFilterResolution(96)
+            .SetMaskResolution(144)
+            .SetBackgroundResolution(120)
+            .SetOcclusionCulling(true)
+            .SetSanitization(true)
+            .SetHeader("Contract header")
+            .SetFooter("Page {page} of {pages}");
+
+        var pdf = converter.ConvertHtml("<h1>.NET binding</h1>");
+        StartsWithPdf(pdf);
+        Contains(pdf, "/MediaBox [0 0 320 480]", "Custom page size was not applied.");
+
+        StartsWithPdf(converter.ConvertMarkdown("# Markdown binding"));
+    }
+
+    private static void FontPacksCrossManagedBoundary(string fixturePath)
+    {
+        using var converter = new HtmlConverter()
+            .AddFontPack(FontPackKind.CjkJapanese, File.ReadAllBytes(fixturePath));
+
+        var pdf = converter.ConvertHtml("<p lang='ja'>第</p>");
+        Contains(pdf, "DroidSansFallback", "The supplied fallback font was not embedded.");
+    }
+
+    private static void NativeFailuresRetainCategory(string _)
+    {
+        using var converter = new HtmlConverter();
+
+        var error = Throws<IronpressException>(() => converter.SetPageSize((PageSize)999));
+        Equal(IronpressErrorKind.InvalidEnum, error.Kind, "Native error category changed.");
+
+        Throws<ArgumentOutOfRangeException>(() => PageDimensions.FromPoints(0, 100));
+    }
+
+    private static void DisposedConvertersRejectWork(string _)
+    {
+        var converter = new HtmlConverter();
+        converter.Dispose();
+
+        Throws<ObjectDisposedException>(() => converter.ConvertHtml("<p>too late</p>"));
+    }
+
+    private static void EquivalentConvertersMatch(string _)
+    {
+        using var first = new HtmlConverter().SetCompression(false).SetMargin(24);
+        using var second = new HtmlConverter().SetCompression(false).SetMargin(24);
+
+        var source = "<h1>Deterministic contract</h1>";
+        SequenceEqual(first.ConvertHtml(source), second.ConvertHtml(source));
+    }
+
+    private static void RepeatedOwnershipCyclesRemainValid(string _)
+    {
+        for (var iteration = 0; iteration < 25; iteration++)
+        {
+            using var converter = new HtmlConverter();
+            StartsWithPdf(converter.ConvertHtml($"<p>cycle {iteration}</p>"));
+        }
+    }
+
+    private static void StartsWithPdf(byte[] bytes)
+    {
+        if (bytes.Length < 4 || Encoding.ASCII.GetString(bytes, 0, 4) != "%PDF")
+        {
+            throw new InvalidOperationException("Conversion did not return PDF bytes.");
+        }
+    }
+
+    private static void Contains(byte[] bytes, string expected, string message)
+    {
+        if (!Encoding.Latin1.GetString(bytes).Contains(expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private static TException Throws<TException>(Action action)
+        where TException : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (TException error)
+        {
+            return error;
+        }
+
+        throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
+    }
+
+    private static void Equal<T>(T expected, T actual, string message)
+        where T : notnull
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException($"{message} Expected {expected}, found {actual}.");
+        }
+    }
+
+    private static void SequenceEqual(byte[] expected, byte[] actual)
+    {
+        if (!expected.AsSpan().SequenceEqual(actual))
+        {
+            throw new InvalidOperationException("Equivalent configurations produced different PDFs.");
+        }
+    }
+}

--- a/bindings/dotnet/tests/Ironpress.Contract/Program.cs
+++ b/bindings/dotnet/tests/Ironpress.Contract/Program.cs
@@ -3,7 +3,7 @@ using Ironpress;
 
 internal static class Program
 {
-    private static readonly (string Name, Action<string> Run)[] Tests =
+    private static readonly (string Name, Action<TestContext> Run)[] Tests =
     [
         ("native contract identifies the package and ABI", NativeContractMatchesPackage),
         ("portable options compose into one conversion", PortableOptionsCompose),
@@ -16,17 +16,18 @@ internal static class Program
 
     private static int Main(string[] arguments)
     {
-        if (arguments.Length != 1)
+        if (arguments.Length != 2)
         {
-            Console.Error.WriteLine("Expected the font-pack fixture path.");
+            Console.Error.WriteLine("Expected the custom-font and font-pack fixture paths.");
             return 2;
         }
 
+        var context = new TestContext(arguments[0], arguments[1]);
         foreach (var test in Tests)
         {
             try
             {
-                test.Run(arguments[0]);
+                test.Run(context);
                 Console.WriteLine($"PASS: {test.Name}");
             }
             catch (Exception error)
@@ -39,7 +40,7 @@ internal static class Program
         return 0;
     }
 
-    private static void NativeContractMatchesPackage(string _)
+    private static void NativeContractMatchesPackage(TestContext _)
     {
         Equal(1u, IronpressInfo.AbiVersion, "Unexpected native ABI generation.");
 
@@ -50,7 +51,7 @@ internal static class Program
         }
     }
 
-    private static void PortableOptionsCompose(string _)
+    private static void PortableOptionsCompose(TestContext context)
     {
         using var converter = new HtmlConverter()
             .SetPageSize(PageSize.Letter)
@@ -66,35 +67,45 @@ internal static class Program
             .SetOcclusionCulling(true)
             .SetSanitization(true)
             .SetHeader("Contract header")
-            .SetFooter("Page {page} of {pages}");
+            .SetFooter("Page {page} of {pages}")
+            .AddFont("ParitySans", File.ReadAllBytes(context.CustomFontPath))
+            .AddFontPack(
+                FontPackKind.CjkJapanese,
+                File.ReadAllBytes(context.FontPackPath));
 
-        var pdf = converter.ConvertHtml("<h1>.NET binding</h1>");
+        var pdf = converter.ConvertHtml(
+            "<h1 style='font-family:ParitySans'>.NET binding</h1><p lang='ja'>第</p>");
         StartsWithPdf(pdf);
         Contains(pdf, "/MediaBox [0 0 320 480]", "Custom page size was not applied.");
 
         StartsWithPdf(converter.ConvertMarkdown("# Markdown binding"));
     }
 
-    private static void FontPacksCrossManagedBoundary(string fixturePath)
+    private static void FontPacksCrossManagedBoundary(TestContext context)
     {
         using var converter = new HtmlConverter()
-            .AddFontPack(FontPackKind.CjkJapanese, File.ReadAllBytes(fixturePath));
+            .AddFontPack(FontPackKind.CjkJapanese, File.ReadAllBytes(context.FontPackPath));
 
         var pdf = converter.ConvertHtml("<p lang='ja'>第</p>");
         Contains(pdf, "DroidSansFallback", "The supplied fallback font was not embedded.");
     }
 
-    private static void NativeFailuresRetainCategory(string _)
+    private static void NativeFailuresRetainCategory(TestContext _)
     {
         using var converter = new HtmlConverter();
 
         var error = Throws<IronpressException>(() => converter.SetPageSize((PageSize)999));
         Equal(IronpressErrorKind.InvalidEnum, error.Kind, "Native error category changed.");
 
+        var fontError = Throws<IronpressException>(() =>
+            converter.AddFontPack(FontPackKind.Emoji, "not a font"u8));
+        Equal(IronpressErrorKind.Font, fontError.Kind, "Font error category changed.");
+
         Throws<ArgumentOutOfRangeException>(() => PageDimensions.FromPoints(0, 100));
+        Throws<ArgumentException>(() => converter.SetHeader("\ud800"));
     }
 
-    private static void DisposedConvertersRejectWork(string _)
+    private static void DisposedConvertersRejectWork(TestContext _)
     {
         var converter = new HtmlConverter();
         converter.Dispose();
@@ -102,7 +113,7 @@ internal static class Program
         Throws<ObjectDisposedException>(() => converter.ConvertHtml("<p>too late</p>"));
     }
 
-    private static void EquivalentConvertersMatch(string _)
+    private static void EquivalentConvertersMatch(TestContext _)
     {
         using var first = new HtmlConverter().SetCompression(false).SetMargin(24);
         using var second = new HtmlConverter().SetCompression(false).SetMargin(24);
@@ -111,7 +122,7 @@ internal static class Program
         SequenceEqual(first.ConvertHtml(source), second.ConvertHtml(source));
     }
 
-    private static void RepeatedOwnershipCyclesRemainValid(string _)
+    private static void RepeatedOwnershipCyclesRemainValid(TestContext _)
     {
         for (var iteration = 0; iteration < 25; iteration++)
         {
@@ -167,4 +178,6 @@ internal static class Program
             throw new InvalidOperationException("Equivalent configurations produced different PDFs.");
         }
     }
+
+    private sealed record TestContext(string CustomFontPath, string FontPackPath);
 }

--- a/bindings/dotnet/tests/Ironpress.Contract/Program.cs
+++ b/bindings/dotnet/tests/Ironpress.Contract/Program.cs
@@ -102,6 +102,7 @@ internal static class Program
         Equal(IronpressErrorKind.Font, fontError.Kind, "Font error category changed.");
 
         Throws<ArgumentOutOfRangeException>(() => PageDimensions.FromPoints(0, 100));
+        Throws<ArgumentOutOfRangeException>(() => converter.SetMargin(float.NaN));
         Throws<ArgumentException>(() => converter.SetHeader("\ud800"));
     }
 

--- a/bindings/dotnet/verify-package.sh
+++ b/bindings/dotnet/verify-package.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <package.nupkg> <version>" >&2
+  exit 2
+fi
+
+PACKAGE="$1"
+VERSION="$2"
+
+if [[ ! -f "$PACKAGE" ]]; then
+  echo "NuGet package not found: $PACKAGE" >&2
+  exit 1
+fi
+
+REQUIRED_ENTRIES=(
+  "Ironpress.nuspec"
+  "LICENSE"
+  "README.md"
+  "lib/net8.0/Ironpress.dll"
+  "runtimes/linux-x64/native/libironpress_ffi.so"
+  "runtimes/linux-arm64/native/libironpress_ffi.so"
+  "runtimes/osx-x64/native/libironpress_ffi.dylib"
+  "runtimes/osx-arm64/native/libironpress_ffi.dylib"
+  "runtimes/win-x64/native/ironpress_ffi.dll"
+)
+
+PACKAGE_ENTRIES="$(unzip -Z1 "$PACKAGE")"
+for entry in "${REQUIRED_ENTRIES[@]}"; do
+  if ! grep -Fqx "$entry" <<<"$PACKAGE_ENTRIES"; then
+    echo "NuGet package is missing $entry" >&2
+    exit 1
+  fi
+done
+
+NATIVE_COUNT="$(grep -c '^runtimes/.*/native/' <<<"$PACKAGE_ENTRIES")"
+if [[ "$NATIVE_COUNT" -ne 5 ]]; then
+  echo "NuGet package must contain exactly five native assets; found $NATIVE_COUNT" >&2
+  exit 1
+fi
+
+if ! unzip -p "$PACKAGE" Ironpress.nuspec |
+  grep -Fq "<version>$VERSION</version>"; then
+  echo "NuGet manifest version does not match $VERSION" >&2
+  exit 1
+fi
+
+echo "NuGet package contract passed for Ironpress $VERSION."

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -5,6 +5,7 @@
 # Updates:
 #   Cargo.toml                          (ironpress crate)
 #   bindings/c/Cargo.toml               (ironpress-ffi internal crate)
+#   bindings/dotnet/src/Ironpress/Ironpress.csproj
 #   bindings/python/pyproject.toml      (PyPI wheel)
 #   bindings/python/Cargo.toml          (ironpress-python internal crate)
 #   bindings/ruby/lib/ironpress/version.rb
@@ -57,11 +58,17 @@ update_core_requirement() {
     perl -i -pe 'if (/^ironpress-core\s*=/) { s/version\s*=\s*"=[^"]+"/version = "='"$NEW"'"/ }' "$file"
 }
 
+update_dotnet_version() {
+    local file="$1"
+    perl -i -pe 's#(<Version>)[^<]+(</Version>)#$1'"$NEW"'$2#' "$file"
+}
+
 echo "Bumping to $NEW"
 
 bump_toml_version  "Cargo.toml"                        && echo "  Cargo.toml"
 bump_toml_version  "bindings/c/Cargo.toml"             && echo "  bindings/c/Cargo.toml"
 update_core_requirement "bindings/c/Cargo.toml"        && echo "  C core requirement"
+update_dotnet_version "bindings/dotnet/src/Ironpress/Ironpress.csproj" && echo "  .NET package"
 bump_pyproject     "bindings/python/pyproject.toml"    && echo "  bindings/python/pyproject.toml"
 bump_toml_version  "bindings/python/Cargo.toml"        && echo "  bindings/python/Cargo.toml"
 update_core_requirement "bindings/python/Cargo.toml"   && echo "  Python core requirement"

--- a/scripts/check-release-versions.sh
+++ b/scripts/check-release-versions.sh
@@ -25,6 +25,11 @@ core_requirement() {
   sed -n 's/^ironpress-core.*version[[:space:]]*=[[:space:]]*"=\([^"]*\)".*/\1/p' "$1"
 }
 
+dotnet_version() {
+  sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' "$1" |
+    head -n 1
+}
+
 if [[ -n "${1:-}" ]]; then
   EXPECTED_VERSION="$1"
 elif [[ "${GITHUB_REF_TYPE:-}" == "tag" && "${GITHUB_REF_NAME:-}" == v* ]]; then
@@ -47,6 +52,7 @@ check_version() {
 check_version "Rust crate" "$(package_version Cargo.toml)"
 check_version "C crate" "$(package_version bindings/c/Cargo.toml)"
 check_version "C core requirement" "$(core_requirement bindings/c/Cargo.toml)"
+check_version ".NET package" "$(dotnet_version bindings/dotnet/src/Ironpress/Ironpress.csproj)"
 check_version "Python crate" "$(package_version bindings/python/Cargo.toml)"
 check_version "Python distribution" "$(package_version bindings/python/pyproject.toml)"
 check_version "Python core requirement" "$(core_requirement bindings/python/Cargo.toml)"

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -30,6 +30,7 @@ const pages = [
     ["rust", ["cargo add ironpress", "use ironpress::html_to_pdf;"]],
     ["cli", ["cargo install ironpress", "ironpress invoice.html invoice.pdf"]],
     ["c", ['#include "ironpress.h"', "ironpress_html_to_pdf", "ironpress_buffer_free"]],
+    ["dotnet", ["dotnet add package Ironpress", "new HtmlConverter", "using var"]],
     ["python", ["python -m pip install ironpress", "ironpress.html_to_pdf"]],
     ["ruby", ["gem install ironpress", "Ironpress.html_to_pdf"]],
     ["browser", ["npm install ironpress", 'from "ironpress";', "await init();", "converter.free();"]],
@@ -286,6 +287,7 @@ if (bindingsReadme !== null) {
   for (const runtime of [
     "rust",
     "cli",
+    "dotnet",
     "python",
     "ruby",
     "browser",

--- a/site/get-started/dotnet/index.html
+++ b/site/get-started/dotnet/index.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>.NET Getting Started: HTML and Markdown to PDF | ironpress</title>
+    <meta
+      name="description"
+      content="Install ironpress from NuGet, render HTML or Markdown to PDF bytes, configure a reusable converter, and manage native ownership safely."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/dotnet/">
+    <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png">
+    <meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="article"><meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with ironpress in .NET">
+    <meta property="og:description" content="Render PDF bytes through a managed facade and packaged native library.">
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/dotnet/">
+    <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png">
+    <meta property="og:image:alt" content="ironpress logo"><meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../../assets/styles.css"><link rel="stylesheet" href="../../assets/guide.css"><link rel="stylesheet" href="../../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Get Started with ironpress in .NET",
+        "description": "Install the NuGet package and generate PDF bytes from HTML or Markdown in .NET.",
+        "author": { "@type": "Person", "name": "Gaston Gouron", "url": "https://github.com/gastongouron" },
+        "publisher": { "@type": "Organization", "name": "ironpress", "url": "https://gastongouron.github.io/ironpress/" },
+        "mainEntityOfPage": "https://gastongouron.github.io/ironpress/get-started/dotnet/",
+        "inLanguage": "en"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#article">Skip to article</a>
+    <header class="site-header">
+      <div class="shell header-inner">
+        <a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="44" height="44"><span>ironpress</span></a>
+        <nav aria-label="Primary navigation"><a href="../" aria-current="page">Get started</a><a href="../../guides/html-to-pdf-rust/">Guide</a><a href="../../playground/">Playground</a><a class="nav-github" href="https://github.com/gastongouron/ironpress">GitHub <span aria-hidden="true">↗</span></a></nav>
+      </div>
+    </header>
+
+    <main class="guide-main" id="article">
+      <div class="shell">
+        <header class="guide-hero">
+          <p class="eyebrow"><span></span> .NET getting started</p>
+          <h1>Generate PDF bytes<br><em>from .NET</em></h1>
+          <p>Install one managed package and run the native Rust renderer inside your process.</p>
+          <span class="runtime-type">.NET 8+ · NuGet · Linux, macOS, Windows</span>
+        </header>
+
+        <div class="guide-layout">
+          <aside class="guide-toc" aria-label="Article contents"><p>In this guide</p><ol><li><a href="#install">Install</a></li><li><a href="#first-pdf">First PDF</a></li><li><a href="#markdown">Markdown</a></li><li><a href="#configure">Configure</a></li><li><a href="#resources">Resources</a></li><li><a href="#limits">Limits and errors</a></li><li><a href="#next">Next steps</a></li></ol></aside>
+
+          <article class="prose">
+            <h2 id="install">Install from NuGet</h2>
+            <p>Add the package to any .NET 8 or newer project. NuGet selects the native asset for the current runtime identifier.</p>
+            <pre><code>dotnet add package Ironpress</code></pre>
+            <p>The package supports Linux x64 and ARM64 with glibc 2.28 or newer, macOS x64 and ARM64, and Windows x64.</p>
+
+            <h2 id="first-pdf">Create an HTML PDF</h2>
+            <pre><code>using Ironpress;
+
+using var converter = new HtmlConverter();
+byte[] pdf = converter.ConvertHtml(
+    "&lt;h1&gt;Hello from .NET&lt;/h1&gt;"
+);
+
+File.WriteAllBytes("output.pdf", pdf);</code></pre>
+            <div class="guide-callout"><strong>Deterministic ownership</strong><p>The managed converter uses a safe native handle. A <code>using</code> declaration releases it deterministically and the runtime retains a final safety net.</p></div>
+
+            <h2 id="markdown">Render Markdown</h2>
+            <p>The same configured converter accepts Markdown and returns an owned byte array:</p>
+            <pre><code>byte[] pdf = converter.ConvertMarkdown(
+    "# Release notes\n\nEverything shipped."
+);</code></pre>
+
+            <h2 id="configure">Reuse a configured converter</h2>
+            <p>Configuration methods return the same converter, so related page and quality choices remain readable together.</p>
+            <pre><code>using var converter = new HtmlConverter()
+    .SetPageSize(PageSize.Letter)
+    .SetMargins(PageMargins.FromPoints(36, 36, 48, 36))
+    .SetCompression(true)
+    .SetImageResolution(144)
+    .SetSanitization(true)
+    .SetHeader("Quarterly report")
+    .SetFooter("Page {page} of {pages}");
+
+byte[] first = converter.ConvertHtml(firstDocument);
+byte[] second = converter.ConvertHtml(secondDocument);</code></pre>
+
+            <h2 id="resources">Provide fonts as bytes</h2>
+            <p>The managed API accepts custom TrueType fonts and optional CJK or emoji packs as bytes. It never downloads a font implicitly.</p>
+            <pre><code>using var converter = new HtmlConverter()
+    .AddFont("MyFont", File.ReadAllBytes("MyFont.ttf"))
+    .AddFontPack(
+        FontPackKind.CjkJapanese,
+        File.ReadAllBytes("ironpress-font-cjk-jp.ttf")
+    );</code></pre>
+
+            <h2 id="limits">Handle failures and runtime limits</h2>
+            <p>Renderer failures throw <code>IronpressException</code>. Its <code>Kind</code> keeps the stable parse, layout, render, font, security, or argument category.</p>
+            <ul class="guide-checklist">
+              <li>HTML sanitization is enabled by default.</li>
+              <li>Converters must not be used or disposed concurrently.</li>
+              <li>Local paths, direct file output, async, streaming, and remote HTTP are absent.</li>
+              <li>The managed package verifies ABI generation 1 before allocating a converter.</li>
+            </ul>
+
+            <h2 id="next">Go further</h2>
+            <div class="guide-links">
+              <a href="https://www.nuget.org/packages/Ironpress">Package on NuGet</a><a href="https://github.com/gastongouron/ironpress/tree/main/bindings/dotnet">.NET binding reference</a><a href="https://github.com/gastongouron/ironpress/blob/main/bindings/c/ABI.md">Native ABI contract</a><a href="https://github.com/gastongouron/ironpress/blob/main/bindings/README.md">Capability matrix</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site-footer"><div class="shell footer-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="36" height="36"><span>ironpress</span></a><p>Pure-Rust document rendering. Open source under MIT.</p><nav aria-label="Footer navigation"><a href="../">All runtimes</a><a href="https://www.nuget.org/packages/Ironpress">NuGet</a><a href="../../parity/reports/">Parity</a></nav></div></footer>
+  </body>
+</html>

--- a/site/get-started/index.html
+++ b/site/get-started/index.html
@@ -6,7 +6,7 @@
     <title>Get Started with ironpress in Your Runtime</title>
     <meta
       name="description"
-      content="Choose a complete ironpress getting-started guide for Rust, C, the CLI, Python, Ruby, browser JavaScript, TypeScript, or Node.js."
+      content="Choose an ironpress guide for Rust, C, .NET, the CLI, Python, Ruby, browser JavaScript, TypeScript, or Node.js."
     >
     <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/">
     <link rel="icon" type="image/png" href="../assets/ironpress-logo.png">
@@ -40,10 +40,11 @@
             { "@type": "ListItem", "position": 1, "name": "Rust", "url": "https://gastongouron.github.io/ironpress/get-started/rust/" },
             { "@type": "ListItem", "position": 2, "name": "C", "url": "https://gastongouron.github.io/ironpress/get-started/c/" },
             { "@type": "ListItem", "position": 3, "name": "CLI", "url": "https://gastongouron.github.io/ironpress/get-started/cli/" },
-            { "@type": "ListItem", "position": 4, "name": "Python", "url": "https://gastongouron.github.io/ironpress/get-started/python/" },
-            { "@type": "ListItem", "position": 5, "name": "Ruby", "url": "https://gastongouron.github.io/ironpress/get-started/ruby/" },
-            { "@type": "ListItem", "position": 6, "name": "Browser JavaScript", "url": "https://gastongouron.github.io/ironpress/get-started/browser/" },
-            { "@type": "ListItem", "position": 7, "name": "Node.js", "url": "https://gastongouron.github.io/ironpress/get-started/node/" }
+            { "@type": "ListItem", "position": 4, "name": ".NET", "url": "https://gastongouron.github.io/ironpress/get-started/dotnet/" },
+            { "@type": "ListItem", "position": 5, "name": "Python", "url": "https://gastongouron.github.io/ironpress/get-started/python/" },
+            { "@type": "ListItem", "position": 6, "name": "Ruby", "url": "https://gastongouron.github.io/ironpress/get-started/ruby/" },
+            { "@type": "ListItem", "position": 7, "name": "Browser JavaScript", "url": "https://gastongouron.github.io/ironpress/get-started/browser/" },
+            { "@type": "ListItem", "position": 8, "name": "Node.js", "url": "https://gastongouron.github.io/ironpress/get-started/node/" }
           ]
         }
       }
@@ -73,7 +74,7 @@
       <div class="shell">
         <header class="get-started-hero">
           <div>
-            <p class="eyebrow"><span></span> One engine, seven paths</p>
+            <p class="eyebrow"><span></span> One engine, eight paths</p>
             <h1>Your first PDF.<br><em>Your runtime.</em></h1>
             <p class="get-started-lede">
               Pick the environment you already ship. Every guide starts from a
@@ -124,6 +125,12 @@
               <a href="./python/">Start with Python</a>
             </article>
             <article class="runtime-path">
+              <div class="runtime-path-top"><span class="runtime-label">Binding</span><span class="runtime-package">NuGet</span></div>
+              <h3>.NET</h3>
+              <p>Install one managed package with its native library for Linux, macOS, or Windows.</p>
+              <a href="./dotnet/">Start with .NET</a>
+            </article>
+            <article class="runtime-path">
               <div class="runtime-path-top"><span class="runtime-label">Binding</span><span class="runtime-package">RubyGems</span></div>
               <h3>Ruby</h3>
               <p>Use an idiomatic chainable converter backed by the same native Rust engine and package contract.</p>
@@ -170,14 +177,14 @@
           <div class="prose">
             <table class="capability-table">
               <thead>
-                <tr><th>Capability</th><th>Rust</th><th>CLI</th><th>C</th><th>Python</th><th>Ruby</th><th>WASM</th></tr>
+                <tr><th>Capability</th><th>Rust</th><th>CLI</th><th>C</th><th>.NET</th><th>Python</th><th>Ruby</th><th>WASM</th></tr>
               </thead>
               <tbody>
-                <tr><td>PDF bytes</td><td class="capability-yes">Yes</td><td class="capability-no">File</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td></tr>
-                <tr><td>Local resources</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td></tr>
-                <tr><td>Direct file output</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td></tr>
-                <tr><td>Streaming or async</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
-                <tr><td>Remote HTTP</td><td>Opt-in</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
+                <tr><td>PDF bytes</td><td class="capability-yes">Yes</td><td class="capability-no">File</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td></tr>
+                <tr><td>Local resources</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td><td class="capability-no">Host bytes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td></tr>
+                <tr><td>Direct file output</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td></tr>
+                <tr><td>Streaming or async</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
+                <tr><td>Remote HTTP</td><td>Opt-in</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
               </tbody>
             </table>
           </div>

--- a/site/index.html
+++ b/site/index.html
@@ -48,7 +48,7 @@
             "name": "ironpress",
             "codeRepository": "https://github.com/gastongouron/ironpress",
             "programmingLanguage": "Rust",
-            "runtimePlatform": ["Rust", "C", "Command line", "Python", "Ruby", "Web browser", "Node.js"],
+            "runtimePlatform": ["Rust", "C", ".NET", "Command line", "Python", "Ruby", "Web browser", "Node.js"],
             "license": "https://opensource.org/license/mit",
             "description": "An in-process HTML, CSS, and Markdown to PDF engine written in Rust."
           }
@@ -148,7 +148,7 @@
           <p><strong>0.93 ms</strong><span>simple HTML median</span></p>
           <p><strong>3,200+</strong><span>tests</span></p>
           <p><strong>1,664</strong><span>parity fixtures</span></p>
-          <p><strong>6</strong><span>runtime paths</span></p>
+          <p><strong>8</strong><span>runtime paths</span></p>
         </div>
       </section>
 
@@ -198,11 +198,11 @@
               <span class="feature-number">04</span>
               <h3>Multiple runtimes</h3>
               <p>
-                Use the same core from Rust, C, the CLI, Python, Ruby, browser
-                WebAssembly, or Node.js.
+                Use the same core from Rust, C, .NET, the CLI, Python, Ruby,
+                browser WebAssembly, or Node.js.
               </p>
               <ul class="runtime-list" aria-label="Supported runtimes">
-                <li>Rust</li><li>C</li><li>CLI</li><li>Python</li><li>Ruby</li><li>Browser</li><li>Node.js</li>
+                <li>Rust</li><li>C</li><li>.NET</li><li>CLI</li><li>Python</li><li>Ruby</li><li>Browser</li><li>Node.js</li>
               </ul>
             </article>
             <article class="feature-card">
@@ -261,6 +261,17 @@ IronpressStatus status =
 pdf = ironpress.html_to_pdf(
     <em>"&lt;h1&gt;Hello&lt;/h1&gt;"</em>
 )</code></pre>
+            </article>
+            <article class="code-card">
+              <p><span>.NET</span><a href="./get-started/dotnet/">guide →</a></p>
+              <pre><code><b>using</b> Ironpress;
+
+<b>using var</b> converter =
+  <b>new</b> HtmlConverter();
+
+<b>byte</b>[] pdf = converter.ConvertHtml(
+  <em>"&lt;h1&gt;Hello&lt;/h1&gt;"</em>
+);</code></pre>
             </article>
             <article class="code-card">
               <p><span>Ruby</span><a href="https://rubygems.org/gems/ironpress">RubyGems ↗</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -31,6 +31,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/dotnet/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://gastongouron.github.io/ironpress/get-started/python/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
## Summary

- add an idiomatic .NET 8 `HtmlConverter` facade over the stable C ABI
- own native converters, buffers, and diagnostics with `SafeHandle`
- map native status codes to categorized `IronpressException` errors
- pack one NuGet artifact for Linux, macOS, and Windows
- install and exercise the packed artifact on every supported RID
- publish through NuGet trusted publishing on a GitHub release
- document installation, configuration, fonts, limits, and ownership

## Native platforms

- `linux-x64` with glibc 2.28 or newer
- `linux-arm64` with glibc 2.28 or newer
- `osx-x64`
- `osx-arm64`
- `win-x64`

## Verification

- packed NuGet consumer contract on macOS ARM64
- package layout and version contract
- .NET build and formatting with zero warnings
- Rust 1.88 Clippy and C ABI tests
- release metadata and public-site contracts

This completes the .NET phase of #228 without closing the wider bindings roadmap.
