### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased
 
-## [1.5.5] — 2026-08-25
+## [1.6.0] — 2026-08-26
 
 ### Added
 
 - Explicit rich-header and rich-footer APIs render sanitized HTML fragments,
   including images and tables, through CSS running elements on every page.
+
+## [1.5.5] — 2026-08-25
+
+### Added
+
 - A header-only C++17 binding provides move-only RAII owners, typed errors, and
   the complete portable converter contract over the stable C ABI.
 - Native release archives provide relocatable CMake targets for C and C++, plus

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress"
-version = "1.5.5"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter with layout engine, LaTeX math, tables, images, custom fonts, and streaming output. No browser, no system dependencies."

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ byte[] pdf = converter.ConvertHtml("<h1>Hello</h1>");
 <dependency>
   <groupId>io.github.gastongouron</groupId>
   <artifactId>ironpress</artifactId>
-  <version>1.5.5</version>
+  <version>1.6.0</version>
 </dependency>
 ```
 

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-ffi"
-version = "1.5.5"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.88"
 publish = false
@@ -12,4 +12,4 @@ repository = "https://github.com/gastongouron/ironpress"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-ironpress-core = { version = "=1.5.5", path = "../..", package = "ironpress" }
+ironpress-core = { version = "=1.6.0", path = "../..", package = "ironpress" }

--- a/bindings/dotnet/src/Ironpress/Ironpress.csproj
+++ b/bindings/dotnet/src/Ironpress/Ironpress.csproj
@@ -11,7 +11,7 @@
 
     <PackageId>Ironpress</PackageId>
     <Title>Ironpress for .NET</Title>
-    <Version>1.5.5</Version>
+    <Version>1.6.0</Version>
     <Authors>Paul Gaston Gouron and Ironpress contributors</Authors>
     <Description>In-process HTML, CSS, and Markdown to PDF rendering for .NET.</Description>
     <PackageTags>pdf;html;css;markdown;converter</PackageTags>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -12,7 +12,7 @@ Ironpress requires Java 17 or newer.
 <dependency>
   <groupId>io.github.gastongouron</groupId>
   <artifactId>ironpress</artifactId>
-  <version>1.5.5</version>
+  <version>1.6.0</version>
 </dependency>
 ```
 

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.gastongouron</groupId>
   <artifactId>ironpress</artifactId>
-  <version>1.5.5</version>
+  <version>1.6.0</version>
   <packaging>jar</packaging>
 
   <name>Ironpress for Java</name>

--- a/bindings/java/src/main/java/io/github/gastongouron/ironpress/IronpressInfo.java
+++ b/bindings/java/src/main/java/io/github/gastongouron/ironpress/IronpressInfo.java
@@ -6,7 +6,7 @@ public final class IronpressInfo {
   public static final int REQUIRED_ABI_VERSION = 1;
 
   /** Ironpress version carried by this Maven artifact. */
-  public static final String PACKAGE_VERSION = "1.5.5";
+  public static final String PACKAGE_VERSION = "1.6.0";
 
   private IronpressInfo() {}
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-python"
-version = "1.5.5"
+version = "1.6.0"
 edition = "2024"
 publish = false
 description = "Python bindings for the Ironpress HTML-to-PDF engine"
@@ -12,5 +12,5 @@ name = "ironpress_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-ironpress-core = { version = "=1.5.5", path = "../..", package = "ironpress" }
+ironpress-core = { version = "=1.6.0", path = "../..", package = "ironpress" }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ironpress"
-version = "1.5.5"
+version = "1.6.0"
 description = "Pure Rust HTML/CSS/Markdown to PDF converter. No browser, no system dependencies."
 readme = "README.md"
 license = "MIT"

--- a/bindings/ruby/Gemfile.lock
+++ b/bindings/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ironpress (1.5.5)
+    ironpress (1.6.0)
       rb_sys (~> 0.9)
 
 GEM

--- a/bindings/ruby/ext/ironpress/Cargo.toml
+++ b/bindings/ruby/ext/ironpress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironpress-ruby"
-version = "1.5.5"
+version = "1.6.0"
 edition = "2024"
 publish = false
 description = "Ruby bindings for the Ironpress HTML-to-PDF engine"
@@ -12,6 +12,6 @@ name = "ironpress_ruby"
 crate-type = ["cdylib"]
 
 [dependencies]
-ironpress-core = { version = "=1.5.5", package = "ironpress" }
+ironpress-core = { version = "=1.6.0", package = "ironpress" }
 magnus = "0.7"
 rb-sys = { version = "0.9", default-features = false, features = ["stable-api-compiled-fallback"] }

--- a/bindings/ruby/lib/ironpress/version.rb
+++ b/bindings/ruby/lib/ironpress/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ironpress
-  VERSION = "1.5.5"
+  VERSION = "1.6.0"
 end

--- a/site/get-started/java/index.html
+++ b/site/get-started/java/index.html
@@ -58,7 +58,7 @@
             <pre><code>&lt;dependency&gt;
   &lt;groupId&gt;io.github.gastongouron&lt;/groupId&gt;
   &lt;artifactId&gt;ironpress&lt;/artifactId&gt;
-  &lt;version&gt;1.5.5&lt;/version&gt;
+  &lt;version&gt;1.6.0&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
             <p>The package supports Linux x86-64 and ARM64 with glibc 2.28 or newer, macOS x86-64 and ARM64, and Windows x86-64.</p>
 


### PR DESCRIPTION
## Summary

- Bump Rust, C ABI, .NET, Java, Python, and Ruby metadata to 1.6.0.
- Update the Java examples in the README and public site.
- Cut the 1.6.0 changelog entry for rich HTML page margins.
- Move that entry out of 1.5.5, which shipped before the feature merged.

## Version choice

This is a backward-compatible minor release because it adds the public
header_html and footer_html APIs across supported surfaces.

## Verification

- scripts/check-release-versions.sh 1.6.0
- cargo fmt --all -- --check
- cargo check --all-features
- cargo package --allow-dirty
- npm run check in scripts
- npm test in scripts
- Main CI is green at 407af6a, including parity, C, Java, and .NET.

## After merge

Wait for main to turn green, then create the v1.6.0 GitHub release. The release
event publishes the crate and language packages.