### PR TITLE
docs: add project community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Report a reproducible Ironpress problem
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Ironpress.
+
+        Do not report security vulnerabilities here. Use [private vulnerability reporting](https://github.com/gastongouron/ironpress/security/advisories/new) instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues for this problem.
+          required: true
+        - label: I reproduced the problem with the latest Ironpress release.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Ironpress version
+      description: Give the exact crate or package version.
+      placeholder: "1.5.4"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: binding
+    attributes:
+      label: Runtime or binding
+      options:
+        - Rust crate
+        - CLI
+        - C ABI
+        - .NET
+        - Java
+        - Python
+        - Ruby
+        - Browser WebAssembly
+        - Node.js WebAssembly
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: Include the operating system, architecture, and runtime version.
+      placeholder: "Ubuntu 24.04, x86-64, Python 3.12"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest input and code that reproduce the problem. You can drag files into this field.
+      placeholder: |
+        HTML, CSS, Markdown, code, or a link to a minimal repository
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Explain the expected output. Link an applicable specification when the behavior is defined by one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Output and evidence
+      description: Attach the generated PDF, reference PDF, screenshot, visual diff, error, or backtrace when relevant.
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow the [Ironpress Code of Conduct](https://github.com/gastongouron/ironpress/blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,7 @@ body:
       options:
         - label: I searched the existing issues for this problem.
           required: true
-        - label: I reproduced the problem with the latest Ironpress release.
+        - label: I reproduced the problem with the latest Ironpress release or current `main`.
           required: true
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/gastongouron/ironpress/security/advisories/new
+    about: Send security reports privately to the maintainers.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,89 @@
+name: Feature request
+description: Propose a focused capability or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Concrete document examples and applicable specifications help us evaluate rendering requests.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and documentation for this request.
+          required: true
+
+  - type: dropdown
+    id: binding
+    attributes:
+      label: Runtime or binding
+      description: Select the main area affected by the request.
+      options:
+        - Rendering core
+        - Rust crate
+        - CLI
+        - C ABI
+        - .NET
+        - Java
+        - Python
+        - Ruby
+        - Browser WebAssembly
+        - Node.js WebAssembly
+        - Packaging or releases
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Describe the concrete use case and why the current behavior is not enough.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Explain the smallest change that would solve the problem.
+    validations:
+      required: true
+
+  - type: input
+    id: specification
+    attributes:
+      label: Specification or reference
+      description: For HTML, CSS, SVG, or PDF behavior, link the applicable standard or another independent source.
+      placeholder: "https://www.w3.org/TR/..."
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example input and expected output
+      description: Add a small document example, API sketch, or expected PDF behavior when possible.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Note any workaround or alternative design you already considered.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I may be able to implement or test this change.
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow the [Ironpress Code of Conduct](https://github.com/gastongouron/ironpress/blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## Summary
+
+<!-- Explain what this changes and why. Keep the pull request focused. -->
+
+## Related issue
+
+<!-- Link the issue with "Closes #123" when applicable. -->
+
+## Behavioral source
+
+<!--
+For rendering changes, link the applicable specification, verified oracle, or
+reproduced regression that establishes the expected behavior.
+-->
+
+## Verification
+
+<!-- List the exact commands run and their results. -->
+
+- [ ] Tests cover the changed behavior
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy -- -D warnings`
+- [ ] `cargo test`
+
+## Visual parity
+
+- [ ] This change does not affect rendered output
+- [ ] Relevant parity fixtures and reports were updated
+- [ ] Any new oracle PDF was generated with the pinned Chromium launcher
+
+## Bindings and documentation
+
+- [ ] The C, .NET, Java, Python, Ruby, and WebAssembly impact was considered
+- [ ] Public API or behavior changes are documented
+- [ ] User-visible changes have a changelog entry
+
+## Final checks
+
+- [ ] The change is focused and contains no unrelated cleanup
+- [ ] No secrets, generated scratch files, or local artifacts are included
+- [ ] I agree to follow the [Ironpress Code of Conduct](https://github.com/gastongouron/ironpress/blob/main/CODE_OF_CONDUCT.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,8 @@ reproduced regression that establishes the expected behavior.
 
 ## Visual parity
 
+<!-- Check the statements that apply. -->
+
 - [ ] This change does not affect rendered output
 - [ ] Relevant parity fixtures and reports were updated
 - [ ] Any new oracle PDF was generated with the pinned Chromium launcher

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to the project maintainer at gastongouron@gmail.com. All
+complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of
+actions.
+
+**Consequence:** A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at the [Contributor Covenant Code of Conduct][version].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the [Contributor
+Covenant FAQ][faq]. Translations are available on the [Contributor Covenant
+website][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,110 @@
 # Contributing to ironpress
 
-Thanks for your interest in contributing!
+Thanks for your interest in contributing. Bug reports, focused fixes, tests,
+documentation, and support for language bindings are all welcome.
 
-## Getting Started
+Participation in this project is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
+Report suspected vulnerabilities through the private process in
+[SECURITY.md](SECURITY.md), not through a public issue.
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b my-feature`
-3. Make your changes
-4. Run the checks:
-   ```bash
-   cargo fmt --check
-   cargo clippy -- -D warnings
-   cargo test
-   ```
-5. Commit and push your branch
-6. Open a pull request against `main`
+## Before starting
+
+Search the existing issues and pull requests before opening a new one. Use the
+bug or feature form so the report includes the runtime, version, platform, and a
+minimal example.
+
+For a substantial feature, public API change, or new CSS behavior, open an issue
+before writing the implementation. This gives maintainers and contributors a
+place to confirm the requirement, applicable specification, and scope.
+
+## Development workflow
+
+1. Fork the repository and branch from `main`.
+2. Keep each change focused on one problem.
+3. Establish the expected behavior from an independent requirement,
+   specification, verified oracle, or reproduced regression.
+4. Add or update tests with the implementation.
+5. Run the checks that apply to the changed area.
+6. Open a pull request against `main` and complete its verification notes.
+
+## Core checks
+
+The minimum supported Rust version is 1.88. Run the core checks from the
+repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test --verbose
+cargo test --verbose --features remote
+```
+
+CI also verifies the WebAssembly target with Rust 1.88:
+
+```bash
+cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
+```
+
+## Area-specific checks
+
+Run the checks closest to the files you changed. The GitHub workflows remain the
+source of truth for complete platform and release-package matrices.
+
+| Area | Local checks |
+|---|---|
+| C ABI | `cargo test -p ironpress-ffi`, `bindings/c/generate-header.sh --check`, `bindings/c/tests/run.sh` |
+| .NET | `dotnet build bindings/dotnet/src/Ironpress/Ironpress.csproj --configuration Release` |
+| Java | `mvn -B -f bindings/java/pom.xml clean verify` after preparing the native assets described by the Java workflow |
+| Python | Install the built wheel, then run `python -m unittest discover -s bindings/python/tests -v` |
+| Ruby | Run `bundle exec rake` from `bindings/ruby` |
+| Browser and Node.js WASM | `scripts/build-wasm-package.sh`, then `node scripts/test-node-package.mjs` |
+| Website | Run `npm ci --ignore-scripts`, `npm test`, and `npm run check` from `scripts` |
+
+See the workflows in [`.github/workflows`](.github/workflows) for required tool
+versions, native targets, package layout checks, and release verification.
+
+## Rendering and parity changes
+
+Ironpress keeps raw visual evidence for every parity fixture. A rendering change
+must not update an expectation only to match the implementation.
+
+- Add the smallest fixture that establishes the behavior.
+- Link the applicable specification or independently verified regression.
+- Run `scripts/parity.sh` when rendered output can change.
+- Keep `tests/parity/reports/index.html`, `tests/parity/REPORT.md`, and
+  `tests/parity/report.json` current.
+- Generate a new oracle PDF only with the pinned Chromium launcher.
+- Run `scripts/parity-gen-refs.sh --check` after any retained oracle change.
+
+Do not translate, crop, resize, filter, or otherwise align comparison rasters.
+Differences must remain visible at their original page coordinates.
 
 ## Guidelines
 
-- All code must pass `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test`
-- Add tests for new functionality
-- Keep PRs focused on a single change
-- Follow existing code style and conventions
+- Production code must not panic.
+- Add tests for new functionality and reproduced bugs.
+- Keep commits and pull requests focused on one logical change.
+- Document public API and user-visible behavior changes.
+- Update `CHANGELOG.md` when a change affects released users.
+- Follow the conventions in the surrounding code and project instructions.
 
 ## Code comments
 
 The codebase is intentionally low on comments. Follow these conventions:
 
-- **`///` doc comments** on public (and most private) structs, enums, fields, and functions. This is the dominant style. Explain *why* when the code encodes a non-obvious spec rule or design choice — a bare *what* is not enough for layout/CSS logic.
-- **`//!` module-level docs** only when a file has a meaningful architectural role worth describing. Not on every file.
-- **`//` inline comments** sparingly, only to annotate non-trivial algorithmic steps.
+- **`///` doc comments** on public and most private structs, enums, fields, and
+  functions. Explain *why* when code encodes a non-obvious specification rule or
+  design choice. A bare *what* is not enough for layout or CSS logic.
+- **`//!` module-level docs** only when a file has a meaningful architectural
+  role worth describing. Not on every file.
+- **`//` inline comments** sparingly, only for non-trivial algorithmic steps.
 - **No block comments** (`/* */`).
 - **No `FIXME` or `HACK` markers.** `TODO:` is acceptable on `#[ignore]` tests.
-- Let well-named identifiers speak for themselves. Don't narrate what the code does, document why it does it that way.
+- Let well-named identifiers speak for themselves. Do not narrate what the code
+  does. Document why it does it that way.
 
 ## Reporting Issues
 
-Open an issue on GitHub with a clear description and, if possible, a minimal reproduction.
+Use the issue forms with a clear description and a minimal reproduction. Attach
+the generated PDF, reference output, visual diff, error, or backtrace when it
+helps explain the problem.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,7 @@ must not update an expectation only to match the implementation.
 - Add the smallest fixture that establishes the behavior.
 - Link the applicable specification or independently verified regression.
 - Run `scripts/parity.sh` when rendered output can change.
-- Keep `tests/parity/reports/index.html`, `tests/parity/REPORT.md`, and
-  `tests/parity/report.json` current.
+- Keep `tests/parity/REPORT.md` and `tests/parity/report.json` current.
 - Generate a new oracle PDF only with the pinned Chromium launcher.
 - Run `scripts/parity-gen-refs.sh --check` after any retained oracle change.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are released for the latest published Ironpress version. Older
+versions are not supported. Please reproduce a suspected vulnerability with the
+latest release before reporting it when that is safe to do.
+
+## Report a vulnerability
+
+Do not open a public issue for a suspected security vulnerability.
+
+Use [GitHub private vulnerability reporting][private-report] to send the report
+to the maintainers. Include as much of the following information as possible:
+
+- The affected Ironpress version and language binding
+- The operating system and architecture
+- A minimal HTML, CSS, Markdown, image, font, or configuration input
+- The security impact and the conditions required to reproduce it
+- Reproduction steps or a proof of concept
+- Any suggested mitigation
+
+The maintainers will acknowledge the report, investigate it privately, and
+coordinate a fix and disclosure when the report is confirmed. Please keep the
+report and related discussion private until a release or coordinated disclosure
+is ready.
+
+## Scope
+
+Reports are especially useful for vulnerabilities involving:
+
+- HTML, CSS, SVG, image, font, or Markdown parsing
+- Resource path boundaries, symlink handling, or remote resource policies
+- Sanitization bypasses or unsafe URL handling
+- Memory safety across the Rust, C, .NET, Java, Python, Ruby, or WebAssembly APIs
+- Denial of service from untrusted document input
+- Release artifacts, package integrity, or CI credentials
+
+General bugs, unsupported CSS features, and rendering differences without a
+security impact should use the public issue tracker instead.
+
+[private-report]: https://github.com/gastongouron/ironpress/security/advisories/new


### PR DESCRIPTION
## Summary

- add Contributor Covenant 2.1 and a private security reporting policy
- add structured bug and feature issue forms plus issue chooser configuration
- add a pull request template focused on behavioral sources, verification, parity, and binding impact
- expand the contribution guide with project-specific checks and parity rules

## Decisions

These files live in Ironpress because the contributor guidance is specific to its renderer, bindings, and visual parity process. Blank issues remain enabled for reports that do not fit the two structured forms. Governance, support, and funding files remain out of scope until the project has the corresponding roles or channels.

## Verification

- parsed all issue forms and configuration with Ruby 2.6 and Psych 3.1
- checked required form fields, unique IDs, body types, options, and contact links
- ran git diff --check
- ran cargo fmt --check
- confirmed all referenced repository paths exist
- confirmed no em dash appears in changed files or commit messages

## Sources

- https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
- https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy
- https://www.contributor-covenant.org/version/2/1/code_of_conduct/