### PR TITLE
chore: finalize the 1.5.4 release

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -28,8 +28,8 @@ jobs:
           fetch-depth: 0
 
       # Keep the required check present: workflows skipped by a top-level path
-      # filter remain pending on GitHub. Website-only changes instead complete
-      # this job without running the expensive renderer parity suite.
+      # filter remain pending on GitHub. Documentation-only changes instead
+      # complete this job without running the expensive renderer parity suite.
       - name: Detect parity-relevant changes
         id: changes
         env:
@@ -42,6 +42,7 @@ jobs:
           while IFS= read -r changed_path; do
             [[ -z "$changed_path" ]] && continue
             case "$changed_path" in
+              README.md|*/README.md|CHANGELOG.md|CONTRIBUTING.md) ;;
               site/*|playground/*) ;;
               scripts/check-site.mjs|scripts/site-document*.mjs|scripts/package*.json) ;;
               .github/workflows/playground.yml) ;;
@@ -50,7 +51,7 @@ jobs:
           done <<< "$changed_paths"
           echo "run=$run_parity" >> "$GITHUB_OUTPUT"
 
-      - name: Skip parity for website-only changes
+      - name: Skip parity for documentation-only changes
         if: steps.changes.outputs.run != 'true'
         run: echo "No renderer or parity inputs changed."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [1.5.4] — 2026-08-23
+
 ### Added
 
 - A versioned C ABI exposes the portable converter contract through opaque
@@ -10,18 +12,6 @@
   ownership and ships native assets for five initial runtime identifiers.
 - A Java 17+ `HtmlConverter` package uses the stable C ABI through JNA,
   `AutoCloseable` ownership, and typed renderer exceptions.
-
-### CI
-
-- NuGet artifacts are installed and rendered on Linux, macOS, and Windows
-  before OIDC trusted publishing can run.
-- Reproducible Maven artifacts are installed from their embedded POM and
-  rendered on all five supported native platforms before publication.
-
-## [1.5.4] — 2026-08-22
-
-### Added
-
 - The existing npm package now exposes `ironpress/node`, an ESM entry point that
   loads its packaged WebAssembly binary without consumer-side file handling.
 
@@ -32,6 +22,10 @@
 
 ### CI
 
+- NuGet artifacts are installed and rendered on Linux, macOS, and Windows
+  before OIDC trusted publishing can run.
+- Reproducible Maven artifacts are installed from their embedded POM and
+  rendered on all five supported native platforms before publication.
 - The packed npm artifact is installed, type-checked, and rendered through every
   supported Node.js LTS line before that exact artifact can be published.
 - Static site checks parse HTML through a standards-compliant tree instead of

--- a/README.md
+++ b/README.md
@@ -24,38 +24,55 @@ subprocess, or system dependencies.
 
 </div>
 
-| Runtime | Documentation | Package |
-|---------|---------------|---------|
-| Rust | [Get started][rust-guide] | [![Crates.io][crates-badge]][crates-package] |
-| C | [Get started][c-guide] | [![GitHub release][release-badge]][releases] |
-| .NET | [Get started][dotnet-guide] | [![NuGet][nuget-badge]][nuget-package] |
-| Java | [Get started][java-guide] | [![Maven Central][maven-badge]][maven-package] |
-| Python | [Get started][python-guide] | [![PyPI][pypi-badge]][pypi-package] |
-| Ruby | [Get started][ruby-guide] | [![Gem][gem-badge]][gem-package] |
-| JavaScript | [Browser][browser-guide] · [Node.js][node-guide] | [![npm][npm-badge]][npm-package] |
-
-[rust-guide]: https://gastongouron.github.io/ironpress/get-started/rust/
-[c-guide]: https://gastongouron.github.io/ironpress/get-started/c/
-[dotnet-guide]: https://gastongouron.github.io/ironpress/get-started/dotnet/
-[java-guide]: https://gastongouron.github.io/ironpress/get-started/java/
-[python-guide]: https://gastongouron.github.io/ironpress/get-started/python/
-[ruby-guide]: https://gastongouron.github.io/ironpress/get-started/ruby/
-[browser-guide]: https://gastongouron.github.io/ironpress/get-started/browser/
-[node-guide]: https://gastongouron.github.io/ironpress/get-started/node/
-[crates-package]: https://crates.io/crates/ironpress
-[crates-badge]: https://img.shields.io/crates/v/ironpress.svg
-[releases]: https://github.com/gastongouron/ironpress/releases/latest
-[release-badge]: https://img.shields.io/github/v/release/gastongouron/ironpress?label=release
-[nuget-package]: https://www.nuget.org/packages/Ironpress
-[nuget-badge]: https://img.shields.io/nuget/v/Ironpress.svg
-[maven-package]: https://central.sonatype.com/artifact/io.github.gastongouron/ironpress
-[maven-badge]: https://img.shields.io/maven-central/v/io.github.gastongouron/ironpress.svg
-[pypi-package]: https://pypi.org/project/ironpress/
-[pypi-badge]: https://img.shields.io/pypi/v/ironpress.svg
-[gem-package]: https://rubygems.org/gems/ironpress
-[gem-badge]: https://img.shields.io/gem/v/ironpress.svg
-[npm-package]: https://www.npmjs.com/package/ironpress
-[npm-badge]: https://img.shields.io/npm/v/ironpress.svg
+<table width="100%">
+  <thead>
+    <tr>
+      <th align="left">Runtime</th>
+      <th align="left">Documentation</th>
+      <th align="left">Package</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Rust</td>
+      <td><a href="https://gastongouron.github.io/ironpress/get-started/rust/">Get started with Rust</a></td>
+      <td><a href="https://crates.io/crates/ironpress"><img alt="Crates.io" src="https://img.shields.io/crates/v/ironpress.svg"></a></td>
+    </tr>
+    <tr>
+      <td>C</td>
+      <td><a href="https://gastongouron.github.io/ironpress/get-started/c/">Get started with C</a></td>
+      <td><a href="https://github.com/gastongouron/ironpress/releases/latest"><img alt="GitHub release" src="https://img.shields.io/github/v/release/gastongouron/ironpress?label=release"></a></td>
+    </tr>
+    <tr>
+      <td>.NET</td>
+      <td><a href="https://gastongouron.github.io/ironpress/get-started/dotnet/">Get started with .NET</a></td>
+      <td><a href="https://www.nuget.org/packages/Ironpress"><img alt="NuGet" src="https://img.shields.io/nuget/v/Ironpress.svg"></a></td>
+    </tr>
+    <tr>
+      <td>Java</td>
+      <td><a href="https://gastongouron.github.io/ironpress/get-started/java/">Get started with Java</a></td>
+      <td><a href="https://central.sonatype.com/artifact/io.github.gastongouron/ironpress"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/io.github.gastongouron/ironpress.svg"></a></td>
+    </tr>
+    <tr>
+      <td>Python</td>
+      <td><a href="https://gastongouron.github.io/ironpress/get-started/python/">Get started with Python</a></td>
+      <td><a href="https://pypi.org/project/ironpress/"><img alt="PyPI" src="https://img.shields.io/pypi/v/ironpress.svg"></a></td>
+    </tr>
+    <tr>
+      <td>Ruby</td>
+      <td><a href="https://gastongouron.github.io/ironpress/get-started/ruby/">Get started with Ruby</a></td>
+      <td><a href="https://rubygems.org/gems/ironpress"><img alt="Gem" src="https://img.shields.io/gem/v/ironpress.svg"></a></td>
+    </tr>
+    <tr>
+      <td>JavaScript</td>
+      <td>
+        <a href="https://gastongouron.github.io/ironpress/get-started/browser/">Get started in the browser</a>
+        · <a href="https://gastongouron.github.io/ironpress/get-started/node/">Get started with Node.js</a>
+      </td>
+      <td><a href="https://www.npmjs.com/package/ironpress"><img alt="npm" src="https://img.shields.io/npm/v/ironpress.svg"></a></td>
+    </tr>
+  </tbody>
+</table>
 
 ironpress turns HTML, CSS, or Markdown into PDF bytes inside your application.
 Its rendering engine handles document layout, font shaping, SVG, math, and PDF

--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ Fast, in-process HTML/CSS/Markdown to PDF rendering in pure Rust. No browser,
 subprocess, or system dependencies.
 
 
-[![Crates.io](https://img.shields.io/crates/v/ironpress.svg)](https://crates.io/crates/ironpress)
-[![PyPI](https://img.shields.io/pypi/v/ironpress.svg)](https://pypi.org/project/ironpress/)
-[![Gem](https://img.shields.io/gem/v/ironpress.svg)](https://rubygems.org/gems/ironpress)
-[![npm](https://img.shields.io/npm/v/ironpress.svg)](https://www.npmjs.com/package/ironpress)
-[![NuGet](https://img.shields.io/nuget/v/Ironpress.svg)](https://www.nuget.org/packages/Ironpress)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.gastongouron/ironpress.svg)](https://central.sonatype.com/artifact/io.github.gastongouron/ironpress)
 [![docs.rs](https://docs.rs/ironpress/badge.svg)](https://docs.rs/ironpress)
 [![CI](https://github.com/gastongouron/ironpress/actions/workflows/ci.yml/badge.svg)](https://github.com/gastongouron/ironpress/actions)
 [![codecov](https://codecov.io/gh/gastongouron/ironpress/branch/main/graph/badge.svg?token=w36XIAwRxG)](https://codecov.io/gh/gastongouron/ironpress)
@@ -29,6 +23,39 @@ subprocess, or system dependencies.
 **[Website](https://gastongouron.github.io/ironpress/)** | **[Get Started](https://gastongouron.github.io/ironpress/get-started/)** | **[Playground](https://gastongouron.github.io/ironpress/playground/)** | **[HTML-to-PDF guide](https://gastongouron.github.io/ironpress/guides/html-to-pdf-rust/)** | **[Parity report](https://gastongouron.github.io/ironpress/parity/reports/)** | **[Wiki](../../wiki)**
 
 </div>
+
+| Runtime | Documentation | Package |
+|---------|---------------|---------|
+| Rust | [Get started][rust-guide] | [![Crates.io][crates-badge]][crates-package] |
+| C | [Get started][c-guide] | [![GitHub release][release-badge]][releases] |
+| .NET | [Get started][dotnet-guide] | [![NuGet][nuget-badge]][nuget-package] |
+| Java | [Get started][java-guide] | [![Maven Central][maven-badge]][maven-package] |
+| Python | [Get started][python-guide] | [![PyPI][pypi-badge]][pypi-package] |
+| Ruby | [Get started][ruby-guide] | [![Gem][gem-badge]][gem-package] |
+| JavaScript | [Browser][browser-guide] · [Node.js][node-guide] | [![npm][npm-badge]][npm-package] |
+
+[rust-guide]: https://gastongouron.github.io/ironpress/get-started/rust/
+[c-guide]: https://gastongouron.github.io/ironpress/get-started/c/
+[dotnet-guide]: https://gastongouron.github.io/ironpress/get-started/dotnet/
+[java-guide]: https://gastongouron.github.io/ironpress/get-started/java/
+[python-guide]: https://gastongouron.github.io/ironpress/get-started/python/
+[ruby-guide]: https://gastongouron.github.io/ironpress/get-started/ruby/
+[browser-guide]: https://gastongouron.github.io/ironpress/get-started/browser/
+[node-guide]: https://gastongouron.github.io/ironpress/get-started/node/
+[crates-package]: https://crates.io/crates/ironpress
+[crates-badge]: https://img.shields.io/crates/v/ironpress.svg
+[releases]: https://github.com/gastongouron/ironpress/releases/latest
+[release-badge]: https://img.shields.io/github/v/release/gastongouron/ironpress?label=release
+[nuget-package]: https://www.nuget.org/packages/Ironpress
+[nuget-badge]: https://img.shields.io/nuget/v/Ironpress.svg
+[maven-package]: https://central.sonatype.com/artifact/io.github.gastongouron/ironpress
+[maven-badge]: https://img.shields.io/maven-central/v/io.github.gastongouron/ironpress.svg
+[pypi-package]: https://pypi.org/project/ironpress/
+[pypi-badge]: https://img.shields.io/pypi/v/ironpress.svg
+[gem-package]: https://rubygems.org/gems/ironpress
+[gem-badge]: https://img.shields.io/gem/v/ironpress.svg
+[npm-package]: https://www.npmjs.com/package/ironpress
+[npm-badge]: https://img.shields.io/npm/v/ironpress.svg
 
 ironpress turns HTML, CSS, or Markdown into PDF bytes inside your application.
 Its rendering engine handles document layout, font shaping, SVG, math, and PDF

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -267,9 +267,28 @@ await requireFile("site/assets/ironpress-logo.png");
 
 const readme = await load("README.md");
 if (readme !== null) {
-  const badgeCount = matches(readme, /\[!\[/g).length;
-  if (badgeCount < 14) {
-    report("README.md", `must retain all 14 badges (found ${badgeCount})`);
+  for (const [name, source] of [
+    ["docs.rs", "https://docs.rs/ironpress/badge.svg"],
+    ["CI", "https://github.com/gastongouron/ironpress/actions/workflows/ci.yml/badge.svg"],
+    ["codecov", "https://codecov.io/gh/gastongouron/ironpress/branch/main/graph/badge.svg"],
+    ["deps.rs", "https://deps.rs/repo/github/gastongouron/ironpress/status.svg"],
+    ["MSRV", "https://img.shields.io/badge/MSRV-1.88-blue.svg"],
+    ["license", "https://img.shields.io/badge/license-MIT-blue.svg"],
+    ["downloads", "https://img.shields.io/crates/d/ironpress.svg"],
+    ["WASM", "https://img.shields.io/badge/wasm-ready-blueviolet.svg"],
+    ["playground", "https://img.shields.io/badge/try_it-playground-blueviolet.svg"],
+    ["parity report", "https://img.shields.io/badge/parity-report-ff69b4.svg"],
+    ["Crates.io", "https://img.shields.io/crates/v/ironpress.svg"],
+    ["GitHub release", "https://img.shields.io/github/v/release/gastongouron/ironpress"],
+    ["NuGet", "https://img.shields.io/nuget/v/Ironpress.svg"],
+    ["Maven Central", "https://img.shields.io/maven-central/v/io.github.gastongouron/ironpress.svg"],
+    ["PyPI", "https://img.shields.io/pypi/v/ironpress.svg"],
+    ["RubyGems", "https://img.shields.io/gem/v/ironpress.svg"],
+    ["npm", "https://img.shields.io/npm/v/ironpress.svg"],
+  ]) {
+    if (!readme.includes(source)) {
+      report("README.md", `must retain the ${name} badge`);
+    }
   }
   for (const url of [
     "https://gastongouron.github.io/ironpress/",


### PR DESCRIPTION
## Summary

- move the C ABI, .NET, and Java entries into 1.5.4
- use the actual release date
- keep Unreleased empty for the next development cycle
- group binding packages in a compact README table
- link every runtime to its matching guide and package registry
- skip the expensive parity suite for documentation-only changes
- keep the required parity check present so branch protection still works

## Verification

- release versions agree on 1.5.4
- all eight public binding guides return HTTP 200
- GitHub accepts the README as valid GFM
- the parity workflow and its documentation path cases validate locally
- git diff check passes

This is the final documentation and metadata pass before publishing v1.5.4.
