### PR TITLE
feat(svg): letter-spacing on <text> + custom-font stack and background-image coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 - Conan 2 and vcpkg source recipes package the existing C and C++ bindings and
   verify static and shared consumers across the native platform matrix.
+- SVG `<text>` honors `letter-spacing` (attribute or inline style, plain
+  number / px user units) through the PDF character-spacing operator on both
+  the custom-font and base-14 paths.
+
+### Fixed
+
+- SVG `<text>` with a CSS font-family stack ("MyFace, Helvetica") resolves
+  registered custom faces again, and every font the SVG renderer binds is also
+  subset and embedded; `<text>` inside CSS background-image SVGs now uses the
+  registered custom fonts instead of always falling back to standard fonts.
 
 ## [1.6.0] — 2026-08-26
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1104,6 +1104,94 @@ mod tests {
     use super::*;
 
     #[test]
+    fn svg_text_letter_spacing_emits_character_spacing() {
+        let pdf = html_to_pdf(
+            r#"<svg width="200" height="50" viewBox="0 0 200 50"><text x="10" y="30" font-size="20" letter-spacing="3">Hello</text></svg>"#,
+        )
+        .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("3 Tc"),
+            "letter-spacing should map to the PDF character-spacing operator"
+        );
+        assert!(
+            content.contains("0 Tc"),
+            "character spacing should be reset after the text object"
+        );
+    }
+
+    #[test]
+    fn add_font_used_by_svg_text() {
+        // A real shapeable face: SVG custom-font emission requires shaped
+        // glyph output, exactly like the HTML custom-font text path.
+        let ttf_data = include_bytes!("../assets/LiberationSans-Regular.ttf").to_vec();
+        let pdf = HtmlConverter::new()
+            .add_font("testfont", ttf_data)
+            .convert(
+                r##"<svg width="200" height="50" viewBox="0 0 200 50"><text x="10" y="30" font-family="testfont, Helvetica" font-size="20" fill="#000000">Hello</text></svg>"##,
+            )
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("/testfont 20 Tf"),
+            "SVG text should bind the registered custom font"
+        );
+        assert!(
+            content.contains("] TJ"),
+            "SVG text with a custom font should emit shaped glyph IDs"
+        );
+        assert!(
+            content.contains("/Subtype /CIDFontType2"),
+            "a custom font used only by SVG text should still be embedded"
+        );
+    }
+
+    #[test]
+    fn add_font_used_by_background_image_svg_text() {
+        // Custom-font text inside a CSS background-image SVG must bind and
+        // embed the registered face exactly like foreground SVG text.
+        let ttf_data = include_bytes!("../assets/LiberationSans-Regular.ttf").to_vec();
+        let svg = r##"<svg xmlns='http://www.w3.org/2000/svg' width='200' height='50'><text x='10' y='30' font-family='testfont' font-size='20' fill='black'>Hello</text></svg>"##;
+        let encoded = svg
+            .replace('<', "%3C")
+            .replace('>', "%3E")
+            .replace('#', "%23")
+            .replace('\'', "%27");
+        let pdf = HtmlConverter::new()
+            .add_font("testfont", ttf_data)
+            .convert(&format!(
+                r#"<div style="width:200px;height:50px;background-image:url(data:image/svg+xml,{encoded})">&nbsp;</div>"#
+            ))
+            .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("/testfont 20 Tf"),
+            "background SVG text should bind the registered custom font"
+        );
+        assert!(
+            content.contains("/Subtype /CIDFontType2"),
+            "a custom font used only by a background SVG should still be embedded"
+        );
+    }
+
+    #[test]
+    fn svg_text_with_unregistered_family_falls_back_to_base14() {
+        let pdf = html_to_pdf(
+            r#"<svg width="200" height="50" viewBox="0 0 200 50"><text x="10" y="30" font-family="NoSuchFont" font-size="20">Hello</text></svg>"#,
+        )
+        .unwrap();
+        let content = String::from_utf8_lossy(&pdf);
+        assert!(
+            content.contains("/Helvetica 20 Tf"),
+            "unregistered SVG font families should keep the base-14 mapping"
+        );
+        assert!(
+            content.contains("(Hello) Tj"),
+            "base-14 SVG text should keep literal text emission"
+        );
+    }
+
+    #[test]
     fn raster_quality_builder_groups_and_normalizes_all_raster_controls() {
         assert_eq!(
             HtmlConverter::new().jpeg_quality,

--- a/src/parser/svg.rs
+++ b/src/parser/svg.rs
@@ -258,6 +258,8 @@ pub enum SvgNode {
         font_bold: Option<bool>,
         /// Per-element font-style override (true = italic/oblique).
         font_italic: Option<bool>,
+        /// `letter-spacing` in SVG user units (plain number / px values only).
+        letter_spacing: Option<f32>,
         /// SVG text-anchor: "start" (default), "middle", or "end".
         text_anchor: SvgTextAnchor,
         content: String,
@@ -799,6 +801,7 @@ fn parse_svg_node_with_viewport(
             let fill_specified = has_fill_specified(el);
             let fill_raw = parse_fill_raw(el);
             let (font_family, font_bold, font_italic) = parse_svg_font_attrs(el);
+            let letter_spacing = parse_svg_letter_spacing(el);
             let content = collect_text_content(el);
             let style = parse_svg_style(el);
             let text_anchor = match el.attributes.get("text-anchor").map(|s| s.as_str()) {
@@ -816,6 +819,7 @@ fn parse_svg_node_with_viewport(
                 font_family,
                 font_bold,
                 font_italic,
+                letter_spacing,
                 text_anchor,
                 content,
                 style,
@@ -1836,6 +1840,19 @@ fn parse_svg_font_style_value(val: &str) -> Option<bool> {
         return None;
     }
     Some(is_italic_value(val))
+}
+
+/// Parse `letter-spacing` from a `<text>` element (attribute or inline style).
+///
+/// Only plain numbers and `px` values are supported (SVG user units);
+/// `normal`, `em`, and percentage values resolve to `None`.
+fn parse_svg_letter_spacing(el: &ElementNode) -> Option<f32> {
+    let raw = style_property_value(el, "letter-spacing")
+        .map(str::to_string)
+        .or_else(|| el.attributes.get("letter-spacing").map(|v| v.to_string()))?;
+    let raw = raw.trim();
+    let raw = raw.strip_suffix("px").unwrap_or(raw).trim();
+    raw.parse::<f32>().ok().filter(|v| v.is_finite())
 }
 
 fn parse_svg_font_attrs(el: &ElementNode) -> (Option<String>, Option<bool>, Option<bool>) {

--- a/src/render/pdf/background_images.rs
+++ b/src/render/pdf/background_images.rs
@@ -115,6 +115,8 @@ pub(super) fn render_svg_background(
         shadings,
         shading_counter,
         ext_gstates,
+        custom_fonts,
+        prepared_custom_fonts,
     } = resources;
     let PdfBackgroundPaintContext {
         background: paint,
@@ -370,11 +372,12 @@ pub(super) fn render_svg_background(
             image_sink: Some(&mut image_sink),
             raster_scale_x: placement.scale_x.abs(),
             raster_scale_y: placement.scale_y.abs(),
-            // SVG used as a CSS background image: custom-font text in
-            // background SVGs is out of scope here (no font context is threaded
-            // this far), so fall back to standard fonts.
-            custom_fonts: None,
-            prepared_custom_fonts: None,
+            // SVG used as a CSS background image: thread the caller's font
+            // context through so custom-font `<text>` resolves registered
+            // families exactly like foreground SVG text (standard fonts remain
+            // the fallback when no context is wired up, e.g. in tests).
+            custom_fonts,
+            prepared_custom_fonts,
         };
         crate::render::svg_to_pdf::render_svg_tree_with_resources(tree, &mut cell, &mut resources);
     }

--- a/src/render/pdf/backgrounds.rs
+++ b/src/render/pdf/backgrounds.rs
@@ -37,6 +37,15 @@ pub(super) struct PdfBackgroundResources<'a> {
     pub(super) shadings: &'a mut Vec<ShadingEntry>,
     pub(super) shading_counter: &'a mut usize,
     pub(super) ext_gstates: Option<&'a mut Vec<(String, f32)>>,
+    /// Loaded custom (bundled) fonts, so `<text>` inside a CSS
+    /// background-image SVG can shape and render with a registered custom
+    /// family instead of falling back to base-14 standard fonts.
+    pub(super) custom_fonts:
+        Option<&'a std::collections::HashMap<String, crate::parser::ttf::TtfFont>>,
+    /// Subsetted/prepared custom fonts mirroring what body text embedded, so
+    /// background SVG text references the same font resource and subset
+    /// glyph-id remapping.
+    pub(super) prepared_custom_fonts: Option<&'a crate::render::pdf_fonts::PreparedCustomFonts>,
 }
 
 impl<'a> PdfBackgroundResources<'a> {
@@ -53,7 +62,21 @@ impl<'a> PdfBackgroundResources<'a> {
             shadings,
             shading_counter,
             ext_gstates,
+            custom_fonts: None,
+            prepared_custom_fonts: None,
         }
+    }
+
+    /// Wire the custom-font context through so background-image SVG `<text>`
+    /// resolves registered families exactly like foreground SVG text.
+    pub(super) fn with_custom_fonts(
+        mut self,
+        custom_fonts: &'a std::collections::HashMap<String, crate::parser::ttf::TtfFont>,
+        prepared_custom_fonts: &'a crate::render::pdf_fonts::PreparedCustomFonts,
+    ) -> Self {
+        self.custom_fonts = Some(custom_fonts);
+        self.prepared_custom_fonts = Some(prepared_custom_fonts);
+        self
     }
 }
 

--- a/src/render/pdf/container/flex.rs
+++ b/src/render/pdf/container/flex.rs
@@ -199,7 +199,8 @@ pub(super) fn render_flex_child(
                     ctx.shadings,
                     ctx.shading_counter,
                     Some(&mut *ctx.page_ext_gstates),
-                ),
+                )
+                .with_custom_fonts(ctx.text.custom_fonts, ctx.text.prepared_custom_fonts),
                 PdfBackgroundPaintContext::local(BackgroundPaintContext::new(
                     flex_image_reference.into(),
                     flex_background.image_destination_box.into(),

--- a/src/render/pdf/container/nested.rs
+++ b/src/render/pdf/container/nested.rs
@@ -497,7 +497,8 @@ pub(super) fn render_nested_container(
                         ctx.shadings,
                         ctx.shading_counter,
                         Some(ctx.page_ext_gstates),
-                    ),
+                    )
+                    .with_custom_fonts(ctx.text.custom_fonts, ctx.text.prepared_custom_fonts),
                     PdfBackgroundPaintContext::local(BackgroundPaintContext::new(
                         nk_image_reference.into(),
                         background_geometry.image_destination_box.into(),

--- a/src/render/pdf/container/text.rs
+++ b/src/render/pdf/container/text.rs
@@ -168,7 +168,8 @@ pub(super) fn render_text_child(
                     ctx.shadings,
                     ctx.shading_counter,
                     Some(ctx.page_ext_gstates),
-                ),
+                )
+                .with_custom_fonts(ctx.text.custom_fonts, ctx.text.prepared_custom_fonts),
                 BlockBackground {
                     geometry: tb_box_geometry,
                     border_radii: *tb_radii,
@@ -535,7 +536,8 @@ pub(super) fn render_text_child(
                     ctx.shadings,
                     ctx.shading_counter,
                     Some(ctx.page_ext_gstates),
-                ),
+                )
+                .with_custom_fonts(ctx.text.custom_fonts, ctx.text.prepared_custom_fonts),
                 BlockBackground {
                     geometry: tb_box_geometry,
                     border_radii: *tb_radii,

--- a/src/render/pdf/page_elements/container_decoration.rs
+++ b/src/render/pdf/page_elements/container_decoration.rs
@@ -247,7 +247,8 @@ pub(super) fn paint_container_decoration(
                     ctx.shadings,
                     ctx.shading_counter,
                     Some(ctx.page_ext_gstates),
-                ),
+                )
+                .with_custom_fonts(ctx.text.custom_fonts, ctx.text.prepared_custom_fonts),
                 paint,
             );
             if c_bg_blended {

--- a/src/render/pdf/page_elements/flex.rs
+++ b/src/render/pdf/page_elements/flex.rs
@@ -187,7 +187,8 @@ pub(in crate::render::pdf) fn render_flex_row(
                     ctx.shadings,
                     ctx.shading_counter,
                     Some(ctx.page_ext_gstates),
-                ),
+                )
+                .with_custom_fonts(ctx.text.custom_fonts, ctx.text.prepared_custom_fonts),
                 PdfBackgroundPaintContext::local(BackgroundPaintContext::new(
                     flex_image_reference.into(),
                     flex_background_geometry.image_destination_box.into(),
@@ -403,7 +404,8 @@ pub(in crate::render::pdf) fn render_flex_row(
                         ctx.shadings,
                         ctx.shading_counter,
                         Some(ctx.page_ext_gstates),
-                    ),
+                    )
+                    .with_custom_fonts(ctx.text.custom_fonts, ctx.text.prepared_custom_fonts),
                     PdfBackgroundPaintContext::local(BackgroundPaintContext::new(
                         cell_background
                             .positioning_area

--- a/src/render/pdf/page_elements/text.rs
+++ b/src/render/pdf/page_elements/text.rs
@@ -555,7 +555,8 @@ pub(in crate::render::pdf) fn render_text_block(
                 ctx.shadings,
                 ctx.shading_counter,
                 Some(ctx.page_ext_gstates),
-            ),
+            )
+            .with_custom_fonts(ctx.text.custom_fonts, ctx.text.prepared_custom_fonts),
             paint,
         );
         if tb_bg_blended {

--- a/src/render/pdf_fonts.rs
+++ b/src/render/pdf_fonts.rs
@@ -1,7 +1,7 @@
 use crate::layout::elements::{
     AvoidPageBreak, ColumnRule, Container, FlexRow, GridRow, HorizontalRule, Image, LayoutElement,
     LayoutVisitor, MathBlock, NamedString, PageBreak, ProgressBar, RunningElement, Svg, TableRow,
-    TextBlock, visit_layout_tree,
+    TextBlock,
 };
 use crate::layout::engine::{Page, TextLine, TextRun};
 use crate::parser::ttf::TtfFont;
@@ -235,7 +235,20 @@ fn collect_font_usage_from_element(
         custom_fonts,
         usage,
     };
-    visit_layout_tree(element, &mut collector);
+    collect_font_usage_walk(element, &mut collector);
+}
+
+/// Depth-first walk pairing the node visitor with a per-box background check:
+/// custom-font `<text>` inside a CSS background-image SVG must be subset and
+/// embedded exactly like foreground SVG text.
+fn collect_font_usage_walk(element: &dyn LayoutElement, collector: &mut FontUsageCollector<'_>) {
+    if let Some(owner) = element.box_paint_owner()
+        && let Some(svg) = owner.box_paint().background.layers.svg.as_ref()
+    {
+        collect_font_usage_from_svg(svg, collector.custom_fonts, collector.usage);
+    }
+    element.accept(collector);
+    element.visit_children(&mut |child| collect_font_usage_walk(child, collector));
 }
 
 struct FontUsageCollector<'a> {
@@ -255,6 +268,9 @@ impl LayoutVisitor for FontUsageCollector<'_> {
                 self.custom_fonts,
                 self.usage,
             );
+            if let Some(svg) = cell.layout.paint.box_paint.background.layers.svg.as_ref() {
+                collect_font_usage_from_svg(svg, self.custom_fonts, self.usage);
+            }
         }
     }
 
@@ -265,12 +281,18 @@ impl LayoutVisitor for FontUsageCollector<'_> {
                 self.custom_fonts,
                 self.usage,
             );
+            if let Some(svg) = cell.layout.paint.box_paint.background.layers.svg.as_ref() {
+                collect_font_usage_from_svg(svg, self.custom_fonts, self.usage);
+            }
         }
     }
 
     fn visit_flex_row(&mut self, element: &FlexRow) {
         for cell in &element.content.cells {
             collect_font_usage_from_lines(&cell.lines, self.custom_fonts, self.usage);
+            if let Some(svg) = cell.paint.background.layers.svg.as_ref() {
+                collect_font_usage_from_svg(svg, self.custom_fonts, self.usage);
+            }
         }
     }
 
@@ -372,8 +394,11 @@ fn collect_font_usage_from_svg_node(
                 .or(style.font_italic)
                 .or(inherited_italic)
                 .unwrap_or(text_ctx.font_italic);
+            // `family` may be a raw CSS family stack ("MyFace, Helvetica");
+            // resolve it exactly like the SVG text renderer so every font the
+            // renderer binds is also subset and embedded.
             let Some((resolved_name, font)) =
-                crate::system_fonts::find_font(custom_fonts, &family, bold, italic)
+                crate::system_fonts::find_font_in_stack(custom_fonts, &family, bold, italic)
             else {
                 return;
             };

--- a/src/render/svg_to_pdf.rs
+++ b/src/render/svg_to_pdf.rs
@@ -139,7 +139,9 @@ impl<'a> SvgPdfResources<'a> {
         italic: bool,
     ) -> Option<(&'a str, &'a crate::parser::ttf::TtfFont)> {
         let fonts = self.custom_fonts?;
-        crate::system_fonts::find_font(fonts, family, bold, italic)
+        // `family` may be a raw CSS family stack ("MyFace, Helvetica"); the
+        // first registered entry wins, matching the font-usage collector.
+        crate::system_fonts::find_font_in_stack(fonts, family, bold, italic)
     }
 
     /// Register an opacity ExtGState and return the generated name, or None
@@ -574,6 +576,7 @@ fn render_node(
             font_family,
             font_bold,
             font_italic,
+            letter_spacing,
             text_anchor,
             content,
             style,
@@ -654,6 +657,13 @@ fn render_node(
                 (false, false) => 3,
             };
 
+            // letter-spacing adds a constant advance between glyphs; it is
+            // painted via the Tc operator and included in anchor width math.
+            let letter_spacing = letter_spacing.unwrap_or(0.0);
+            let spacing_gaps = |glyph_count: usize| -> f32 {
+                letter_spacing * glyph_count.saturating_sub(1) as f32
+            };
+
             // Adjust x for text-anchor. Use the real shaped advance for custom
             // fonts so anchoring matches the actual glyph widths.
             let text_x = match text_anchor {
@@ -665,12 +675,14 @@ fn render_node(
                                 || {
                                     let (ff, is_bold) = font_metrics_font(&font);
                                     crate::fonts::str_width(content, size, &ff, is_bold)
+                                        + spacing_gaps(content.chars().count())
                                 },
-                                |shaped| shaped.width,
+                                |shaped| shaped.width + spacing_gaps(shaped.glyphs.len()),
                             )
                     } else {
                         let (ff, is_bold) = font_metrics_font(&font);
                         crate::fonts::str_width(content, size, &ff, is_bold)
+                            + spacing_gaps(content.chars().count())
                     };
                     if *text_anchor == SvgTextAnchor::Middle {
                         x - text_w * 0.5
@@ -691,11 +703,15 @@ fn render_node(
                     fill,
                     stroke,
                     style.stroke_width,
+                    letter_spacing,
                     out,
                 );
             } else {
                 out.push_str("BT\n");
                 out.push_str(&format!("/{font} {size} Tf\n"));
+                if letter_spacing != 0.0 {
+                    out.push_str(&format!("{letter_spacing} Tc\n"));
+                }
                 out.push_str(&format!("{text_render_mode} Tr\n"));
                 if let Some((r, g, b)) = fill {
                     out.push_str(&format!("{r} {g} {b} rg\n"));
@@ -707,6 +723,11 @@ fn render_node(
                 out.push_str(&format!("1 0 0 -1 {text_x} {y} Tm\n"));
                 let encoded = encode_pdf_text(content);
                 out.push_str(&format!("({encoded}) Tj\n"));
+                if letter_spacing != 0.0 {
+                    // Character spacing survives ET; reset so later text on the
+                    // same content stream is unaffected.
+                    out.push_str("0 Tc\n");
+                }
                 out.push_str("ET\n");
             }
             if opacity_wrapped {
@@ -1523,6 +1544,7 @@ fn emit_custom_svg_text(
     fill: Option<(f32, f32, f32)>,
     stroke: Option<(f32, f32, f32)>,
     stroke_width: f32,
+    letter_spacing: f32,
     out: &mut String,
 ) {
     let Some(shaped) = crate::text::shape_text_with_explicit_font(content, size, custom.font)
@@ -1532,6 +1554,9 @@ fn emit_custom_svg_text(
 
     out.push_str("BT\n");
     out.push_str(&format!("/{} {size} Tf\n", custom.resource_name));
+    if letter_spacing != 0.0 {
+        out.push_str(&format!("{letter_spacing} Tc\n"));
+    }
     out.push_str(&format!("{text_render_mode} Tr\n"));
     if let Some((r, g, b)) = fill {
         out.push_str(&format!("{r} {g} {b} rg\n"));
@@ -1566,6 +1591,11 @@ fn emit_custom_svg_text(
         crate::render::pdf::append_pdf_tj_adjustment(out, tj_adjustment);
     }
     out.push_str("] TJ\n");
+    if letter_spacing != 0.0 {
+        // Character spacing survives ET; reset so later text on the same
+        // content stream is unaffected.
+        out.push_str("0 Tc\n");
+    }
     out.push_str("ET\n");
 }
 
@@ -2264,6 +2294,7 @@ mod tests {
             font_family: Some("Helvetica".to_string()),
             font_bold: Some(false),
             font_italic: Some(false),
+            letter_spacing: None,
             text_anchor: SvgTextAnchor::Start,
             content: text.to_string(),
             style: SvgStyle {
@@ -3366,6 +3397,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3420,6 +3452,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3478,6 +3511,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle::default(),
@@ -3516,6 +3550,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3565,6 +3600,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3620,6 +3656,7 @@ mod tests {
                     font_family: None,
                     font_bold: None,
                     font_italic: None,
+                    letter_spacing: None,
                     text_anchor: SvgTextAnchor::Start,
                     content: "Hello".to_string(),
                     style: SvgStyle {
@@ -3659,6 +3696,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle {
@@ -3711,6 +3749,7 @@ mod tests {
                     font_family: None,
                     font_bold: None,
                     font_italic: None,
+                    letter_spacing: None,
                     text_anchor: SvgTextAnchor::Start,
                     content: "Hello".to_string(),
                     style: SvgStyle {
@@ -3750,6 +3789,7 @@ mod tests {
                 font_family: None,
                 font_bold: None,
                 font_italic: None,
+                letter_spacing: None,
                 text_anchor: SvgTextAnchor::Start,
                 content: "Hello".to_string(),
                 style: SvgStyle::default(),

--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -226,6 +226,25 @@ pub(crate) fn find_font<'a>(
     })
 }
 
+/// Resolve a raw CSS font-family stack (`"MyFace, Helvetica"`) against the
+/// registered fonts: the first entry with a registered face wins, so an
+/// author-listed custom face beats a later base-14 fallback. A single family
+/// name resolves exactly like [`find_font`].
+pub(crate) fn find_font_in_stack<'a>(
+    fonts: &'a HashMap<String, TtfFont>,
+    stack: &str,
+    bold: bool,
+    italic: bool,
+) -> Option<(&'a str, &'a TtfFont)> {
+    stack.split(',').find_map(|family| {
+        let family = family.trim().trim_matches(|c| c == '\'' || c == '"').trim();
+        if family.is_empty() {
+            return None;
+        }
+        find_font(fonts, family, bold, italic)
+    })
+}
+
 /// Resolve a face using CSS Fonts' discrete width matching order before style
 /// and weight fallback. Callers that retain the returned map key can then keep
 /// using [`find_font`] for shaping, metrics, and PDF embedding.


### PR DESCRIPTION
## Summary

Two related SVG `<text>` fidelity changes in one focused commit:

**`letter-spacing` support (Added).** Parse `letter-spacing` from the attribute or inline style (plain numbers and `px` user units; `normal`/`em`/`%` resolve to none, per the parser's existing absolute-unit policy) and emit it as the PDF character-spacing operator (`Tc`), reset after each text object so later text on the same content stream is unaffected. Anchor-width math for `text-anchor: middle/end` includes the spacing gaps on both the custom-font (shaped glyph count) and base-14 (char count) paths.

**Custom-font resolution gaps (Fixed).** SVG `<text>` already resolves a single registered family, but two gaps remained:

1. A CSS family stack (`font-family="MyFace, Helvetica"`) never matched registered faces — the string was tried as one family name. Worse, the renderer and the font-usage collector disagreed: after fixing only the renderer, the bound font was never subset/embedded, producing a dangling font reference. Both now resolve through one shared `system_fonts::find_font_in_stack` (first registered entry wins), so every font the renderer binds is also embedded.
2. `<text>` inside a CSS background-image SVG explicitly opted out of custom fonts ("no font context is threaded this far"). The font context now threads through `PdfBackgroundResources` (a `with_custom_fonts` builder, wired at every background call site), and the usage collector walks background-image SVG trees on every painted box and table/grid/flex cell, so background SVG text is subset and embedded exactly like foreground SVG text.

## Tests

- `svg_text_letter_spacing_emits_character_spacing` — asserts `3 Tc` and the `0 Tc` reset.
- `add_font_used_by_svg_text` — family stack binds the registered face, emits shaped `TJ` glyphs, and the font is embedded (`/Subtype /CIDFontType2`).
- `add_font_used_by_background_image_svg_text` — the same guarantees for a `background-image: url(data:image/svg+xml,…)` div.
- `svg_text_with_unregistered_family_falls_back_to_base14` — unregistered families keep the base-14 mapping and literal text emission.

## Verification

- `cargo fmt --check` clean.
- `cargo test --lib`: 3333 passed, 0 failed (3329 baseline + the 4 tests above).
- `cargo test --lib --features remote`: 3346 passed, 0 failed.
- `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm` clean.
- Parity suite unchanged (no existing fixture exercises SVG text letter-spacing or custom-font stacks; rendered output only changes where the features/bugs applied).

## Notes for review

- `find_font_in_stack` trims quotes/whitespace per entry and delegates to the existing `find_font`, so single-family behavior is byte-identical to before.
- `PdfBackgroundResources::new` keeps its signature; the fonts ride an optional builder (`with_custom_fonts`) so test call sites stay as they are and paths without a font context (none remain in production) keep the standard-font fallback.
- This ports pre-1.5 work from this fork, re-targeted at the split `emit_custom_svg_text`/base-14 emitters the 1.6.0 renderer grew.
