### PR TITLE
fix(native): pin the release dependency graph

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,8 +13,9 @@ names must not be advertised as generally available before that happens.
 
 ConanCenter requires recipes to build from source rather than repackage
 precompiled binaries. The vcpkg port follows the same model so both registries
-exercise one contract. Each recipe fetches an immutable Ironpress tag and
-verifies its archive checksum.
+exercise one contract. Each recipe fetches an immutable Ironpress tag, injects
+the pinned workspace lockfile, and verifies both checksums before building with
+`--locked`.
 
 Building requires Rust 1.88 or newer on the target host. The initial recipes
 support native builds for Linux and macOS on x86-64 and ARM64, and Windows on
@@ -75,10 +76,12 @@ the immutable source archive and its checksum are part of each recipe.
 
 1. Update the version in `packaging/conan/config.yml`, `conandata.yml`, and the
    vcpkg manifest.
-2. Update the Conan SHA-256 and vcpkg SHA-512 from the tagged source archive.
-3. Run the Conan and vcpkg static and shared consumer tests.
-4. Let the full native CI matrix pass before opening external registry updates.
+2. Pin the released `Cargo.lock` URL and its Conan SHA-256 and vcpkg SHA-512.
+3. Update the Conan SHA-256 and vcpkg SHA-512 from the tagged source archive.
+4. Run the Conan and vcpkg static and shared consumer tests.
+5. Let the full native CI matrix pass before opening external registry updates.
 
 The `v1.6.0` source tag predates the committed workspace lockfile, so its recipe
-resolves compatible dependencies during the build. Future release tags include
-`Cargo.lock`; both recipes detect it and build with `--locked`.
+uses the immutable lockfile from the corresponding release merge. Future
+release tags include `Cargo.lock`, which remains pinned separately so an absent
+or mismatched lock cannot silently produce an unlocked package.

--- a/packaging/conan/all/conandata.yml
+++ b/packaging/conan/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
   "1.6.0":
-    url: "https://github.com/gastongouron/ironpress/archive/refs/tags/v1.6.0.tar.gz"
-    sha256: "380f174720f813d16d69cfd14f5a2af7657b0c2b58c33ec42dad612d7dcb974b"
+    archive:
+      url: "https://github.com/gastongouron/ironpress/archive/refs/tags/v1.6.0.tar.gz"
+      sha256: "380f174720f813d16d69cfd14f5a2af7657b0c2b58c33ec42dad612d7dcb974b"
+    cargo_lock:
+      url: "https://raw.githubusercontent.com/gastongouron/ironpress/11256bdeed794c8721777d8c52d420dd6ec433e0/Cargo.lock"
+      sha256: "6322f2d67285c66de3f3062fa8eccbeb1bffbbe7e7bb55d50ff44ea7084a4e93"

--- a/packaging/conan/all/conanfile.py
+++ b/packaging/conan/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
-from conan.tools.files import collect_libs, copy, get
+from conan.tools.files import collect_libs, copy, download, get
 import os
 
 
@@ -27,7 +27,13 @@ class IronpressConan(ConanFile):
         self.folders.build = "build"
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        sources = self.conan_data["sources"][self.version]
+        get(self, **sources["archive"], strip_root=True)
+        download(
+            self,
+            **sources["cargo_lock"],
+            filename=os.path.join(self.source_folder, "Cargo.lock"),
+        )
 
     def validate(self):
         supported = {
@@ -58,13 +64,8 @@ class IronpressConan(ConanFile):
         release = " --release" if self._cargo_profile == "release" else ""
         target_dir = os.path.join(self.build_folder, "cargo")
         manifest = os.path.join(self.source_folder, "Cargo.toml")
-        locked = (
-            " --locked"
-            if os.path.isfile(os.path.join(self.source_folder, "Cargo.lock"))
-            else ""
-        )
         self.run(
-            f"cargo build{locked} --manifest-path=\"{manifest}\""
+            f"cargo build --locked --manifest-path=\"{manifest}\""
             " --package ironpress-ffi"
             f" --target-dir=\"{target_dir}\"{release}"
         )

--- a/packaging/vcpkg/ports/ironpress/portfile.cmake
+++ b/packaging/vcpkg/ports/ironpress/portfile.cmake
@@ -6,6 +6,14 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+vcpkg_download_distfile(
+    CARGO_LOCK
+    URLS "https://raw.githubusercontent.com/gastongouron/ironpress/11256bdeed794c8721777d8c52d420dd6ec433e0/Cargo.lock"
+    FILENAME "ironpress-${VERSION}-Cargo.lock"
+    SHA512 05feb581d5dcb3af3ad11b947283e5c1e873997bb74786b2949fe7d058efc5d91151dc55e22aeff9ad1bb7f076c9fe6237f25ce588ec9679fbd3225997cecf00
+)
+configure_file("${CARGO_LOCK}" "${SOURCE_PATH}/Cargo.lock" COPYONLY)
+
 find_program(
     CARGO
     NAMES cargo cargo.exe
@@ -28,11 +36,6 @@ elseif(VCPKG_TARGET_IS_LINUX AND NOT VCPKG_HOST_IS_LINUX)
     message(FATAL_ERROR "Ironpress cannot cross-compile from ${HOST_TRIPLET} to ${TARGET_TRIPLET}.")
 endif()
 
-set(CARGO_LOCKED)
-if(EXISTS "${SOURCE_PATH}/Cargo.lock")
-    set(CARGO_LOCKED --locked)
-endif()
-
 function(ironpress_build profile cargo_profile)
     set(target_dir "${CURRENT_BUILDTREES_DIR}/${profile}")
     set(profile_argument)
@@ -42,7 +45,7 @@ function(ironpress_build profile cargo_profile)
     vcpkg_execute_required_process(
         COMMAND
             "${CARGO}" build
-            ${CARGO_LOCKED}
+            --locked
             --manifest-path "${SOURCE_PATH}/Cargo.toml"
             --package ironpress-ffi
             --target-dir "${target_dir}"


### PR DESCRIPTION
## Summary

- pin the exact v1.6.0 workspace lockfile in both source package recipes
- verify the lock independently before every build
- make `cargo build --locked` unconditional
- document the release update contract

## Why

The v1.6.0 tag predates the committed workspace `Cargo.lock`.

The first package build therefore resolved a fresh compatible graph. It also
created a lockfile in Conan's shared source cache, so later builds appeared
locked even though the first one was not.

Both recipes now fetch the immutable lockfile from the v1.6.0 release merge and
verify its checksum before Cargo runs.

## Verification

- Conan 2.31.1 static C and C++ consumers
- Conan 2.31.1 shared C and C++ consumers
- vcpkg static C and C++ consumers
- vcpkg shared C and C++ consumers
- injected vcpkg lock SHA-512 matches the committed workspace lock
- Python syntax and diff checks
