### PR TITLE
feat(cpp): add move-only RAII binding

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -8,6 +8,7 @@ on:
       - 'Cargo.toml'
       - 'src/**'
       - 'bindings/c/**'
+      - 'bindings/cpp/**'
       - 'tests/fonts/NotoEmoji-TestSubset.ttf'
       - 'tests/parity/fonts/ParitySans.ttf'
       - 'scripts/bump-version.sh'
@@ -19,6 +20,7 @@ on:
       - 'Cargo.toml'
       - 'src/**'
       - 'bindings/c/**'
+      - 'bindings/cpp/**'
       - 'tests/fonts/NotoEmoji-TestSubset.ttf'
       - 'tests/parity/fonts/ParitySans.ttf'
       - 'scripts/bump-version.sh'
@@ -63,12 +65,21 @@ jobs:
         env:
           IRONPRESS_VALGRIND: '1'
         run: bindings/c/tests/run.sh
+      - name: Test C++ ownership under Valgrind
+        env:
+          CXX: g++
+          IRONPRESS_VALGRIND: '1'
+        run: bindings/cpp/tests/run.sh
       - name: Compile and test the release library from C
         env:
           IRONPRESS_PROFILE: release
         run: bindings/c/tests/run.sh
       - name: Package the Linux x86_64 libraries
         run: bindings/c/package-unix.sh linux-x86_64
+      - name: Test the packaged C++ consumer with GCC
+        env:
+          CXX: g++
+        run: bindings/cpp/tests/verify-package.sh linux-x86_64
       - name: Verify the glibc 2.28 compatibility floor
         run: bindings/c/verify-glibc-floor.sh target/release/libironpress_ffi.so 2.28
       - uses: actions/upload-artifact@v7
@@ -94,6 +105,10 @@ jobs:
         run: bindings/c/tests/run.sh
       - name: Package the Linux aarch64 libraries
         run: bindings/c/package-unix.sh linux-aarch64
+      - name: Test the packaged C++ consumer with GCC
+        env:
+          CXX: g++
+        run: bindings/cpp/tests/verify-package.sh linux-aarch64
       - name: Verify the glibc 2.28 compatibility floor
         run: bindings/c/verify-glibc-floor.sh target/release/libironpress_ffi.so 2.28
       - uses: actions/upload-artifact@v7
@@ -125,6 +140,10 @@ jobs:
         run: bindings/c/tests/run.sh
       - name: Package the native libraries
         run: bindings/c/package-unix.sh ${{ matrix.artifact }}
+      - name: Test the packaged C++ consumer with Clang
+        env:
+          CXX: clang++
+        run: bindings/cpp/tests/verify-package.sh ${{ matrix.artifact }}
       - uses: actions/upload-artifact@v7
         with:
           name: ironpress-c-${{ matrix.artifact }}
@@ -155,11 +174,28 @@ jobs:
           $version = (Select-String -Path bindings/c/Cargo.toml -Pattern '^version = "([^"]+)"').Matches[0].Groups[1].Value
           $bundle = "ironpress-c-$version-windows-x86_64"
           $root = "dist/c/$bundle"
-          New-Item -ItemType Directory -Force "$root/include", "$root/lib" | Out-Null
+          New-Item -ItemType Directory -Force "$root/include/ironpress", "$root/lib" | Out-Null
           Copy-Item bindings/c/include/ironpress.h "$root/include/"
+          Copy-Item bindings/cpp/include/ironpress.hpp "$root/include/"
+          Copy-Item bindings/cpp/include/ironpress/* "$root/include/ironpress/" -Recurse
           Copy-Item bindings/c/ABI.md, bindings/c/README.md, LICENSE "$root/"
+          Copy-Item bindings/cpp/README.md "$root/CPP.md"
           Copy-Item target/release/ironpress_ffi.dll, target/release/ironpress_ffi*.lib "$root/lib/"
           Compress-Archive -Path $root -DestinationPath "dist/c/$bundle.zip"
+      - name: Test the packaged C++ consumer with MSVC
+        shell: cmd
+        run: |
+          call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          for /f "tokens=3" %%v in ('findstr /b /c:"version = " bindings\c\Cargo.toml') do set VERSION=%%~v
+          set "BUNDLE=ironpress-c-%VERSION%-windows-x86_64"
+          set "PACKAGE_ROOT=%RUNNER_TEMP%\ironpress-cpp-package"
+          powershell -NoProfile -Command "Expand-Archive -Path 'dist/c/%BUNDLE%.zip' -DestinationPath '%PACKAGE_ROOT%'"
+          set "ROOT=%PACKAGE_ROOT%\%BUNDLE%"
+          cl /nologo /std:c++17 /permissive- /Zc:__cplusplus /EHsc /utf-8 /W4 /WX /I "%ROOT%\include" bindings\cpp\tests\smoke.cpp /Fe:target\ironpress-cpp-package-static-smoke.exe /link "%ROOT%\lib\ironpress_ffi.lib" kernel32.lib ntdll.lib userenv.lib ws2_32.lib dbghelp.lib
+          target\ironpress-cpp-package-static-smoke.exe tests\parity\fonts\ParitySans.ttf tests\fonts\NotoEmoji-TestSubset.ttf
+          cl /nologo /std:c++17 /permissive- /Zc:__cplusplus /EHsc /utf-8 /W4 /WX /I "%ROOT%\include" bindings\cpp\tests\smoke.cpp /Fe:target\ironpress-cpp-package-smoke.exe /link "%ROOT%\lib\ironpress_ffi.dll.lib"
+          set "PATH=%ROOT%\lib;%PATH%"
+          target\ironpress-cpp-package-smoke.exe tests\parity\fonts\ParitySans.ttf tests\fonts\NotoEmoji-TestSubset.ttf
       - uses: actions/upload-artifact@v7
         with:
           name: ironpress-c-windows-x86_64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added
+
+- A header-only C++17 binding provides move-only RAII owners, typed errors, and
+  the complete portable converter contract over the stable C ABI.
+
+### CI
+
+- C++ consumers render through GCC, Clang, and MSVC, then repeat the smoke test
+  from the exact native archive prepared for release.
+
+### Documentation
+
+- The binding matrix, native guides, README, and public site include the C++
+  install, ownership, error, font, and runtime contracts.
+
 ## [1.5.4] — 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ subprocess, or system dependencies.
       <td><a href="https://github.com/gastongouron/ironpress/releases/latest"><img alt="GitHub release" src="https://img.shields.io/github/v/release/gastongouron/ironpress?label=release"></a></td>
     </tr>
     <tr>
+      <td>C++</td>
+      <td><a href="https://gastongouron.github.io/ironpress/get-started/cpp/">Get started with C++</a></td>
+      <td><a href="https://github.com/gastongouron/ironpress/releases/latest"><img alt="GitHub release" src="https://img.shields.io/github/v/release/gastongouron/ironpress?label=release"></a></td>
+    </tr>
+    <tr>
       <td>.NET</td>
       <td><a href="https://gastongouron.github.io/ironpress/get-started/dotnet/">Get started with .NET</a></td>
       <td><a href="https://www.nuget.org/packages/Ironpress"><img alt="NuGet" src="https://img.shields.io/nuget/v/Ironpress.svg"></a></td>
@@ -76,15 +81,15 @@ subprocess, or system dependencies.
 
 ironpress turns HTML, CSS, or Markdown into PDF bytes inside your application.
 Its rendering engine handles document layout, font shaping, SVG, math, and PDF
-serialization without launching Chrome. Use it from Rust, C, .NET, Java, the
-CLI, Python, Ruby, Node.js, or browser WebAssembly.
+serialization without launching Chrome. Use it from Rust, C, C++, .NET, Java,
+the CLI, Python, Ruby, Node.js, or browser WebAssembly.
 
 ## Why ironpress?
 
 - **Simple deployment:** one library or binary, with no browser runtime to install or manage.
 - **Document-focused layout:** flexbox, grid, tables, multi-column layout, `@page`, headers, and footers.
 - **Production typography:** font subsetting, core Unicode coverage, optional regional CJK/emoji packs, SVG, and math.
-- **Multiple runtimes:** the same Rust core ships to Rust, C, .NET, Java, Python, Ruby, and WebAssembly.
+- **Multiple runtimes:** the same Rust core ships to Rust, C, C++, .NET, Java, Python, Ruby, and WebAssembly.
 - **Defensive defaults:** HTML/SVG sanitization, constrained file access, and opt-in remote fetching policies.
 
 ## Quick start
@@ -102,7 +107,7 @@ let pdf = ironpress::markdown_to_pdf("# Hello\n\nWorld").unwrap();
 
 Choose a complete [getting-started
 guide](https://gastongouron.github.io/ironpress/get-started/) for Rust, the CLI,
-C, .NET, Java, Python, Ruby, browser JavaScript, or Node.js. For a deeper Rust walkthrough, see
+C, C++, .NET, Java, Python, Ruby, browser JavaScript, or Node.js. For a deeper Rust walkthrough, see
 [HTML-to-PDF rendering without Headless
 Chrome](https://gastongouron.github.io/ironpress/guides/html-to-pdf-rust/), or
 paste a document into the [browser
@@ -179,6 +184,7 @@ does not change page geometry. The CLI exposes the same controls through
 | **Images** | JPEG + PNG, data URIs, local files, remote URLs (`remote` feature) | [Architecture](../../wiki/Architecture) |
 | **PDF** | PDF 1.4, bookmarks, link annotations, headers/footers, gradients, streaming output | [PDF Rendering](../../wiki/PDF-Rendering) |
 | **C ABI** | Stable native API with versioned Linux, macOS, and Windows libraries | [C binding](bindings/c/README.md) |
+| **C++** | Move-only C++17 RAII owners over the stable native ABI | [C++ binding](bindings/cpp/README.md) |
 | **.NET** | Managed `HtmlConverter`, typed failures, and RID-native assets | [.NET binding](bindings/dotnet/README.md) |
 | **Java** | Java 17 `HtmlConverter`, typed failures, and packaged native assets | [Java binding](bindings/java/README.md) |
 | **WASM** | `npm install ironpress` - runs in browsers and Node.js | [WASM & Playground](../../wiki/WASM-Playground) |

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -1,25 +1,25 @@
 # Language bindings
 
-Ironpress exposes one rendering engine through Rust, C, .NET, Java, Python, Ruby,
-browser WebAssembly, and Node.js WebAssembly. Each binding keeps the conventions
-of its runtime while sharing the portable converter contract below.
+Ironpress exposes one rendering engine through Rust, C, C++, .NET, Java, Python,
+Ruby, browser WebAssembly, and Node.js WebAssembly. Each binding keeps the
+conventions of its runtime while sharing the portable converter contract below.
 
 ## Capability matrix
 
-| Capability | Rust | C ABI | .NET | Java | Python | Ruby | Browser WASM | Node.js WASM |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| HTML and Markdown to PDF bytes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Reusable configured converter | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Page size and margins | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| PDF and raster quality controls | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Sanitization | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Headers and footers | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Custom TTF fonts | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Optional CJK and emoji packs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Local resource boundary | Yes | No | No | No | Yes | Yes | No | No |
-| Direct file output | Yes | No | No | No | Yes | Yes | No | No |
-| Streaming writer and async API | Yes | No | No | No | No | No | No | No |
-| Remote HTTP resources | Opt-in | No | No | No | No | No | No | No |
+| Capability | Rust | C ABI | C++ | .NET | Java | Python | Ruby | Browser WASM | Node.js WASM |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| HTML and Markdown to PDF bytes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Reusable configured converter | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Page size and margins | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| PDF and raster quality controls | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Sanitization | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Headers and footers | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Custom TTF fonts | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Optional CJK and emoji packs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Local resource boundary | Yes | No | No | No | No | Yes | Yes | No | No |
+| Direct file output | Yes | No | No | No | No | Yes | Yes | No | No |
+| Streaming writer and async API | Yes | No | No | No | No | No | No | No | No |
+| Remote HTTP resources | Opt-in | No | No | No | No | No | No | No | No |
 
 WebAssembly receives font and document bytes from the host application. It does
 not read local paths. Remote resource loading remains available only through the
@@ -32,6 +32,7 @@ network access.
 |---|---|---|
 | Rust | [`ironpress`](https://crates.io/crates/ironpress) | Source crate, Rust 1.88+ |
 | C | [GitHub Releases](https://github.com/gastongouron/ironpress/releases) | Header, static library, and shared library for Linux, macOS, and Windows |
+| C++ | [GitHub Releases](https://github.com/gastongouron/ironpress/releases) | C++17 RAII headers with the C static and shared libraries |
 | .NET | [`Ironpress`](https://www.nuget.org/packages/Ironpress) | .NET 8+ managed assembly with Linux, macOS, and Windows native assets |
 | Java | [`io.github.gastongouron:ironpress`](https://central.sonatype.com/artifact/io.github.gastongouron/ironpress) | Java 17+ JAR with Linux, macOS, and Windows native assets |
 | Python | [`ironpress`](https://pypi.org/project/ironpress/) | CPython 3.8+ ABI3 wheels for Linux, macOS, and Windows |
@@ -40,7 +41,7 @@ network access.
 | Node.js WebAssembly | [`ironpress/node`](https://www.npmjs.com/package/ironpress) | Node.js 22/24 ESM entry using the same WebAssembly binary |
 
 All published packages use the same Ironpress version. CI builds and exercises
-the C, .NET, Java, Python, and Ruby artifacts before a release can publish them.
+the C, C++, .NET, Java, Python, and Ruby artifacts before a release can publish them.
 The NuGet and Maven packages are installed and rendered on every advertised
 platform without Rust.
 The generated npm tarball is installed, type-checked, and rendered through
@@ -51,6 +52,7 @@ Start with the guide for your runtime:
 - [Rust](https://gastongouron.github.io/ironpress/get-started/rust/)
 - [CLI](https://gastongouron.github.io/ironpress/get-started/cli/)
 - [C](c/README.md)
+- [C++](https://gastongouron.github.io/ironpress/get-started/cpp/)
 - [.NET](https://gastongouron.github.io/ironpress/get-started/dotnet/)
 - [Java](https://gastongouron.github.io/ironpress/get-started/java/)
 - [Python](https://gastongouron.github.io/ironpress/get-started/python/)

--- a/bindings/c/ABI.md
+++ b/bindings/c/ABI.md
@@ -1,9 +1,9 @@
 # Ironpress C ABI
 
-The C binding is the native contract shared by C, C++, and .NET. Java may use
-the same contract through JNA or a thin JNI adapter. The ABI translates values,
-ownership, and failures only; all document behavior remains in the `ironpress`
-crate.
+The C binding is the native contract shared by C, C++, .NET, and Java. C++ uses
+a header-only RAII layer, .NET uses P/Invoke, and Java uses JNA. The ABI
+translates values, ownership, and failures only; all document behavior remains
+in the `ironpress` crate.
 
 ## Compatibility
 

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -1,8 +1,8 @@
 # Ironpress for C
 
 Ironpress exposes its portable HTML and Markdown conversion contract through a
-stable C ABI. The same native boundary is intended to support the .NET and C++
-bindings without exposing Rust layouts or requiring a Rust toolchain at runtime.
+stable C ABI. The same native boundary supports the .NET, Java, and C++ bindings
+without exposing Rust layouts or requiring a Rust toolchain at runtime.
 
 ## Install
 
@@ -17,9 +17,9 @@ platform:
 | `macos-aarch64` | macOS Apple Silicon |
 | `windows-x86_64` | Windows x86_64, MSVC |
 
-Every archive contains `include/ironpress.h`, a shared library, a static
-library, this guide, the ABI contract, and the license. `SHA256SUMS` in the
-release verifies the archives.
+Every archive contains the C header, the header-only C++17 wrapper, a shared
+library, a static library, both native guides, the ABI contract, and the
+license. `SHA256SUMS` in the release verifies the archives.
 
 ## Convert HTML
 

--- a/bindings/c/package-unix.sh
+++ b/bindings/c/package-unix.sh
@@ -17,10 +17,14 @@ readonly bundle_dir="${work_dir}/${bundle}"
 readonly output_dir="${repository_dir}/dist/c"
 trap 'rm -rf "${work_dir}"' EXIT
 
-mkdir -p "${bundle_dir}/include" "${bundle_dir}/lib" "${output_dir}"
+mkdir -p "${bundle_dir}/include/ironpress" "${bundle_dir}/lib" "${output_dir}"
 cp "${binding_dir}/include/ironpress.h" "${bundle_dir}/include/"
+cp "${repository_dir}/bindings/cpp/include/ironpress.hpp" "${bundle_dir}/include/"
+cp -R "${repository_dir}/bindings/cpp/include/ironpress/." \
+    "${bundle_dir}/include/ironpress/"
 cp "${binding_dir}/ABI.md" "${binding_dir}/README.md" "${repository_dir}/LICENSE" \
     "${bundle_dir}/"
+cp "${repository_dir}/bindings/cpp/README.md" "${bundle_dir}/CPP.md"
 cp "${repository_dir}/target/release/libironpress_ffi.a" "${bundle_dir}/lib/"
 
 case "${platform}" in

--- a/bindings/cpp/README.md
+++ b/bindings/cpp/README.md
@@ -1,0 +1,87 @@
+# Ironpress for C++
+
+Ironpress provides a header-only C++17 wrapper over its stable C ABI. It keeps
+native converter and PDF allocations under move-only RAII ownership, while the
+Rust renderer remains the only implementation of document behavior.
+
+## Install
+
+Download the archive for your platform from an Ironpress GitHub release. Add
+its `include` directory to your compiler search path and link either the shared
+or static `ironpress_ffi` library from `lib`.
+
+The archive contains both `ironpress.hpp` and `ironpress.h`. Keep these headers
+paired with the library from the same archive. The wrapper checks the linked ABI
+generation before allocating or converting.
+
+## Convert HTML
+
+```cpp
+#include "ironpress.hpp"
+
+#include <fstream>
+
+int main() {
+    ironpress::Converter converter;
+    converter.set_page_size(ironpress::PageSize::letter)
+        .set_margins(ironpress::PageMargins::uniform(36.0F))
+        .set_footer("Page {page} / {pages}");
+
+    const auto pdf = converter.convert_html("<h1>Hello from C++</h1>");
+    std::ofstream output("output.pdf", std::ios::binary);
+    output.write(reinterpret_cast<const char*>(pdf.data()),
+                 static_cast<std::streamsize>(pdf.size()));
+}
+```
+
+`Converter` and `Pdf` cannot be copied. Moving either object transfers its one
+native owner, and destruction releases that owner through the matching C ABI
+function. A moved-from object is empty and may be destroyed or assigned again.
+
+## Errors
+
+Fallible methods throw `ironpress::Error`. Its `status()` method exposes a
+stable `ironpress::Status` category, while `native_status()` preserves an
+unknown status from a newer library. The diagnostic in `what()` is copied
+before the native error owner is released.
+
+Validated value constructors use `std::invalid_argument`, matching normal C++
+argument handling before any native call occurs.
+
+No C++ exception crosses the native boundary. Rust panics are caught by the C
+ABI, returned as `Status::internal`, and only then translated into a C++
+exception. Destructors never throw.
+
+## Fonts and binary input
+
+`ironpress::BytesView` borrows bytes without copying them. Its source must stay
+alive for the complete call:
+
+```cpp
+std::vector<std::uint8_t> font = read_font();
+converter.add_font("Inter", ironpress::BytesView(font));
+```
+
+The same API accepts the five optional CJK and emoji packs through
+`add_font_pack`.
+
+## Threads and capabilities
+
+A converter may move between threads while idle. Do not configure, convert, or
+destroy the same owner concurrently. PDF byte views remain valid until their
+`Pdf` owner is destroyed or moved.
+
+The wrapper exposes the same portable contract as the C ABI: HTML and Markdown
+PDF bytes, reusable converters, page geometry, quality controls, sanitization,
+headers, footers, custom fonts, and optional font packs. It does not read local
+paths or enable remote resources.
+
+## Build from source
+
+```bash
+cargo build --release -p ironpress-ffi
+IRONPRESS_PROFILE=release bindings/cpp/tests/run.sh
+```
+
+CI compiles and runs the consumer against static and shared libraries with GCC
+and Clang. The Windows consumer is compiled and run with MSVC.

--- a/bindings/cpp/include/ironpress.hpp
+++ b/bindings/cpp/include/ironpress.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "ironpress/converter.hpp"
+
+#include <cstdint>
+#include <string_view>
+
+namespace ironpress {
+
+/// Return the stable C ABI generation exposed by the linked library.
+[[nodiscard]] inline std::uint32_t abi_version() noexcept {
+    return ironpress_abi_version();
+}
+
+/// Return the linked Ironpress package version.
+[[nodiscard]] inline std::string_view version() noexcept {
+    const char* value = ironpress_version();
+    return value == nullptr ? std::string_view{} : std::string_view(value);
+}
+
+/// Convert UTF-8 HTML with a default one-shot converter.
+[[nodiscard]] inline Pdf html_to_pdf(std::string_view html) {
+    detail::NativeResult::require_compatible_abi();
+    IronpressBuffer* pdf = nullptr;
+    IronpressError* error = nullptr;
+    const auto status =
+        ironpress_html_to_pdf(detail::text(html), &pdf, &error);
+    return Pdf::take(status, pdf, error);
+}
+
+/// Convert UTF-8 Markdown with a default one-shot converter.
+[[nodiscard]] inline Pdf markdown_to_pdf(std::string_view markdown) {
+    detail::NativeResult::require_compatible_abi();
+    IronpressBuffer* pdf = nullptr;
+    IronpressError* error = nullptr;
+    const auto status =
+        ironpress_markdown_to_pdf(detail::text(markdown), &pdf, &error);
+    return Pdf::take(status, pdf, error);
+}
+
+}

--- a/bindings/cpp/include/ironpress/converter.hpp
+++ b/bindings/cpp/include/ironpress/converter.hpp
@@ -1,0 +1,196 @@
+#pragma once
+
+#include "ironpress/pdf.hpp"
+
+#include <cstdint>
+#include <string_view>
+#include <utility>
+
+namespace ironpress {
+
+/// A reusable configured converter with unique native ownership.
+class Converter final {
+public:
+    /// Allocate a default converter after verifying the linked ABI generation.
+    Converter() {
+        detail::NativeResult::require_compatible_abi();
+        IronpressConverter* converter = nullptr;
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_new(&converter, &error);
+        detail::ConverterOwner owner(converter);
+        detail::NativeResult::require_success(status, error);
+        if (!owner) {
+            throw detail::NativeResult::contract_violation(
+                "Native converter allocation returned no owner.");
+        }
+        owner_ = std::move(owner);
+    }
+
+    Converter(const Converter&) = delete;
+    Converter& operator=(const Converter&) = delete;
+    Converter(Converter&&) noexcept = default;
+    Converter& operator=(Converter&&) noexcept = default;
+    ~Converter() noexcept = default;
+
+    /// Report whether this object still owns a native converter.
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return static_cast<bool>(owner_);
+    }
+
+    /// Configure one named physical page size.
+    Converter& set_page_size(PageSize page_size) {
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_set_page_size(
+            owner_.get(), static_cast<std::uint32_t>(page_size), &error);
+        return configured(status, error);
+    }
+
+    /// Configure one custom physical page size.
+    Converter& set_page_size(PageDimensions dimensions) {
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_set_page_size_custom(
+            owner_.get(), dimensions.width(), dimensions.height(), &error);
+        return configured(status, error);
+    }
+
+    /// Configure physical page margins.
+    Converter& set_margins(PageMargins margins) {
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_set_margins(
+            owner_.get(), margins.top(), margins.right(), margins.bottom(),
+            margins.left(), &error);
+        return configured(status, error);
+    }
+
+    /// Enable or disable PDF compression.
+    Converter& set_compression(bool enabled) {
+        return configure_boolean(ironpress_converter_set_compress, enabled);
+    }
+
+    /// Set JPEG quality; the renderer clamps values above 100.
+    Converter& set_jpeg_quality(std::uint8_t quality) {
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_set_jpeg_quality(
+            owner_.get(), quality, &error);
+        return configured(status, error);
+    }
+
+    /// Enable or disable automatic source-image downscaling.
+    Converter& set_auto_resize_images(bool enabled) {
+        return configure_boolean(ironpress_converter_set_auto_resize_images,
+                                 enabled);
+    }
+
+    /// Set target source-image resolution in dots per inch.
+    Converter& set_image_dpi(float dpi) {
+        return configure_number(ironpress_converter_set_image_dpi, dpi);
+    }
+
+    /// Set CSS filter rasterization resolution in dots per inch.
+    Converter& set_filter_dpi(float dpi) {
+        return configure_number(ironpress_converter_set_filter_dpi, dpi);
+    }
+
+    /// Set CSS mask rasterization resolution in dots per inch.
+    Converter& set_mask_dpi(float dpi) {
+        return configure_number(ironpress_converter_set_mask_dpi, dpi);
+    }
+
+    /// Set flattened-background rasterization resolution in dots per inch.
+    Converter& set_background_raster_dpi(float dpi) {
+        return configure_number(ironpress_converter_set_background_raster_dpi,
+                                dpi);
+    }
+
+    /// Enable or disable conservative raster occlusion culling.
+    Converter& set_occlusion_culling(bool enabled) {
+        return configure_boolean(ironpress_converter_set_occlusion_cull,
+                                 enabled);
+    }
+
+    /// Enable or disable HTML sanitization.
+    Converter& set_sanitization(bool enabled) {
+        return configure_boolean(ironpress_converter_set_sanitize, enabled);
+    }
+
+    /// Configure the plain-text page header.
+    Converter& set_header(std::string_view header) {
+        return configure_text(ironpress_converter_set_header, header);
+    }
+
+    /// Configure the plain-text page footer.
+    Converter& set_footer(std::string_view footer) {
+        return configure_text(ironpress_converter_set_footer, footer);
+    }
+
+    /// Add or replace one custom TrueType font family.
+    Converter& add_font(std::string_view family, BytesView font_data) {
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_add_font(
+            owner_.get(), detail::text(family), font_data.native(), &error);
+        return configured(status, error);
+    }
+
+    /// Add one optional CJK or emoji fallback pack.
+    Converter& add_font_pack(FontPackKind kind, BytesView font_data) {
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_add_font_pack(
+            owner_.get(), static_cast<std::uint32_t>(kind), font_data.native(),
+            &error);
+        return configured(status, error);
+    }
+
+    /// Convert UTF-8 HTML to one uniquely owned PDF buffer.
+    [[nodiscard]] Pdf convert_html(std::string_view html) const {
+        IronpressBuffer* pdf = nullptr;
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_convert_html(
+            owner_.get(), detail::text(html), &pdf, &error);
+        return Pdf::take(status, pdf, error);
+    }
+
+    /// Convert UTF-8 Markdown to one uniquely owned PDF buffer.
+    [[nodiscard]] Pdf convert_markdown(std::string_view markdown) const {
+        IronpressBuffer* pdf = nullptr;
+        IronpressError* error = nullptr;
+        const auto status = ironpress_converter_convert_markdown(
+            owner_.get(), detail::text(markdown), &pdf, &error);
+        return Pdf::take(status, pdf, error);
+    }
+
+private:
+    using BooleanSetter = IronpressStatus (*)(IronpressConverter*, std::uint8_t,
+                                               IronpressError**);
+    using NumberSetter = IronpressStatus (*)(IronpressConverter*, float,
+                                              IronpressError**);
+    using TextSetter = IronpressStatus (*)(IronpressConverter*, IronpressBytes,
+                                            IronpressError**);
+
+    Converter& configured(IronpressStatus status, IronpressError* error) {
+        detail::NativeResult::require_success(status, error);
+        return *this;
+    }
+
+    Converter& configure_boolean(BooleanSetter setter, bool enabled) {
+        IronpressError* error = nullptr;
+        const auto status = setter(
+            owner_.get(), enabled ? IRONPRESS_TRUE : IRONPRESS_FALSE, &error);
+        return configured(status, error);
+    }
+
+    Converter& configure_number(NumberSetter setter, float value) {
+        IronpressError* error = nullptr;
+        const auto status = setter(owner_.get(), value, &error);
+        return configured(status, error);
+    }
+
+    Converter& configure_text(TextSetter setter, std::string_view value) {
+        IronpressError* error = nullptr;
+        const auto status = setter(owner_.get(), detail::text(value), &error);
+        return configured(status, error);
+    }
+
+    detail::ConverterOwner owner_;
+};
+
+}

--- a/bindings/cpp/include/ironpress/detail/native.hpp
+++ b/bindings/cpp/include/ironpress/detail/native.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "ironpress/types.hpp"
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace ironpress::detail {
+
+struct BufferDeleter final {
+    void operator()(IronpressBuffer* buffer) const noexcept {
+        if (buffer != nullptr) {
+            (void)ironpress_buffer_free(&buffer);
+        }
+    }
+};
+
+struct ConverterDeleter final {
+    void operator()(IronpressConverter* converter) const noexcept {
+        if (converter != nullptr) {
+            (void)ironpress_converter_free(&converter);
+        }
+    }
+};
+
+struct ErrorDeleter final {
+    void operator()(IronpressError* error) const noexcept {
+        if (error != nullptr) {
+            (void)ironpress_error_free(&error);
+        }
+    }
+};
+
+using BufferOwner = std::unique_ptr<IronpressBuffer, BufferDeleter>;
+using ConverterOwner = std::unique_ptr<IronpressConverter, ConverterDeleter>;
+using ErrorOwner = std::unique_ptr<IronpressError, ErrorDeleter>;
+
+/// Parses native results once and releases every native error owner.
+class NativeResult final {
+public:
+    static void require_compatible_abi() {
+        const auto linked_version = ironpress_abi_version();
+        if (linked_version != IRONPRESS_ABI_VERSION) {
+            throw contract_violation(
+                "Ironpress C++ requires ABI " +
+                std::to_string(IRONPRESS_ABI_VERSION) + ", but ABI " +
+                std::to_string(linked_version) + " was loaded.");
+        }
+    }
+
+    static void require_success(IronpressStatus status,
+                                IronpressError* raw_error) {
+        ErrorOwner error(raw_error);
+        if (status == IRONPRESS_STATUS_OK && !error) {
+            return;
+        }
+        if (status == IRONPRESS_STATUS_OK) {
+            throw contract_violation(
+                "A successful native call returned an error owner.");
+        }
+        throw Error(category(status), status, message(error.get(), status));
+    }
+
+    [[nodiscard]] static Error contract_violation(std::string message) {
+        return Error(Status::internal, IRONPRESS_STATUS_INTERNAL,
+                     std::move(message));
+    }
+
+private:
+    [[nodiscard]] static Status category(IronpressStatus status) noexcept {
+        switch (status) {
+            case IRONPRESS_STATUS_INVALID_ARGUMENT:
+                return Status::invalid_argument;
+            case IRONPRESS_STATUS_INVALID_UTF8:
+                return Status::invalid_utf8;
+            case IRONPRESS_STATUS_INVALID_ENUM:
+                return Status::invalid_enum;
+            case IRONPRESS_STATUS_INVALID_HANDLE:
+                return Status::invalid_handle;
+            case IRONPRESS_STATUS_OUTPUT_NOT_EMPTY:
+                return Status::output_not_empty;
+            case IRONPRESS_STATUS_PARSE:
+                return Status::parse;
+            case IRONPRESS_STATUS_CSS:
+                return Status::css;
+            case IRONPRESS_STATUS_LAYOUT:
+                return Status::layout;
+            case IRONPRESS_STATUS_RENDER:
+                return Status::render;
+            case IRONPRESS_STATUS_FONT:
+                return Status::font;
+            case IRONPRESS_STATUS_IO:
+                return Status::io;
+            case IRONPRESS_STATUS_SECURITY:
+                return Status::security;
+            case IRONPRESS_STATUS_INTERNAL:
+                return Status::internal;
+            default:
+                return Status::unknown;
+        }
+    }
+
+    [[nodiscard]] static std::string message(const IronpressError* error,
+                                             IronpressStatus status) {
+        if (error == nullptr) {
+            return "Ironpress failed with native status " +
+                   std::to_string(status) + ".";
+        }
+        const auto size = ironpress_error_message_len(error);
+        const auto* data = ironpress_error_message_data(error);
+        if (data == nullptr || size == 0) {
+            return "Ironpress returned an empty native diagnostic.";
+        }
+        return {reinterpret_cast<const char*>(data), size};
+    }
+};
+
+[[nodiscard]] inline IronpressBytes text(std::string_view value) noexcept {
+    return {reinterpret_cast<const std::uint8_t*>(value.data()), value.size()};
+}
+
+}

--- a/bindings/cpp/include/ironpress/pdf.hpp
+++ b/bindings/cpp/include/ironpress/pdf.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "ironpress/detail/native.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <utility>
+
+namespace ironpress {
+
+/// One uniquely owned PDF allocation returned by Ironpress.
+class Pdf final {
+public:
+    Pdf() = delete;
+    Pdf(const Pdf&) = delete;
+    Pdf& operator=(const Pdf&) = delete;
+    Pdf(Pdf&&) noexcept = default;
+    Pdf& operator=(Pdf&&) noexcept = default;
+    ~Pdf() noexcept = default;
+
+    /// Borrow the first PDF byte for the lifetime of this owner.
+    [[nodiscard]] const std::uint8_t* data() const noexcept {
+        return ironpress_buffer_data(owner_.get());
+    }
+
+    /// Return the PDF byte count.
+    [[nodiscard]] std::size_t size() const noexcept {
+        return ironpress_buffer_len(owner_.get());
+    }
+
+    /// Report whether this object still owns a native PDF buffer.
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return static_cast<bool>(owner_);
+    }
+
+private:
+    explicit Pdf(detail::BufferOwner owner) noexcept : owner_(std::move(owner)) {}
+
+    [[nodiscard]] static Pdf take(IronpressStatus status,
+                                  IronpressBuffer* raw_buffer,
+                                  IronpressError* raw_error) {
+        detail::BufferOwner buffer(raw_buffer);
+        detail::NativeResult::require_success(status, raw_error);
+        if (!buffer) {
+            throw detail::NativeResult::contract_violation(
+                "Native conversion returned no PDF owner.");
+        }
+        return Pdf(std::move(buffer));
+    }
+
+    detail::BufferOwner owner_;
+
+    friend class Converter;
+    friend Pdf html_to_pdf(std::string_view html);
+    friend Pdf markdown_to_pdf(std::string_view markdown);
+};
+
+}

--- a/bindings/cpp/include/ironpress/types.hpp
+++ b/bindings/cpp/include/ironpress/types.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+#include "ironpress.h"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ironpress {
+
+namespace detail {
+class NativeResult;
+}
+
+/// Stable machine-readable Ironpress failure category.
+enum class Status : IronpressStatus {
+    unknown = -1,
+    invalid_argument = IRONPRESS_STATUS_INVALID_ARGUMENT,
+    invalid_utf8 = IRONPRESS_STATUS_INVALID_UTF8,
+    invalid_enum = IRONPRESS_STATUS_INVALID_ENUM,
+    invalid_handle = IRONPRESS_STATUS_INVALID_HANDLE,
+    output_not_empty = IRONPRESS_STATUS_OUTPUT_NOT_EMPTY,
+    parse = IRONPRESS_STATUS_PARSE,
+    css = IRONPRESS_STATUS_CSS,
+    layout = IRONPRESS_STATUS_LAYOUT,
+    render = IRONPRESS_STATUS_RENDER,
+    font = IRONPRESS_STATUS_FONT,
+    io = IRONPRESS_STATUS_IO,
+    security = IRONPRESS_STATUS_SECURITY,
+    internal = IRONPRESS_STATUS_INTERNAL,
+};
+
+/// A categorized Ironpress failure copied from the native error owner.
+class Error final : public std::runtime_error {
+public:
+    /// Return the stable category, or `unknown` for a newer native status.
+    [[nodiscard]] Status status() const noexcept { return status_; }
+
+    /// Return the exact status emitted by the linked native library.
+    [[nodiscard]] IronpressStatus native_status() const noexcept {
+        return native_status_;
+    }
+
+private:
+    Error(Status status, IronpressStatus native_status, std::string message)
+        : std::runtime_error(std::move(message)),
+          status_(status),
+          native_status_(native_status) {}
+
+    Status status_;
+    IronpressStatus native_status_;
+
+    friend class detail::NativeResult;
+};
+
+/// Named physical page sizes understood by Ironpress.
+enum class PageSize : std::uint32_t {
+    a4 = IRONPRESS_PAGE_SIZE_A4,
+    letter = IRONPRESS_PAGE_SIZE_LETTER,
+    legal = IRONPRESS_PAGE_SIZE_LEGAL,
+};
+
+/// The role of an optional Ironpress fallback-font pack.
+enum class FontPackKind : std::uint32_t {
+    cjk_japanese = IRONPRESS_FONT_PACK_CJK_JAPANESE,
+    cjk_korean = IRONPRESS_FONT_PACK_CJK_KOREAN,
+    cjk_simplified_chinese = IRONPRESS_FONT_PACK_CJK_SIMPLIFIED_CHINESE,
+    cjk_traditional_chinese = IRONPRESS_FONT_PACK_CJK_TRADITIONAL_CHINESE,
+    emoji = IRONPRESS_FONT_PACK_EMOJI,
+};
+
+/// A borrowed byte range that remains owned by the caller.
+class BytesView final {
+public:
+    /// Borrow one pointer-plus-size range for the duration of a native call.
+    BytesView(const std::uint8_t* data, std::size_t size)
+        : value_{data, size} {
+        if (data == nullptr && size != 0) {
+            throw std::invalid_argument(
+                "byte data must not be null when its size is non-zero");
+        }
+    }
+
+    /// Borrow a byte vector without copying it.
+    explicit BytesView(const std::vector<std::uint8_t>& bytes) noexcept
+        : value_{bytes.data(), bytes.size()} {}
+
+    /// Return the borrowed data pointer.
+    [[nodiscard]] const std::uint8_t* data() const noexcept {
+        return value_.data;
+    }
+
+    /// Return the borrowed byte count.
+    [[nodiscard]] std::size_t size() const noexcept { return value_.len; }
+
+private:
+    [[nodiscard]] IronpressBytes native() const noexcept { return value_; }
+
+    IronpressBytes value_;
+
+    friend class Converter;
+};
+
+/// A positive finite custom page size measured in points.
+class PageDimensions final {
+public:
+    /// Parse physical point dimensions into a valid custom page size.
+    [[nodiscard]] static PageDimensions from_points(float width, float height) {
+        if (!std::isfinite(width) || width <= 0.0F) {
+            throw std::invalid_argument("page width must be positive and finite");
+        }
+        if (!std::isfinite(height) || height <= 0.0F) {
+            throw std::invalid_argument("page height must be positive and finite");
+        }
+        return PageDimensions(width, height);
+    }
+
+    /// Return the physical width in points.
+    [[nodiscard]] float width() const noexcept { return width_; }
+
+    /// Return the physical height in points.
+    [[nodiscard]] float height() const noexcept { return height_; }
+
+private:
+    PageDimensions(float width, float height) noexcept
+        : width_(width), height_(height) {}
+
+    float width_;
+    float height_;
+};
+
+/// Finite physical page margins in CSS clockwise order.
+class PageMargins final {
+public:
+    /// Parse four equal physical margins.
+    [[nodiscard]] static PageMargins uniform(float points) {
+        return from_points(points, points, points, points);
+    }
+
+    /// Parse physical margins in top, right, bottom, left order.
+    [[nodiscard]] static PageMargins from_points(float top,
+                                                 float right,
+                                                 float bottom,
+                                                 float left) {
+        if (!std::isfinite(top) || !std::isfinite(right) ||
+            !std::isfinite(bottom) || !std::isfinite(left)) {
+            throw std::invalid_argument("page margins must be finite");
+        }
+        return PageMargins(top, right, bottom, left);
+    }
+
+    /// Return the top margin in points.
+    [[nodiscard]] float top() const noexcept { return top_; }
+
+    /// Return the right margin in points.
+    [[nodiscard]] float right() const noexcept { return right_; }
+
+    /// Return the bottom margin in points.
+    [[nodiscard]] float bottom() const noexcept { return bottom_; }
+
+    /// Return the left margin in points.
+    [[nodiscard]] float left() const noexcept { return left_; }
+
+private:
+    PageMargins(float top, float right, float bottom, float left) noexcept
+        : top_(top), right_(right), bottom_(bottom), left_(left) {}
+
+    float top_;
+    float right_;
+    float bottom_;
+    float left_;
+};
+
+}

--- a/bindings/cpp/tests/run.sh
+++ b/bindings/cpp/tests/run.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repository_dir="$(cd "${test_dir}/../../.." && pwd)"
+readonly profile="${IRONPRESS_PROFILE:-debug}"
+readonly library_dir="${repository_dir}/target/${profile}"
+readonly work_dir="$(mktemp -d)"
+readonly host="$(uname -s)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+cd "${repository_dir}"
+build_arguments=(build -p ironpress-ffi)
+if [[ "${profile}" == "release" ]]; then
+    build_arguments+=(--release)
+elif [[ "${profile}" != "debug" ]]; then
+    echo "unsupported Rust build profile: ${profile}" >&2
+    exit 1
+fi
+cargo "${build_arguments[@]}"
+
+compile_static_smoke() {
+    "${CXX:-c++}" \
+        -std=c++17 \
+        -g \
+        -Wall \
+        -Wextra \
+        -Wpedantic \
+        -Werror \
+        -I bindings/c/include \
+        -I bindings/cpp/include \
+        bindings/cpp/tests/smoke.cpp \
+        "${library_dir}/libironpress_ffi.a" \
+        "$@" \
+        -o "${work_dir}/ironpress-cpp-static-smoke"
+}
+
+if [[ "${host}" == "Linux" ]]; then
+    compile_static_smoke -ldl -lpthread -lm
+else
+    compile_static_smoke
+fi
+
+"${CXX:-c++}" \
+    -std=c++17 \
+    -g \
+    -Wall \
+    -Wextra \
+    -Wpedantic \
+    -Werror \
+    -I bindings/c/include \
+    -I bindings/cpp/include \
+    bindings/cpp/tests/smoke.cpp \
+    -L "${library_dir}" \
+    -lironpress_ffi \
+    -o "${work_dir}/ironpress-cpp-smoke"
+
+test_arguments=(
+    tests/parity/fonts/ParitySans.ttf
+    tests/fonts/NotoEmoji-TestSubset.ttf
+)
+"${work_dir}/ironpress-cpp-static-smoke" "${test_arguments[@]}"
+
+case "${host}" in
+    Darwin)
+        DYLD_LIBRARY_PATH="${library_dir}" \
+            "${work_dir}/ironpress-cpp-smoke" "${test_arguments[@]}"
+        ;;
+    Linux)
+        if [[ "${IRONPRESS_VALGRIND:-0}" == "1" ]]; then
+            command -v valgrind >/dev/null
+            LD_LIBRARY_PATH="${library_dir}" valgrind \
+                --leak-check=full \
+                --track-origins=yes \
+                --show-leak-kinds=definite \
+                --errors-for-leak-kinds=definite \
+                --error-exitcode=1 \
+                "${work_dir}/ironpress-cpp-smoke" "${test_arguments[@]}"
+        else
+            LD_LIBRARY_PATH="${library_dir}" \
+                "${work_dir}/ironpress-cpp-smoke" "${test_arguments[@]}"
+        fi
+        ;;
+    *)
+        echo "unsupported C++ smoke-test host: ${host}" >&2
+        exit 1
+        ;;
+esac

--- a/bindings/cpp/tests/smoke.cpp
+++ b/bindings/cpp/tests/smoke.cpp
@@ -1,0 +1,224 @@
+#include "ironpress.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+static_assert(!std::is_default_constructible_v<ironpress::Pdf>);
+static_assert(!std::is_copy_constructible_v<ironpress::Pdf>);
+static_assert(!std::is_copy_assignable_v<ironpress::Pdf>);
+static_assert(std::is_nothrow_move_constructible_v<ironpress::Pdf>);
+static_assert(std::is_nothrow_move_assignable_v<ironpress::Pdf>);
+static_assert(std::is_nothrow_destructible_v<ironpress::Pdf>);
+
+static_assert(!std::is_copy_constructible_v<ironpress::Converter>);
+static_assert(!std::is_copy_assignable_v<ironpress::Converter>);
+static_assert(std::is_nothrow_move_constructible_v<ironpress::Converter>);
+static_assert(std::is_nothrow_move_assignable_v<ironpress::Converter>);
+static_assert(std::is_nothrow_destructible_v<ironpress::Converter>);
+static_assert(!std::is_default_constructible_v<ironpress::PageDimensions>);
+static_assert(!std::is_default_constructible_v<ironpress::PageMargins>);
+
+namespace {
+
+void require(bool condition, std::string_view message) {
+    if (!condition) {
+        std::cerr << message << '\n';
+        std::exit(EXIT_FAILURE);
+    }
+}
+
+std::vector<std::uint8_t> read_file(const char* path) {
+    std::ifstream file(path, std::ios::binary);
+    require(file.good(), "font fixture could not be opened");
+    return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+void require_pdf(const ironpress::Pdf& pdf) {
+    require(pdf.size() > 4, "PDF output is too short");
+    require(pdf.data() != nullptr, "PDF output has no readable bytes");
+    require(std::string_view(reinterpret_cast<const char*>(pdf.data()), 4) == "%PDF",
+            "conversion did not return a PDF");
+}
+
+void require_contains(const ironpress::Pdf& pdf,
+                      std::string_view expected,
+                      std::string_view message) {
+    const auto* begin = pdf.data();
+    const auto* end = begin + pdf.size();
+    const auto found = std::search(
+        begin, end, expected.begin(), expected.end(),
+        [](std::uint8_t byte, char character) {
+            return byte == static_cast<std::uint8_t>(character);
+        });
+    require(found != end, message);
+}
+
+IronpressBytes c_text(std::string_view value) {
+    return {reinterpret_cast<const std::uint8_t*>(value.data()), value.size()};
+}
+
+std::vector<std::uint8_t> render_equivalent_c_pdf(std::string_view source) {
+    IronpressConverter* converter = nullptr;
+    IronpressBuffer* pdf = nullptr;
+    IronpressError* error = nullptr;
+
+    require(ironpress_converter_new(&converter, &error) == IRONPRESS_STATUS_OK,
+            "C baseline converter allocation failed");
+    require(ironpress_converter_set_page_size(
+                converter, IRONPRESS_PAGE_SIZE_LETTER, &error) ==
+                IRONPRESS_STATUS_OK,
+            "C baseline page size failed");
+    require(ironpress_converter_set_margins(
+                converter, 24.0F, 24.0F, 24.0F, 24.0F, &error) ==
+                IRONPRESS_STATUS_OK,
+            "C baseline margins failed");
+    require(ironpress_converter_set_compress(
+                converter, IRONPRESS_FALSE, &error) == IRONPRESS_STATUS_OK,
+            "C baseline compression failed");
+    require(ironpress_converter_set_header(
+                converter, c_text("Contract header"), &error) ==
+                IRONPRESS_STATUS_OK,
+            "C baseline header failed");
+    require(ironpress_converter_set_footer(
+                converter, c_text("Page {page} / {pages}"), &error) ==
+                IRONPRESS_STATUS_OK,
+            "C baseline footer failed");
+    require(ironpress_converter_convert_html(
+                converter, c_text(source), &pdf, &error) == IRONPRESS_STATUS_OK,
+            "C baseline conversion failed");
+
+    const auto* data = ironpress_buffer_data(pdf);
+    const auto size = ironpress_buffer_len(pdf);
+    require(data != nullptr && size > 4, "C baseline returned no PDF bytes");
+    std::vector<std::uint8_t> bytes(data, data + size);
+    require(ironpress_buffer_free(&pdf) == IRONPRESS_STATUS_OK,
+            "C baseline PDF release failed");
+    require(ironpress_converter_free(&converter) == IRONPRESS_STATUS_OK,
+            "C baseline converter release failed");
+    return bytes;
+}
+
+}
+
+int main(int argc, char** argv) {
+    require(argc == 3, "expected custom-font and font-pack fixture paths");
+    require(ironpress::abi_version() == IRONPRESS_ABI_VERSION,
+            "ABI version query disagrees with the C header");
+    require(!ironpress::version().empty(), "package version is empty");
+
+    ironpress::Converter converter;
+    converter.set_page_size(ironpress::PageSize::letter)
+        .set_page_size(ironpress::PageDimensions::from_points(420.0F, 595.0F))
+        .set_margins(ironpress::PageMargins::uniform(24.0F))
+        .set_margins(ironpress::PageMargins::from_points(36.0F, 36.0F, 36.0F,
+                                                        36.0F))
+        .set_header("C++ RAII")
+        .set_footer("Page {page} / {pages}")
+        .set_compression(true)
+        .set_jpeg_quality(82)
+        .set_auto_resize_images(true)
+        .set_image_dpi(240.0F)
+        .set_filter_dpi(192.0F)
+        .set_mask_dpi(240.0F)
+        .set_background_raster_dpi(160.0F)
+        .set_occlusion_culling(false)
+        .set_sanitization(true);
+
+    const auto custom_font = read_file(argv[1]);
+    converter.add_font("ParitySans", ironpress::BytesView(custom_font));
+    const auto font_pack = read_file(argv[2]);
+    converter.add_font_pack(ironpress::FontPackKind::emoji,
+                            ironpress::BytesView(font_pack));
+
+    auto pdf = converter.convert_html(
+        "<p style=\"font-family:ParitySans\">Hello from C++ 😀</p>");
+    require_pdf(pdf);
+    require_contains(pdf, "/MediaBox [0 0 420 595]",
+                     "custom page dimensions were not applied");
+    require_contains(pdf, "ParitySans", "custom font was not embedded");
+    const auto font_pack_pdf = converter.convert_html("<p>😀</p>");
+    require_contains(font_pack_pdf, "NotoEmoji",
+                     "emoji font pack was not embedded");
+
+    auto moved_pdf = std::move(pdf);
+    require(!pdf, "moved-from PDF still owns the native buffer");
+    require_pdf(moved_pdf);
+
+    ironpress::Converter moved_converter = std::move(converter);
+    require(!converter, "moved-from converter still owns the native handle");
+    require_pdf(moved_converter.convert_markdown("# Markdown"));
+
+    bool invalid_utf8_was_typed = false;
+    const char invalid_utf8[] = {static_cast<char>(0xff)};
+    try {
+        (void)moved_converter.convert_html(std::string_view(invalid_utf8, 1));
+    } catch (const ironpress::Error& error) {
+        invalid_utf8_was_typed = error.status() == ironpress::Status::invalid_utf8;
+        require(!std::string_view(error.what()).empty(), "native error message is empty");
+    }
+    require(invalid_utf8_was_typed, "invalid UTF-8 did not produce a typed error");
+
+    bool moved_from_was_rejected = false;
+    try {
+        (void)converter.convert_html("<p>closed</p>");
+    } catch (const ironpress::Error& error) {
+        moved_from_was_rejected = error.status() == ironpress::Status::invalid_handle;
+    }
+    require(moved_from_was_rejected, "moved-from converter was not rejected safely");
+
+    bool invalid_configuration_was_typed = false;
+    try {
+        moved_converter.set_image_dpi(
+            std::numeric_limits<float>::infinity());
+    } catch (const ironpress::Error& error) {
+        invalid_configuration_was_typed =
+            error.status() == ironpress::Status::invalid_argument;
+    }
+    require(invalid_configuration_was_typed,
+            "invalid configuration did not produce a typed error");
+
+    bool invalid_page_size_was_rejected = false;
+    try {
+        (void)ironpress::PageDimensions::from_points(0.0F, 595.0F);
+    } catch (const std::invalid_argument&) {
+        invalid_page_size_was_rejected = true;
+    }
+    require(invalid_page_size_was_rejected,
+            "invalid page dimensions formed a public value");
+
+    const auto equivalent_source =
+        std::string_view("<h1>Deterministic C and C++ contract</h1>");
+    ironpress::Converter equivalent_converter;
+    equivalent_converter.set_page_size(ironpress::PageSize::letter)
+        .set_margins(ironpress::PageMargins::uniform(24.0F))
+        .set_compression(false)
+        .set_header("Contract header")
+        .set_footer("Page {page} / {pages}");
+    const auto equivalent_cpp_pdf =
+        equivalent_converter.convert_html(equivalent_source);
+    const auto equivalent_c_pdf = render_equivalent_c_pdf(equivalent_source);
+    require(equivalent_c_pdf.size() == equivalent_cpp_pdf.size() &&
+                std::equal(equivalent_c_pdf.begin(), equivalent_c_pdf.end(),
+                           equivalent_cpp_pdf.data()),
+            "equivalent C and C++ configurations produced different PDFs");
+
+    for (int iteration = 0; iteration < 25; ++iteration) {
+        ironpress::Converter cycle;
+        auto cycle_pdf = cycle.convert_html("<p>ownership cycle</p>");
+        require_pdf(cycle_pdf);
+    }
+
+    require_pdf(ironpress::html_to_pdf("<p>one shot</p>"));
+    require_pdf(ironpress::markdown_to_pdf("# one shot"));
+    return EXIT_SUCCESS;
+}

--- a/bindings/cpp/tests/verify-package.sh
+++ b/bindings/cpp/tests/verify-package.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <platform-architecture>" >&2
+    exit 1
+fi
+
+readonly test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repository_dir="$(cd "${test_dir}/../../.." && pwd)"
+readonly platform="$1"
+readonly version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' \
+    "${repository_dir}/bindings/c/Cargo.toml" | head -n 1)"
+readonly bundle="ironpress-c-${version}-${platform}"
+readonly archive="${repository_dir}/dist/c/${bundle}.tar.gz"
+readonly work_dir="$(mktemp -d)"
+readonly package_dir="${work_dir}/${bundle}"
+readonly host="$(uname -s)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+tar -xzf "${archive}" -C "${work_dir}"
+
+compile_static_smoke() {
+    "${CXX:-c++}" \
+        -std=c++17 \
+        -Wall \
+        -Wextra \
+        -Wpedantic \
+        -Werror \
+        -I "${package_dir}/include" \
+        "${repository_dir}/bindings/cpp/tests/smoke.cpp" \
+        "${package_dir}/lib/libironpress_ffi.a" \
+        "$@" \
+        -o "${work_dir}/ironpress-cpp-package-static-smoke"
+}
+
+if [[ "${host}" == "Linux" ]]; then
+    compile_static_smoke -ldl -lpthread -lm
+else
+    compile_static_smoke
+fi
+
+"${CXX:-c++}" \
+    -std=c++17 \
+    -Wall \
+    -Wextra \
+    -Wpedantic \
+    -Werror \
+    -I "${package_dir}/include" \
+    "${repository_dir}/bindings/cpp/tests/smoke.cpp" \
+    -L "${package_dir}/lib" \
+    -lironpress_ffi \
+    -o "${work_dir}/ironpress-cpp-package-smoke"
+
+test_arguments=(
+    "${repository_dir}/tests/parity/fonts/ParitySans.ttf"
+    "${repository_dir}/tests/fonts/NotoEmoji-TestSubset.ttf"
+)
+"${work_dir}/ironpress-cpp-package-static-smoke" "${test_arguments[@]}"
+
+case "${host}" in
+    Darwin)
+        DYLD_LIBRARY_PATH="${package_dir}/lib" \
+            "${work_dir}/ironpress-cpp-package-smoke" "${test_arguments[@]}"
+        ;;
+    Linux)
+        LD_LIBRARY_PATH="${package_dir}/lib" \
+            "${work_dir}/ironpress-cpp-package-smoke" "${test_arguments[@]}"
+        ;;
+    *)
+        echo "unsupported C++ package-test host: ${host}" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/check-site.mjs
+++ b/scripts/check-site.mjs
@@ -30,6 +30,7 @@ const pages = [
     ["rust", ["cargo add ironpress", "use ironpress::html_to_pdf;"]],
     ["cli", ["cargo install ironpress", "ironpress invoice.html invoice.pdf"]],
     ["c", ['#include "ironpress.h"', "ironpress_html_to_pdf", "ironpress_buffer_free"]],
+    ["cpp", ['#include "ironpress.hpp"', "ironpress::Converter", "ironpress::Error"]],
     ["dotnet", ["dotnet add package Ironpress", "new HtmlConverter", "using var"]],
     ["java", ["&lt;artifactId&gt;ironpress&lt;/artifactId&gt;", "new HtmlConverter", "try (var converter"]],
     ["python", ["python -m pip install ironpress", "ironpress.html_to_pdf"]],
@@ -307,6 +308,7 @@ if (bindingsReadme !== null) {
   for (const runtime of [
     "rust",
     "cli",
+    "cpp",
     "dotnet",
     "java",
     "python",

--- a/site/get-started/cpp/index.html
+++ b/site/get-started/cpp/index.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>C++ Getting Started: HTML and Markdown to PDF | ironpress</title>
+    <meta
+      name="description"
+      content="Use the ironpress C++17 RAII wrapper to render HTML or Markdown to owned PDF bytes with move-only converters and typed native errors."
+    >
+    <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/cpp/">
+    <link rel="icon" type="image/png" href="../../assets/ironpress-logo.png">
+    <meta name="theme-color" content="#f3efe4">
+    <meta property="og:type" content="article"><meta property="og:site_name" content="ironpress">
+    <meta property="og:title" content="Get Started with ironpress in C++">
+    <meta property="og:description" content="Use move-only C++17 owners over the stable native ABI to render PDF bytes in process.">
+    <meta property="og:url" content="https://gastongouron.github.io/ironpress/get-started/cpp/">
+    <meta property="og:image" content="https://gastongouron.github.io/ironpress/assets/ironpress-logo.png">
+    <meta property="og:image:alt" content="ironpress logo"><meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="../../assets/styles.css"><link rel="stylesheet" href="../../assets/guide.css"><link rel="stylesheet" href="../../assets/get-started.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Get Started with ironpress in C++",
+        "description": "Download the native library and generate PDF bytes from HTML or Markdown with C++17 RAII owners.",
+        "author": { "@type": "Person", "name": "Gaston Gouron", "url": "https://github.com/gastongouron" },
+        "publisher": { "@type": "Organization", "name": "ironpress", "url": "https://gastongouron.github.io/ironpress/" },
+        "mainEntityOfPage": "https://gastongouron.github.io/ironpress/get-started/cpp/",
+        "inLanguage": "en"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#article">Skip to article</a>
+    <header class="site-header">
+      <div class="shell header-inner">
+        <a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="44" height="44"><span>ironpress</span></a>
+        <nav aria-label="Primary navigation"><a href="../" aria-current="page">Get started</a><a href="../../guides/html-to-pdf-rust/">Guide</a><a href="../../playground/">Playground</a><a class="nav-github" href="https://github.com/gastongouron/ironpress">GitHub <span aria-hidden="true">↗</span></a></nav>
+      </div>
+    </header>
+
+    <main class="guide-main" id="article">
+      <div class="shell">
+        <header class="guide-hero">
+          <p class="eyebrow"><span></span> C++ getting started</p>
+          <h1>Generate PDF bytes<br><em>from C++</em></h1>
+          <p>Use move-only owners for native state and let deterministic destruction release every allocation.</p>
+          <span class="runtime-type">C++17 · ABI generation 1 · GCC, Clang, MSVC</span>
+        </header>
+
+        <div class="guide-layout">
+          <aside class="guide-toc" aria-label="Article contents"><p>In this guide</p><ol><li><a href="#install">Install</a></li><li><a href="#first-pdf">First PDF</a></li><li><a href="#markdown">Markdown</a></li><li><a href="#configure">Configure</a></li><li><a href="#resources">Resources</a></li><li><a href="#limits">Limits and errors</a></li><li><a href="#next">Next steps</a></li></ol></aside>
+
+          <article class="prose">
+            <h2 id="install">Download the native library</h2>
+            <p>Choose the archive for your platform from the matching GitHub release. It contains the C++ wrapper, the underlying C header, shared and static libraries, the ABI contract, and checksums.</p>
+            <pre><code>c++ -std=c++17 main.cpp \
+  -I ironpress-c-&lt;VERSION&gt;-linux-x86_64/include \
+  -L ironpress-c-&lt;VERSION&gt;-linux-x86_64/lib \
+  -lironpress_ffi -o render</code></pre>
+            <p>Keep the headers and library from the same archive. The wrapper checks the linked ABI generation before use.</p>
+
+            <h2 id="first-pdf">Create an HTML PDF</h2>
+            <pre><code>#include "ironpress.hpp"
+
+#include &lt;fstream&gt;
+
+int main() {
+    ironpress::Converter converter;
+    auto pdf = converter.convert_html("&lt;h1&gt;Hello from C++&lt;/h1&gt;");
+
+    std::ofstream output("output.pdf", std::ios::binary);
+    output.write(reinterpret_cast&lt;const char*&gt;(pdf.data()),
+                 static_cast&lt;std::streamsize&gt;(pdf.size()));
+}</code></pre>
+            <div class="guide-callout"><strong>Ownership rule</strong><p><code>Converter</code> and <code>Pdf</code> are move-only. Their destructors release the one native owner and never throw.</p></div>
+
+            <h2 id="markdown">Render Markdown</h2>
+            <p>Markdown returns the same uniquely owned PDF type:</p>
+            <pre><code>auto pdf = converter.convert_markdown(
+    "# Release notes\n\nEverything shipped."
+);</code></pre>
+
+            <h2 id="configure">Reuse a configured converter</h2>
+            <p>Configuration methods return the converter, so related settings stay readable and reusable.</p>
+            <pre><code>converter
+    .set_page_size(ironpress::PageSize::letter)
+    .set_margins(ironpress::PageMargins::uniform(36.0F))
+    .set_compression(true)
+    .set_footer("Page {page} / {pages}");
+
+auto first = converter.convert_html(first_html);
+auto second = converter.convert_html(second_html);</code></pre>
+
+            <h2 id="resources">Provide fonts as bytes</h2>
+            <p>The C++ wrapper does not read document paths or access the network. Read a TrueType font or optional CJK or emoji pack in your application, then lend its bytes for one call.</p>
+            <pre><code>std::vector&lt;std::uint8_t&gt; font = read_font();
+converter.add_font("Inter", ironpress::BytesView(font));</code></pre>
+
+            <h2 id="limits">Handle failures and runtime limits</h2>
+            <p>Fallible methods throw <code>ironpress::Error</code> after the C call returns. Its status is stable and its message is copied before the native error owner is released.</p>
+            <pre><code>try {
+    auto pdf = converter.convert_html(source);
+} catch (const ironpress::Error&amp; error) {
+    log(error.status(), error.what());
+}</code></pre>
+            <ul class="guide-checklist">
+              <li>No exception or Rust panic crosses the native boundary.</li>
+              <li>A converter may move between threads while idle, but concurrent use is unsupported.</li>
+              <li>Local paths, direct file output, async, streaming, and remote HTTP are absent.</li>
+              <li>A moved-from owner may be destroyed or assigned a new owner.</li>
+            </ul>
+
+            <h2 id="next">Go further</h2>
+            <div class="guide-links">
+              <a href="https://github.com/gastongouron/ironpress/releases">Download a release</a><a href="https://github.com/gastongouron/ironpress/tree/main/bindings/cpp">C++ binding reference</a><a href="https://github.com/gastongouron/ironpress/blob/main/bindings/c/ABI.md">ABI contract</a><a href="https://github.com/gastongouron/ironpress/blob/main/bindings/README.md">Capability matrix</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site-footer"><div class="shell footer-inner"><a class="brand" href="../../" aria-label="ironpress home"><img src="../../assets/ironpress-logo.png" alt="ironpress" width="36" height="36"><span>ironpress</span></a><p>Pure-Rust document rendering. Open source under MIT.</p><nav aria-label="Footer navigation"><a href="../">All runtimes</a><a href="https://github.com/gastongouron/ironpress/releases">Releases</a><a href="../../parity/reports/">Parity</a></nav></div></footer>
+  </body>
+</html>

--- a/site/get-started/index.html
+++ b/site/get-started/index.html
@@ -6,7 +6,7 @@
     <title>Get Started with ironpress in Your Runtime</title>
     <meta
       name="description"
-      content="Choose an ironpress guide for Rust, C, .NET, Java, the CLI, Python, Ruby, browser JavaScript, TypeScript, or Node.js."
+      content="Choose an ironpress guide for Rust, C, C++, .NET, Java, the CLI, Python, Ruby, browser JavaScript, TypeScript, or Node.js."
     >
     <link rel="canonical" href="https://gastongouron.github.io/ironpress/get-started/">
     <link rel="icon" type="image/png" href="../assets/ironpress-logo.png">
@@ -39,13 +39,14 @@
           "itemListElement": [
             { "@type": "ListItem", "position": 1, "name": "Rust", "url": "https://gastongouron.github.io/ironpress/get-started/rust/" },
             { "@type": "ListItem", "position": 2, "name": "C", "url": "https://gastongouron.github.io/ironpress/get-started/c/" },
-            { "@type": "ListItem", "position": 3, "name": "CLI", "url": "https://gastongouron.github.io/ironpress/get-started/cli/" },
-            { "@type": "ListItem", "position": 4, "name": ".NET", "url": "https://gastongouron.github.io/ironpress/get-started/dotnet/" },
-            { "@type": "ListItem", "position": 5, "name": "Java", "url": "https://gastongouron.github.io/ironpress/get-started/java/" },
-            { "@type": "ListItem", "position": 6, "name": "Python", "url": "https://gastongouron.github.io/ironpress/get-started/python/" },
-            { "@type": "ListItem", "position": 7, "name": "Ruby", "url": "https://gastongouron.github.io/ironpress/get-started/ruby/" },
-            { "@type": "ListItem", "position": 8, "name": "Browser JavaScript", "url": "https://gastongouron.github.io/ironpress/get-started/browser/" },
-            { "@type": "ListItem", "position": 9, "name": "Node.js", "url": "https://gastongouron.github.io/ironpress/get-started/node/" }
+            { "@type": "ListItem", "position": 3, "name": "C++", "url": "https://gastongouron.github.io/ironpress/get-started/cpp/" },
+            { "@type": "ListItem", "position": 4, "name": "CLI", "url": "https://gastongouron.github.io/ironpress/get-started/cli/" },
+            { "@type": "ListItem", "position": 5, "name": ".NET", "url": "https://gastongouron.github.io/ironpress/get-started/dotnet/" },
+            { "@type": "ListItem", "position": 6, "name": "Java", "url": "https://gastongouron.github.io/ironpress/get-started/java/" },
+            { "@type": "ListItem", "position": 7, "name": "Python", "url": "https://gastongouron.github.io/ironpress/get-started/python/" },
+            { "@type": "ListItem", "position": 8, "name": "Ruby", "url": "https://gastongouron.github.io/ironpress/get-started/ruby/" },
+            { "@type": "ListItem", "position": 9, "name": "Browser JavaScript", "url": "https://gastongouron.github.io/ironpress/get-started/browser/" },
+            { "@type": "ListItem", "position": 10, "name": "Node.js", "url": "https://gastongouron.github.io/ironpress/get-started/node/" }
           ]
         }
       }
@@ -75,7 +76,7 @@
       <div class="shell">
         <header class="get-started-hero">
           <div>
-            <p class="eyebrow"><span></span> One engine, nine paths</p>
+            <p class="eyebrow"><span></span> One engine, ten paths</p>
             <h1>Your first PDF.<br><em>Your runtime.</em></h1>
             <p class="get-started-lede">
               Pick the environment you already ship. Every guide starts from a
@@ -118,6 +119,12 @@
               <h3>C</h3>
               <p>Link a versioned static or shared library through opaque handles, stable status codes, and explicit ownership.</p>
               <a href="./c/">Start with C</a>
+            </article>
+            <article class="runtime-path">
+              <div class="runtime-path-top"><span class="runtime-label">RAII wrapper</span><span class="runtime-package">GitHub Releases</span></div>
+              <h3>C++</h3>
+              <p>Use move-only C++17 converters and PDF owners over the same stable native library.</p>
+              <a href="./cpp/">Start with C++</a>
             </article>
             <article class="runtime-path">
               <div class="runtime-path-top"><span class="runtime-label">Binding</span><span class="runtime-package">PyPI</span></div>
@@ -184,14 +191,14 @@
           <div class="prose">
             <table class="capability-table">
               <thead>
-                <tr><th>Capability</th><th>Rust</th><th>CLI</th><th>C</th><th>.NET</th><th>Java</th><th>Python</th><th>Ruby</th><th>WASM</th></tr>
+                <tr><th>Capability</th><th>Rust</th><th>CLI</th><th>C</th><th>C++</th><th>.NET</th><th>Java</th><th>Python</th><th>Ruby</th><th>WASM</th></tr>
               </thead>
               <tbody>
-                <tr><td>PDF bytes</td><td class="capability-yes">Yes</td><td class="capability-no">File</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td></tr>
-                <tr><td>Local resources</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td><td class="capability-no">Host bytes</td><td class="capability-no">Host bytes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td></tr>
-                <tr><td>Direct file output</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td></tr>
-                <tr><td>Streaming or async</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
-                <tr><td>Remote HTTP</td><td>Opt-in</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
+                <tr><td>PDF bytes</td><td class="capability-yes">Yes</td><td class="capability-no">File</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td></tr>
+                <tr><td>Local resources</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td><td class="capability-no">Host bytes</td><td class="capability-no">Host bytes</td><td class="capability-no">Host bytes</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">Host bytes</td></tr>
+                <tr><td>Direct file output</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-yes">Yes</td><td class="capability-yes">Yes</td><td class="capability-no">No</td></tr>
+                <tr><td>Streaming or async</td><td class="capability-yes">Yes</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
+                <tr><td>Remote HTTP</td><td>Opt-in</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td><td class="capability-no">No</td></tr>
               </tbody>
             </table>
           </div>

--- a/site/index.html
+++ b/site/index.html
@@ -198,11 +198,11 @@
               <span class="feature-number">04</span>
               <h3>Multiple runtimes</h3>
               <p>
-                Use the same core from Rust, C, .NET, Java, the CLI, Python, Ruby,
-                browser WebAssembly, or Node.js.
+                Use the same core from Rust, C, C++, .NET, Java, the CLI, Python,
+                Ruby, browser WebAssembly, or Node.js.
               </p>
               <ul class="runtime-list" aria-label="Supported runtimes">
-                <li>Rust</li><li>C</li><li>.NET</li><li>Java</li><li>CLI</li><li>Python</li><li>Ruby</li><li>Browser</li><li>Node.js</li>
+                <li>Rust</li><li>C</li><li>C++</li><li>.NET</li><li>Java</li><li>CLI</li><li>Python</li><li>Ruby</li><li>Browser</li><li>Node.js</li>
               </ul>
             </article>
             <article class="feature-card">
@@ -221,7 +221,7 @@
         <div class="shell">
           <div class="section-heading section-heading-light">
             <div>
-              <p class="eyebrow"><span></span> One core, nine paths</p>
+              <p class="eyebrow"><span></span> One core, ten paths</p>
               <h2>Start in the language<br>you already ship.</h2>
             </div>
             <p>
@@ -253,6 +253,15 @@ IronpressStatus status =
   ironpress_html_to_pdf(
     html, &amp;pdf, &amp;error
   );</code></pre>
+            </article>
+            <article class="code-card">
+              <p><span>C++</span><a href="./get-started/cpp/">guide →</a></p>
+              <pre><code><b>#include</b> <em>"ironpress.hpp"</em>
+
+ironpress::Converter converter;
+<b>auto</b> pdf = converter.convert_html(
+  <em>"&lt;h1&gt;Hello&lt;/h1&gt;"</em>
+);</code></pre>
             </article>
             <article class="code-card">
               <p><span>Python</span><a href="https://pypi.org/project/ironpress/">PyPI ↗</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -31,6 +31,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://gastongouron.github.io/ironpress/get-started/cpp/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://gastongouron.github.io/ironpress/get-started/dotnet/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
Closes #228

## Summary

- add a header-only C++17 wrapper over ABI v1
- own converters and PDFs through move-only RAII
- expose native failures as typed C++ errors
- ship the C++ headers in every native release archive
- publish a public C++ guide and update the binding matrix

## Verification

- compare equivalent C and C++ configuration byte for byte
- compose page geometry, headers, footers, fonts, and font packs
- repeat create, convert, move, and destroy cycles under Valgrind
- test static and shared artifacts with GCC, Clang, and MSVC
- extract and consume the exact archives prepared for release
- pass the site contract, Rust 1.88 clippy, and FFI tests
