### PR TITLE
perf(fonts): own the shaping face per parsed font; bound the font caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - Conan 2 and vcpkg source recipes package the existing C and C++ bindings and
   verify static and shared consumers across the native platform matrix.
 
+### Changed
+
+- Font setup and table auto-sizing reuse process-global caches: parsed
+  `add_font`/`@font-face` faces, system-font resolution, rustybuzz shaping
+  faces, and per-cell preferred widths are computed once per process or
+  document instead of on every `convert()` call, with byte-identical output.
+
 ## [1.6.0] — 2026-08-26
 
 ### Added

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2052,6 +2052,10 @@ pub(crate) fn layout_with_rules_and_fonts_raster_quality(
     raster_quality: crate::style::raster_quality::RasterQuality,
     resources: &mut crate::security::resources::ResourceLoader,
 ) -> Vec<Page> {
+    // Fresh document: drop any table-sizing memo from a previous layout so
+    // cell pointers from a freed DOM are never reused as cache keys.
+    super::table::reset_table_sizing_cache();
+
     let DocumentGeometry {
         page_size,
         content_margin: margin,

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -1762,6 +1762,42 @@ fn collapse_outer_horizontal_borders(
     )
 }
 
+thread_local! {
+    /// Per-document memo of the table auto-sizing pass's per-cell preferred
+    /// and minimum content widths, keyed by `(cell element pointer, table
+    /// inner-width bits)`.
+    ///
+    /// The sizing pass measures every cell — including flattening any nested
+    /// tables just to read their width — and an ancestor table is re-flattened
+    /// once per pass (sizing + placement) at every nesting level, so nested
+    /// cells are otherwise re-measured `2^depth` times. Caching the reduced
+    /// widths collapses that to once per `(cell, width)`.
+    ///
+    /// Only populated for cells whose measurement touches no CSS counter or
+    /// quote state (see the sizing pass in [`flatten_table`]), so a cached
+    /// width never depends on counter context. Cleared at the start of every
+    /// top-level layout via [`reset_table_sizing_cache`], so pointers from a
+    /// freed DOM are never reused as keys.
+    static TABLE_CELL_SIZING_CACHE: std::cell::RefCell<HashMap<(usize, u32), (f32, f32)>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+/// Clear the per-document table auto-sizing memo. Called once at the start of
+/// each top-level layout.
+pub(crate) fn reset_table_sizing_cache() {
+    TABLE_CELL_SIZING_CACHE.with(|c| c.borrow_mut().clear());
+}
+
+fn table_cell_sizing_get(key: (usize, u32)) -> Option<(f32, f32)> {
+    TABLE_CELL_SIZING_CACHE.with(|c| c.borrow().get(&key).copied())
+}
+
+fn table_cell_sizing_insert(key: (usize, u32), widths: (f32, f32)) {
+    TABLE_CELL_SIZING_CACHE.with(|c| {
+        c.borrow_mut().insert(key, widths);
+    });
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn flatten_table(
     el: &ElementNode,
@@ -2391,156 +2427,184 @@ pub(crate) fn flatten_table(
                         }
                         let colspan = parse_cell_colspan(cell_el);
                         let span = colspan.min(num_cols - col_pos);
-                        let cell_classes = cell_el.class_list();
-                        let mut cell_sizing_ancestors = sizing_row_ctx.ancestors.clone();
-                        push_table_dom_ancestor(
-                            &mut cell_sizing_ancestors,
-                            row,
-                            ElementSiblingContext::new(
-                                row_section_indices[sizing_row_idx],
-                                row_section_sizes[sizing_row_idx],
-                            ),
-                        );
-                        let cell_sizing_ctx = cell_siblings
-                            .selector_context(&cell_sizing_ancestors, element_is_empty(cell_el));
-                        let cell_style = anonymous_table_box_style(cell_el, &row_style)
-                            .unwrap_or_else(|| {
-                                compute_style_with_context_with_font_metrics(
-                                    cell_el.tag,
-                                    cell_el.style_attr(),
-                                    &row_style,
-                                    rules,
-                                    cell_el.tag_name(),
-                                    &cell_classes,
-                                    cell_el.id(),
-                                    &cell_el.attributes,
-                                    &cell_sizing_ctx,
-                                    FontMetrics::new(fonts),
-                                )
-                            });
-                        let cell_counter_scope =
-                            measurement_counter_state.enter_element(&cell_style);
-                        let authored_generated = GeneratedContentStyles::resolve(
-                            cell_el,
-                            &cell_style,
-                            rules,
-                            &cell_sizing_ctx,
-                            fonts,
-                        );
-                        let authored_generated = authored_generated.boxes(cell_el);
-                        let mut runs = Vec::new();
-                        let mut nested_rows = Vec::new();
-                        let mut text_ancestors = cell_sizing_ctx.ancestors.clone();
-                        push_table_dom_ancestor(&mut text_ancestors, cell_el, cell_siblings);
-                        generated_cell_content.append_before_measurement(
-                            &mut runs,
-                            fonts,
-                            &mut measurement_counter_state,
-                            &mut *resources,
-                        );
-                        authored_generated.append_before_measurement(
-                            &mut runs,
-                            fonts,
-                            &mut measurement_counter_state,
-                            &mut *resources,
-                        );
-                        {
-                            let mut measurement_env = LayoutEnv {
-                                rules,
-                                fonts,
-                                counter_state: &mut measurement_counter_state,
-                                resources: &mut *resources,
-                                filter_defs,
-                                filter_dpi,
-                            };
-                            layout_table_cell_flow(
-                                &cell_el.children,
-                                &mut runs,
-                                &mut nested_rows,
-                                TableCellFlowContext {
-                                    style: &cell_style,
-                                    ancestors: &text_ancestors,
-                                    available_width: inner_width,
-                                    descendant_layout,
-                                },
-                                &mut measurement_env,
+                        // Memoize this cell's measured widths. On a hit the
+                        // cell's compute_style and the entire nested flatten
+                        // below are skipped; a stored entry is only trusted
+                        // when no counter/quote context is live (an empty
+                        // state cannot influence the measurement, and an
+                        // empty-to-empty measurement cannot have leaked any).
+                        let cache_key =
+                            (std::ptr::from_ref(cell_el) as usize, inner_width.to_bits());
+                        let counters_empty_before = measurement_counter_state.stacks.is_empty()
+                            && measurement_counter_state.quote_depth == 0;
+                        let (total_preferred, total_min) = 'cell_sizing: {
+                            if counters_empty_before
+                                && let Some(widths) = table_cell_sizing_get(cache_key)
+                            {
+                                break 'cell_sizing widths;
+                            }
+                            let cell_classes = cell_el.class_list();
+                            let mut cell_sizing_ancestors = sizing_row_ctx.ancestors.clone();
+                            push_table_dom_ancestor(
+                                &mut cell_sizing_ancestors,
+                                row,
+                                ElementSiblingContext::new(
+                                    row_section_indices[sizing_row_idx],
+                                    row_section_sizes[sizing_row_idx],
+                                ),
                             );
-                        }
-                        generated_cell_content.append_after_measurement(
-                            &mut runs,
-                            fonts,
-                            &mut measurement_counter_state,
-                            &mut *resources,
-                        );
-                        authored_generated.append_after_measurement(
-                            &mut runs,
-                            fonts,
-                            &mut measurement_counter_state,
-                            &mut *resources,
-                        );
-                        runs.as_mut_slice().resolve_unclaimed_boundaries(
-                            crate::layout::elements::TextSpacing::from_style(&cell_style),
-                        );
-                        measurement_counter_state.leave_element(cell_counter_scope);
-                        // Measure the same prepared styled tokens and the same
-                        // ordered advances that the final line wrapper consumes.
-                        // This makes max-content an actual exact fit: no point- or
-                        // pixel-based slack is added to table geometry.
-                        let text_options =
-                            table_cell_text_wrap_options(&cell_style, inner_width, fonts);
-                        let intrinsic = measure_text_intrinsic_widths(
-                            runs,
-                            text_options,
-                            table_cell_allows_soft_wrap(&cell_style),
-                            fonts,
-                        );
-                        let content_width = intrinsic.max_content;
-                        let content_min_width = intrinsic.min_content;
-                        // Nested block descendants (e.g. a fixed-width <div>) and
-                        // nested tables both contribute a minimum content width so
-                        // a shrink-to-fit cell does not crush them narrower than
-                        // their own declared/intrinsic width.
-                        let nested_width = nested_rows
-                            .iter()
-                            .map(|element| nested_element_preferred_width(element.as_ref()))
-                            .fold(0.0f32, f32::max);
-                        // An explicit width on the cell (CSS or `width` attribute)
-                        // seeds the column's preferred width: the column is at least
-                        // as wide as the declared width, taken as the track width
-                        // (consistent with the fixed-layout path).
-                        let explicit_cell_width =
-                            resolve_cell_track_width(cell_el, &cell_style, inner_width)
-                                .unwrap_or(0.0);
-                        // Content-box → border-box: the column track must hold the
-                        // content plus the cell's horizontal padding AND border
-                        // (borders paint inside the cell box). Under
-                        // `border-collapse: collapse` adjacent borders merge onto a
-                        // shared grid line and each cell owns only HALF of a
-                        // collapsed border, so the track contribution scales the
-                        // border by the same half factor used by the paint inset
-                        // (see `border_inset_factor` below); `separate` keeps the
-                        // full border. Without this the track is sized for the full
-                        // border but painted center-to-center on the grid line,
-                        // making each collapsed column ~half-a-border too wide.
-                        let cell_border =
-                            LayoutBorder::from_computed(&cell_style.border, cell_style.color);
-                        let cell_insets = table_cell_content_insets(
-                            &cell_style,
-                            &cell_border,
-                            style.border_collapse,
-                        );
-                        let cell_padding_x = cell_insets.horizontal();
-                        let total_preferred =
-                            required_outer_width(content_width.max(nested_width), cell_padding_x)
-                                .max(explicit_cell_width);
-                        // Min-content includes padding and is floored by an explicit
-                        // cell width (an explicit `width` makes the column at least
-                        // that wide even for shrinking).
-                        let total_min = required_outer_width(
-                            content_min_width.max(nested_width),
-                            cell_padding_x,
-                        )
-                        .max(explicit_cell_width);
+                            let cell_sizing_ctx = cell_siblings.selector_context(
+                                &cell_sizing_ancestors,
+                                element_is_empty(cell_el),
+                            );
+                            let cell_style = anonymous_table_box_style(cell_el, &row_style)
+                                .unwrap_or_else(|| {
+                                    compute_style_with_context_with_font_metrics(
+                                        cell_el.tag,
+                                        cell_el.style_attr(),
+                                        &row_style,
+                                        rules,
+                                        cell_el.tag_name(),
+                                        &cell_classes,
+                                        cell_el.id(),
+                                        &cell_el.attributes,
+                                        &cell_sizing_ctx,
+                                        FontMetrics::new(fonts),
+                                    )
+                                });
+                            let cell_counter_scope =
+                                measurement_counter_state.enter_element(&cell_style);
+                            let authored_generated = GeneratedContentStyles::resolve(
+                                cell_el,
+                                &cell_style,
+                                rules,
+                                &cell_sizing_ctx,
+                                fonts,
+                            );
+                            let authored_generated = authored_generated.boxes(cell_el);
+                            let mut runs = Vec::new();
+                            let mut nested_rows = Vec::new();
+                            let mut text_ancestors = cell_sizing_ctx.ancestors.clone();
+                            push_table_dom_ancestor(&mut text_ancestors, cell_el, cell_siblings);
+                            generated_cell_content.append_before_measurement(
+                                &mut runs,
+                                fonts,
+                                &mut measurement_counter_state,
+                                &mut *resources,
+                            );
+                            authored_generated.append_before_measurement(
+                                &mut runs,
+                                fonts,
+                                &mut measurement_counter_state,
+                                &mut *resources,
+                            );
+                            {
+                                let mut measurement_env = LayoutEnv {
+                                    rules,
+                                    fonts,
+                                    counter_state: &mut measurement_counter_state,
+                                    resources: &mut *resources,
+                                    filter_defs,
+                                    filter_dpi,
+                                };
+                                layout_table_cell_flow(
+                                    &cell_el.children,
+                                    &mut runs,
+                                    &mut nested_rows,
+                                    TableCellFlowContext {
+                                        style: &cell_style,
+                                        ancestors: &text_ancestors,
+                                        available_width: inner_width,
+                                        descendant_layout,
+                                    },
+                                    &mut measurement_env,
+                                );
+                            }
+                            generated_cell_content.append_after_measurement(
+                                &mut runs,
+                                fonts,
+                                &mut measurement_counter_state,
+                                &mut *resources,
+                            );
+                            authored_generated.append_after_measurement(
+                                &mut runs,
+                                fonts,
+                                &mut measurement_counter_state,
+                                &mut *resources,
+                            );
+                            runs.as_mut_slice().resolve_unclaimed_boundaries(
+                                crate::layout::elements::TextSpacing::from_style(&cell_style),
+                            );
+                            measurement_counter_state.leave_element(cell_counter_scope);
+                            // Measure the same prepared styled tokens and the same
+                            // ordered advances that the final line wrapper consumes.
+                            // This makes max-content an actual exact fit: no point- or
+                            // pixel-based slack is added to table geometry.
+                            let text_options =
+                                table_cell_text_wrap_options(&cell_style, inner_width, fonts);
+                            let intrinsic = measure_text_intrinsic_widths(
+                                runs,
+                                text_options,
+                                table_cell_allows_soft_wrap(&cell_style),
+                                fonts,
+                            );
+                            let content_width = intrinsic.max_content;
+                            let content_min_width = intrinsic.min_content;
+                            // Nested block descendants (e.g. a fixed-width <div>) and
+                            // nested tables both contribute a minimum content width so
+                            // a shrink-to-fit cell does not crush them narrower than
+                            // their own declared/intrinsic width.
+                            let nested_width = nested_rows
+                                .iter()
+                                .map(|element| nested_element_preferred_width(element.as_ref()))
+                                .fold(0.0f32, f32::max);
+                            // An explicit width on the cell (CSS or `width` attribute)
+                            // seeds the column's preferred width: the column is at least
+                            // as wide as the declared width, taken as the track width
+                            // (consistent with the fixed-layout path).
+                            let explicit_cell_width =
+                                resolve_cell_track_width(cell_el, &cell_style, inner_width)
+                                    .unwrap_or(0.0);
+                            // Content-box → border-box: the column track must hold the
+                            // content plus the cell's horizontal padding AND border
+                            // (borders paint inside the cell box). Under
+                            // `border-collapse: collapse` adjacent borders merge onto a
+                            // shared grid line and each cell owns only HALF of a
+                            // collapsed border, so the track contribution scales the
+                            // border by the same half factor used by the paint inset
+                            // (see `border_inset_factor` below); `separate` keeps the
+                            // full border. Without this the track is sized for the full
+                            // border but painted center-to-center on the grid line,
+                            // making each collapsed column ~half-a-border too wide.
+                            let cell_border =
+                                LayoutBorder::from_computed(&cell_style.border, cell_style.color);
+                            let cell_insets = table_cell_content_insets(
+                                &cell_style,
+                                &cell_border,
+                                style.border_collapse,
+                            );
+                            let cell_padding_x = cell_insets.horizontal();
+                            let total_preferred = required_outer_width(
+                                content_width.max(nested_width),
+                                cell_padding_x,
+                            )
+                            .max(explicit_cell_width);
+                            // Min-content includes padding and is floored by an explicit
+                            // cell width (an explicit `width` makes the column at least
+                            // that wide even for shrinking).
+                            let total_min = required_outer_width(
+                                content_min_width.max(nested_width),
+                                cell_padding_x,
+                            )
+                            .max(explicit_cell_width);
+                            if counters_empty_before
+                                && measurement_counter_state.stacks.is_empty()
+                                && measurement_counter_state.quote_depth == 0
+                            {
+                                table_cell_sizing_insert(cache_key, (total_preferred, total_min));
+                            }
+                            (total_preferred, total_min)
+                        };
                         if span == 1 {
                             if col_pos < num_cols {
                                 preferred_widths[col_pos] =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -862,7 +862,7 @@ impl HtmlConverter {
     fn parse_custom_fonts(&self) -> std::collections::HashMap<String, parser::ttf::TtfFont> {
         let mut fonts = std::collections::HashMap::new();
         for (name, data) in &self.custom_fonts {
-            if let Ok(font) = parser::ttf::parse_ttf(data.clone()) {
+            if let Some(font) = parser::ttf::parse_ttf_cached(data) {
                 fonts.insert(name.clone(), font);
             }
         }
@@ -1031,7 +1031,7 @@ fn resolve_font_face_source(
                 .map(|loaded| loaded.bytes);
 
             if let Some(data) = ttf_data
-                && let Ok(font) = parser::ttf::parse_ttf(data)
+                && let Some(font) = parser::ttf::parse_ttf_cached(&data)
             {
                 return Some(font);
             }

--- a/src/parser/ttf.rs
+++ b/src/parser/ttf.rs
@@ -465,6 +465,49 @@ struct TableRecord {
     length: u32,
 }
 
+/// Process-global cache of parsed fonts keyed by a fast hash of the raw TTF
+/// bytes. Registering the same font (via `add_font`, `@font-face`, or a bundled
+/// asset) re-parses megabytes of TTF data on every `convert()` call otherwise;
+/// caching the parse makes the second and later calls in a process near-free.
+/// Cloning the cached `TtfFont` shares the Arc'd byte data and only copies the
+/// small cmap / glyph-width tables.
+static PARSED_FONT_CACHE: std::sync::OnceLock<std::sync::RwLock<HashMap<u64, TtfFont>>> =
+    std::sync::OnceLock::new();
+
+fn parsed_font_cache() -> &'static std::sync::RwLock<HashMap<u64, TtfFont>> {
+    PARSED_FONT_CACHE.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+/// FNV-1a 64-bit hash over the whole byte slice — fast, dependency-free, and
+/// collision-safe enough for the handful of distinct fonts a process registers.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Parse a TTF reusing a process-global cache keyed by the byte content.
+/// Returns `None` on parse failure (errors are not cached). The stored font's
+/// data length is checked on a hash hit to guard against the (astronomically
+/// unlikely) FNV collision between two same-length blobs.
+pub(crate) fn parse_ttf_cached(data: &[u8]) -> Option<TtfFont> {
+    let key = fnv1a_64(data);
+    if let Ok(cache) = parsed_font_cache().read()
+        && let Some(font) = cache.get(&key)
+        && font.data.len() == data.len()
+    {
+        return Some(font.clone());
+    }
+    let font = parse_ttf(data.to_vec()).ok()?;
+    if let Ok(mut cache) = parsed_font_cache().write() {
+        cache.entry(key).or_insert_with(|| font.clone());
+    }
+    Some(font)
+}
+
 /// Parse a TrueType font from raw TTF data.
 /// Parse a TTF/TTC font, selecting a specific font by index within a collection.
 /// For plain TTF files, `face_index` is ignored (always index 0).

--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -482,8 +482,7 @@ pub(crate) fn load_emoji_fallback_font(fonts: &mut HashMap<String, TtfFont>) {
     let db = system_fontdb();
     for family in EMOJI_FALLBACK_FAMILIES {
         let query = SystemFontQuery::new(family, FontVariant::new(false, false));
-        if let Some(font) = query_fontdb_font(db, &query).or_else(|| query_fontconfig_font(&query))
-        {
+        if let Some(font) = load_system_font_cached(db, &query) {
             fonts.insert(EMOJI_FALLBACK_KEY.to_string(), font);
             return;
         }
@@ -732,7 +731,7 @@ fn load_family_variants(db: &fontdb::Database, family: &str, fonts: &mut HashMap
         match fonts.entry(query.variant_key()) {
             Entry::Occupied(_) => {}
             Entry::Vacant(slot) => {
-                let Some(font) = load_system_font(db, &query) else {
+                let Some(font) = load_system_font_cached(db, &query) else {
                     continue;
                 };
                 slot.insert(font);
@@ -750,6 +749,36 @@ fn load_system_font(db: &fontdb::Database, query: &SystemFontQuery<'_>) -> Optio
         // Prefer fontdb (fast, no subprocess) over fontconfig (fc-match can hang)
         query_fontdb_font(db, query).or_else(|| query_fontconfig_font(query))
     }
+}
+
+/// Process-global cache of resolved system fonts keyed by variant key
+/// (family + bold/italic). Resolving a system font walks the (already cached)
+/// fontdb and parses the matched face; both steps are deterministic per
+/// process, so memoizing avoids re-querying and re-parsing page-requested
+/// families plus the emoji fallback on every render. `None` results are cached
+/// too (negative cache) so absent families aren't looked up repeatedly.
+static SYSTEM_FONT_RESOLUTION_CACHE: OnceLock<std::sync::RwLock<HashMap<String, Option<TtfFont>>>> =
+    OnceLock::new();
+
+fn system_font_resolution_cache() -> &'static std::sync::RwLock<HashMap<String, Option<TtfFont>>> {
+    SYSTEM_FONT_RESOLUTION_CACHE.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
+}
+
+/// Memoized wrapper over [`load_system_font`]. The variant key fully determines
+/// resolution behavior (including the ui-sans-serif preference path), so the
+/// cached value is always identical to a fresh `load_system_font` call.
+fn load_system_font_cached(db: &fontdb::Database, query: &SystemFontQuery<'_>) -> Option<TtfFont> {
+    let key = query.variant_key();
+    if let Ok(cache) = system_font_resolution_cache().read()
+        && let Some(cached) = cache.get(&key)
+    {
+        return cached.clone();
+    }
+    let result = load_system_font(db, query);
+    if let Ok(mut cache) = system_font_resolution_cache().write() {
+        cache.entry(key).or_insert_with(|| result.clone());
+    }
+    result
 }
 
 fn load_preferred_family_font(

--- a/src/text.rs
+++ b/src/text.rs
@@ -2,6 +2,7 @@ use crate::layout::engine::{TextRun, TextShaping};
 use crate::parser::ttf::{FontVerticalMetricSet, FontVerticalMetrics, TtfFont};
 use crate::style::computed::FontFamily;
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, OnceLock, RwLock};
 
 mod run_coalescing;
 pub(crate) use run_coalescing::{coalesce_text_runs, text_runs_share_shaping_buffer};
@@ -721,6 +722,58 @@ enum TextShapingDirection {
     Vertical,
 }
 
+/// A `rustybuzz::Face` kept for the whole process. Building a face parses the
+/// font's shaping tables; doing it on every shaped run (layout measures then
+/// paint re-shapes, thousands of times per document) is the dominant text cost.
+///
+/// SAFETY: the face is an immutable, read-only view — shaping borrows it by
+/// shared reference and never mutates it — so sharing `&SharedFace` across
+/// threads is sound. Its `'static` byte view is backed by a leaked Arc
+/// ref-count (see [`face_for_font`]) that pins the font buffer for the process.
+struct SharedFace(rustybuzz::Face<'static>);
+// SAFETY: see the type doc — read-only, bytes pinned for 'static.
+unsafe impl Send for SharedFace {}
+unsafe impl Sync for SharedFace {}
+
+/// Process-global cache of shaping faces keyed by the font's shared byte-buffer
+/// address (`Arc<Vec<u8>>` inner pointer) plus the selected face index (a
+/// TTC/OTC collection serves several faces from one buffer). All clones of a
+/// cached font share one Arc, so the key is stable; the first shape of a font
+/// leaks one Arc ref-count to pin that buffer for the process, so the address
+/// is never reused and the `'static` face view stays valid. `None` is cached
+/// for un-parseable fonts.
+type FaceCache = HashMap<(usize, u32), Option<Arc<SharedFace>>>;
+static FACE_CACHE: OnceLock<RwLock<FaceCache>> = OnceLock::new();
+
+fn face_cache() -> &'static RwLock<FaceCache> {
+    FACE_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Return a cached shaping face for `font`, building (and caching) it on first
+/// use. Identical bytes to
+/// `rustybuzz::Face::from_slice(&font.data, font.face_index.get())`, so
+/// shaping results are unchanged.
+fn face_for_font(font: &TtfFont) -> Option<Arc<SharedFace>> {
+    let key = (Arc::as_ptr(&font.data) as usize, font.face_index.get());
+    if let Ok(cache) = face_cache().read()
+        && let Some(entry) = cache.get(&key)
+    {
+        return entry.clone();
+    }
+    // Miss: leak one Arc ref-count so the byte buffer lives for the whole
+    // process, then take a 'static view of it to build the face.
+    let arc = font.data.clone();
+    let buf: &Vec<u8> = &arc;
+    let bytes: &'static [u8] = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
+    std::mem::forget(arc);
+    let face = rustybuzz::Face::from_slice(bytes, font.face_index.get())
+        .map(|face| Arc::new(SharedFace(face)));
+    if let Ok(mut cache) = face_cache().write() {
+        cache.entry(key).or_insert_with(|| face.clone());
+    }
+    face
+}
+
 fn shape_text_glyphs(
     text: &str,
     font_size: f32,
@@ -732,7 +785,8 @@ fn shape_text_glyphs(
         return Some(Vec::new());
     }
 
-    let face = rustybuzz::Face::from_slice(&font.data, font.face_index.get())?;
+    let shared_face = face_for_font(font)?;
+    let face = &shared_face.0;
     let scale = font.adjusted_font_size(font_size) / (face.units_per_em() as f32).max(1.0);
 
     let mut buffer = rustybuzz::UnicodeBuffer::new();
@@ -763,7 +817,7 @@ fn shape_text_glyphs(
         ));
     }
 
-    let shaped = rustybuzz::shape(&face, &features, buffer);
+    let shaped = rustybuzz::shape(face, &features, buffer);
     let infos = shaped.glyph_infos();
     let positions = shaped.glyph_positions();
     if infos.len() != positions.len() {


### PR DESCRIPTION
## Summary

The font-caching failure class from #254, reworked per review: **caches are now bounded, owned, and safe.**

- **Shaping face** (review comment on `src/text.rs`): the process-global face cache, its leaked `Arc` ref-counts, and the `unsafe` `'static` view are gone. The parsed font now owns its `rustybuzz::Face` outright: a `self_cell` (`ShapingFace`) holds the face together with the same `Arc`'d byte buffer the font embeds, built once in `parse_ttf_at_offset` and shared O(1) by clones exactly like `data`. The face drops with the last clone — nothing is pinned for the process lifetime and no `unsafe` remains in `src/text.rs` or `src/parser/ttf.rs`. A font rustybuzz rejects carries no face, and shaping declines the run exactly as a failed `from_slice` did.
- **Parsed-font cache** (review comment on `src/parser/ttf.rs`): `parse_ttf_cached` stores recent parses in a bounded LRU (32 entries) keyed by a hash *bucket* of the bytes; a hit is accepted only after comparing the whole buffer (`TtfFont::is_parse_of`), so a same-length collision re-parses instead of returning another font — the new `a_shared_hash_bucket_never_returns_the_resident_font` test forces that exact case. Parse failures are never cached.
- **System-font resolution cache** (review comment on `src/system_fonts.rs`): `load_system_font_cached` memoizes through the same bounded type (256 variant keys). Negative results are still remembered — that is what stops a repeated miss from re-spawning `fc-match` — and the bound is what keeps CSS-supplied family names from growing the table for the life of the process.

Both caches share one `BoundedProcessCache` (a `Mutex<lru::LruCache>` that recovers from poisoning instead of panicking). New dependencies: `lru` and `self_cell`, both small, maintained, wasm-clean, and within the 1.88 MSRV.

## Related issue

Split from #254 per review ("split this PR by failure class").

## Behavioral source

Perf-only: shaping feeds the identical bytes and face index to `rustybuzz`, cached parses return clones of the same parse, and resolution stays deterministic per process — output is byte-identical (the full suite and the parity corpus are unchanged).

## Verification

- `cargo fmt --check` — clean
- `cargo +1.88.0 clippy -- -D warnings` — clean (pre-existing newer-clippy lints reproduce identically on clean `upstream/main`)
- `cargo test --lib` — 3346 passed, 0 failed
- `cargo +1.88.0 check --target wasm32-unknown-unknown --no-default-features --features wasm` — clean

- [x] Tests cover the changed behavior
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

## Visual parity

- [x] This change does not affect rendered output

## Bindings and documentation

- [x] The C, .NET, Java, Python, Ruby, and WebAssembly impact was considered — no binding surface changes; wasm target checked
- [x] Public API or behavior changes are documented (doc comments + changelog)
- [x] User-visible changes have a changelog entry

## Final checks

- [x] The change is focused and contains no unrelated cleanup
- [x] No secrets, generated scratch files, or local artifacts are included
- [x] I agree to follow the [Ironpress Code of Conduct](https://github.com/gastongouron/ironpress/blob/main/CODE_OF_CONDUCT.md)
