### PR TITLE
fix(table): keep inline-block boxes inline with cell text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Conan 2 and vcpkg source recipes package the existing C and C++ bindings and
   verify static and shared consumers across the native platform matrix.
 
+### Fixed
+
+- An inline-tagged `display: inline-block` inside a table cell (form fill-in
+  underlines, checkbox squares) flows inline with the cell's sibling text
+  again instead of dropping onto its own stacked line below it.
+
 ## [1.6.0] — 2026-08-26
 
 ### Added

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -3777,11 +3777,16 @@ fn table_cell_edge_block_margins(
 }
 
 fn table_cell_child_should_flatten(el: &ElementNode, style: &ComputedStyle) -> bool {
+    // An inline-tagged inline-block stays in the cell's text-run flow — the
+    // same gate as `InlineFormattingRole::uses_text_run_layout` — so a form
+    // fill-in underline or checkbox square renders inline with its sibling
+    // text (CSS 2 §9.2.2) instead of dropping onto its own stacked line.
+    let inline_block_in_text_flow = style.display == Display::InlineBlock && el.tag.is_inline();
     el.tag == HtmlTag::Table
         || el.tag == HtmlTag::Img
         || el.tag == HtmlTag::Svg
         || (recurses_as_layout_child(el.tag) && !collects_as_inline_text(el.tag))
-        || style.display != Display::Inline
+        || (style.display != Display::Inline && !inline_block_in_text_flow)
         || style.position.is_absolute()
 }
 
@@ -3872,6 +3877,41 @@ mod subpoint_width_tests {
             visit_layout_tree(element.as_ref(), &mut rows);
         }
         rows.0
+    }
+
+    /// An inline-tagged `display:inline-block` inside a table cell stays in
+    /// the cell's text-run flow — one line whose atomic run carries an
+    /// `InlineBox` — instead of dropping onto its own stacked block line
+    /// (form fill-ins: `NPO <span style="…border-bottom…"></span> after`).
+    #[test]
+    fn inline_block_in_table_cell_flows_inline_with_text() {
+        let nodes = parse_html(
+            r#"<table><tr><td>NPO <span style="display:inline-block;width:60pt;border-bottom:1pt solid #000">&nbsp;</span> after</td></tr></table>"#,
+        )
+        .expect("valid fill-in fixture");
+        let pages = layout(&nodes, PageSize::new(400.0, 300.0), Margin::uniform(10.0));
+        let rows = table_rows(&pages[0]);
+        assert_eq!(rows.len(), 1, "one table row expected");
+        let cell = &rows[0].content.cells[0].layout;
+        assert!(
+            cell.content.children.is_empty(),
+            "inline-block must not be flattened into stacked cell children"
+        );
+        assert_eq!(
+            cell.content.lines.len(),
+            1,
+            "label, fill-in box, and trailing text share one line"
+        );
+        let line = &cell.content.lines[0];
+        assert!(
+            line.runs.iter().any(|run| run.inline_box.is_some()),
+            "the inline-block must be collected as an atomic inline-box run"
+        );
+        let text: String = line.runs.iter().map(|run| run.text.as_str()).collect();
+        assert!(
+            text.contains("NPO") && text.contains("after"),
+            "sibling text must stay in the same line, got {text:?}"
+        );
     }
 
     #[test]

--- a/src/render/pdf/layout_elements.rs
+++ b/src/render/pdf/layout_elements.rs
@@ -281,7 +281,7 @@ pub(super) fn render_cell_content(
                 PdfPoint::new(placement.origin.x, content_top),
                 placement.col_width,
             ),
-            &mut ctx.text,
+            ctx,
         );
         render_cell_child_elements(
             content,
@@ -319,7 +319,7 @@ pub(super) fn render_cell_content(
             PdfPoint::new(placement.origin.x, content_top),
             placement.col_width,
         ),
-        &mut ctx.text,
+        ctx,
     );
 }
 
@@ -357,14 +357,16 @@ pub(super) fn render_cell_text(
     content: &mut String,
     cell: &CellBox,
     placement: CellTextPlacement,
-    ctx: &mut TextRenderContext<'_>,
+    ctx: &mut PageRenderContext<'_>,
 ) {
     let cell_inner_w = placement.col_width - cell.box_model.content_insets.horizontal();
-    let mut baseline_cursor =
-        TextBaselineCursor::new(placement.origin.y, ctx.pdf_writer.page_content_transform);
+    let mut baseline_cursor = TextBaselineCursor::new(
+        placement.origin.y,
+        ctx.text.pdf_writer.page_content_transform,
+    );
     let mut first_drawn_line = true;
     for line in &cell.content.lines {
-        let metrics = line_box_metrics(line, ctx.custom_fonts);
+        let metrics = line_box_metrics(line, ctx.text.custom_fonts);
         let text_y = baseline_cursor.next_horizontal(metrics);
         let line_annotation_bottom = text_y - metrics.descender - metrics.half_leading;
         let line_annotation_height =
@@ -386,7 +388,7 @@ pub(super) fn render_cell_text(
         let merged = crate::text::coalesce_text_runs(&line.runs);
         let line_width: f32 = merged
             .iter()
-            .map(|run| estimate_run_width_with_fonts(run, ctx.custom_fonts))
+            .map(|run| estimate_run_width_with_fonts(run, ctx.text.custom_fonts))
             .sum();
         let text_x = match cell.alignment.inline {
             TextAlign::Right => {
@@ -401,8 +403,54 @@ pub(super) fn render_cell_text(
             }
             _ => placement.origin.x + cell.box_model.content_insets.left + first_line_indent,
         };
+        // Line-box edges for inline-box vertical alignment, mirroring the
+        // page-level text painter's geometry.
+        let line_top_y = text_y + metrics.ascender + metrics.half_leading;
+        let line_bottom_y = text_y - metrics.descender - metrics.half_leading;
+        let (text_ascent, text_descent) = line_text_content_extents(line, ctx.text.custom_fonts);
+        let line_text_top_y = if text_ascent > 0.0 {
+            text_y + text_ascent
+        } else {
+            line_top_y
+        };
+        let line_text_bottom_y = if text_descent > 0.0 {
+            text_y - text_descent
+        } else {
+            line_bottom_y
+        };
         let mut x = text_x;
         for (run_index, run) in merged.iter().enumerate() {
+            // Atomic inline box (display: inline-block) in the cell's text
+            // flow: paint the box and its inner content, then advance —
+            // the same treatment the page-level line painter applies.
+            if let Some(inline) = run.inline_box.as_deref() {
+                if !run.is_inline_edge() {
+                    render_inline_box(
+                        content,
+                        inline,
+                        x + inline.margin_left,
+                        text_y,
+                        ctx.text.page_height,
+                        line_top_y,
+                        line_bottom_y,
+                        line_text_top_y,
+                        line_text_bottom_y,
+                        run.font_size,
+                        run_line_height_for_vertical_align(run),
+                        line_primary_x_height_ratio(&merged, ctx.text.custom_fonts),
+                        ctx.text.custom_fonts,
+                        ctx.text.prepared_custom_fonts,
+                        ctx.page_ext_gstates,
+                        ctx.bg_alpha_counter,
+                        ctx.shadings,
+                        ctx.shading_counter,
+                        ctx.text.pdf_writer,
+                        ctx.text.page_images,
+                    );
+                }
+                x += run.atomic_inline_advance().unwrap_or_default();
+                continue;
+            }
             if let Some(advance) = run.atomic_inline_advance() {
                 x += advance;
                 continue;
@@ -410,13 +458,13 @@ pub(super) fn render_cell_text(
             if run.text.is_empty() {
                 continue;
             }
-            let run_width = estimate_run_width_with_fonts(run, ctx.custom_fonts);
+            let run_width = estimate_run_width_with_fonts(run, ctx.text.custom_fonts);
             let previous = merged[..run_index]
                 .iter()
                 .rev()
                 .find(|previous| previous.inline_box.is_none() && !previous.text.is_empty());
             let decoration =
-                HorizontalRunDecorations::new(run, x, run_width, text_y, ctx.custom_fonts)
+                HorizontalRunDecorations::new(run, x, run_width, text_y, ctx.text.custom_fonts)
                     .continuing_after(previous);
 
             if let Some(background) = run.background_color {
@@ -439,17 +487,17 @@ pub(super) fn render_cell_text(
             decoration.paint_text(
                 content,
                 crate::layout::text::line_primary_font_size(&merged),
-                ctx.prepared_custom_fonts,
+                ctx.text.prepared_custom_fonts,
                 0.0,
-                ctx.pdf_writer,
-                ctx.page_images,
+                ctx.text.pdf_writer,
+                ctx.text.page_images,
             );
 
             if let Some(annotation) = text_run_link_annotation(
                 run,
                 PdfRect::new(x, line_annotation_bottom, run_width, line_annotation_height),
             ) {
-                ctx.annotations.push(annotation);
+                ctx.text.annotations.push(annotation);
             }
 
             x += run_width;

--- a/src/render/pdf/layout_elements/test_support.rs
+++ b/src/render/pdf/layout_elements/test_support.rs
@@ -159,7 +159,7 @@ pub(in crate::render::pdf) fn render_nested_text_block(
                 geometry.padding_box().width,
             )
             .with_first_line_indent(block.text_indent),
-            &mut ctx.text,
+            ctx,
         );
     }
 }

--- a/src/render/pdf/mod.rs
+++ b/src/render/pdf/mod.rs
@@ -187,9 +187,8 @@ use writer_output::PagePaintStreams;
 
 #[cfg(test)]
 use layout_elements::{
-    CellTextPlacement, NestedTextBlock, TextRenderContext, plan_nested_layout_elements,
-    render_cell_text, render_nested_layout_elements, render_nested_text_block,
-    table_row_total_height,
+    CellTextPlacement, NestedTextBlock, plan_nested_layout_elements, render_cell_text,
+    render_nested_layout_elements, render_nested_text_block, table_row_total_height,
 };
 
 fn collect_document_svg_defs(pages: &[Page]) -> crate::parser::svg::SvgDefs {

--- a/src/render/pdf/tests/layout.rs
+++ b/src/render/pdf/tests/layout.rs
@@ -657,13 +657,22 @@ fn render_cell_text_vertical_centering() {
     let prepared_fonts = PreparedCustomFonts::new();
     let mut ts_pdf_writer = PdfWriter::new();
     let mut ts_page_images = Vec::new();
-    let mut text_context = TextRenderContext::new(
-        TEST_PAGE_PAINT_BOX.height,
-        &fonts,
-        &prepared_fonts,
-        &mut annotations,
+    let mut ts_shadings = Vec::new();
+    let mut ts_shading_counter = 0usize;
+    let mut ts_ext_gstates = Vec::new();
+    let mut ts_alpha_counter = 0usize;
+    let mut text_context = PageRenderContext::new(
         &mut ts_pdf_writer,
         &mut ts_page_images,
+        &fonts,
+        &prepared_fonts,
+        &mut ts_shadings,
+        &mut ts_shading_counter,
+        &mut ts_ext_gstates,
+        &mut ts_alpha_counter,
+        &mut annotations,
+        TEST_PAGE_PAINT_BOX,
+        TEST_PAGE_PAINT_BOX.height,
     );
     render_cell_text(
         &mut content,

--- a/src/render/pdf/tests/nested_tables.rs
+++ b/src/render/pdf/tests/nested_tables.rs
@@ -124,13 +124,22 @@
         let mut annotations = Vec::new();
         let mut ts_pdf_writer = PdfWriter::new();
         let mut ts_page_images = Vec::new();
-        let mut ctx = TextRenderContext::new(
-            TEST_PAGE_PAINT_BOX.height,
-            &custom_fonts,
-            &prepared_custom_fonts,
-            &mut annotations,
+        let mut ts_shadings = Vec::new();
+        let mut ts_shading_counter = 0usize;
+        let mut ts_ext_gstates = Vec::new();
+        let mut ts_alpha_counter = 0usize;
+        let mut ctx = PageRenderContext::new(
             &mut ts_pdf_writer,
             &mut ts_page_images,
+            &custom_fonts,
+            &prepared_custom_fonts,
+            &mut ts_shadings,
+            &mut ts_shading_counter,
+            &mut ts_ext_gstates,
+            &mut ts_alpha_counter,
+            &mut annotations,
+            TEST_PAGE_PAINT_BOX,
+            TEST_PAGE_PAINT_BOX.height,
         );
 
         let run = test_text_run("Aligned");
@@ -190,13 +199,22 @@
         let mut annotations = Vec::new();
         let mut ts_pdf_writer = PdfWriter::new();
         let mut ts_page_images = Vec::new();
-        let mut ctx = TextRenderContext::new(
-            TEST_PAGE_PAINT_BOX.height,
-            &custom_fonts,
-            &prepared_custom_fonts,
-            &mut annotations,
+        let mut ts_shadings = Vec::new();
+        let mut ts_shading_counter = 0usize;
+        let mut ts_ext_gstates = Vec::new();
+        let mut ts_alpha_counter = 0usize;
+        let mut ctx = PageRenderContext::new(
             &mut ts_pdf_writer,
             &mut ts_page_images,
+            &custom_fonts,
+            &prepared_custom_fonts,
+            &mut ts_shadings,
+            &mut ts_shading_counter,
+            &mut ts_ext_gstates,
+            &mut ts_alpha_counter,
+            &mut annotations,
+            TEST_PAGE_PAINT_BOX,
+            TEST_PAGE_PAINT_BOX.height,
         );
 
         let underline_run = TextRun {
@@ -268,13 +286,22 @@
         let mut annotations = Vec::new();
         let mut ts_pdf_writer = PdfWriter::new();
         let mut ts_page_images = Vec::new();
-        let mut ctx = TextRenderContext::new(
-            TEST_PAGE_PAINT_BOX.height,
-            &custom_fonts,
-            &prepared_custom_fonts,
-            &mut annotations,
+        let mut ts_shadings = Vec::new();
+        let mut ts_shading_counter = 0usize;
+        let mut ts_ext_gstates = Vec::new();
+        let mut ts_alpha_counter = 0usize;
+        let mut ctx = PageRenderContext::new(
             &mut ts_pdf_writer,
             &mut ts_page_images,
+            &custom_fonts,
+            &prepared_custom_fonts,
+            &mut ts_shadings,
+            &mut ts_shading_counter,
+            &mut ts_ext_gstates,
+            &mut ts_alpha_counter,
+            &mut annotations,
+            TEST_PAGE_PAINT_BOX,
+            TEST_PAGE_PAINT_BOX.height,
         );
 
         let run = TextRun {
@@ -323,13 +350,22 @@
         let mut annotations = Vec::new();
         let mut ts_pdf_writer = PdfWriter::new();
         let mut ts_page_images = Vec::new();
-        let mut ctx = TextRenderContext::new(
-            TEST_PAGE_PAINT_BOX.height,
-            &custom_fonts,
-            &prepared_custom_fonts,
-            &mut annotations,
+        let mut ts_shadings = Vec::new();
+        let mut ts_shading_counter = 0usize;
+        let mut ts_ext_gstates = Vec::new();
+        let mut ts_alpha_counter = 0usize;
+        let mut ctx = PageRenderContext::new(
             &mut ts_pdf_writer,
             &mut ts_page_images,
+            &custom_fonts,
+            &prepared_custom_fonts,
+            &mut ts_shadings,
+            &mut ts_shading_counter,
+            &mut ts_ext_gstates,
+            &mut ts_alpha_counter,
+            &mut annotations,
+            TEST_PAGE_PAINT_BOX,
+            TEST_PAGE_PAINT_BOX.height,
         );
 
         let run = TextRun {

--- a/src/render/pdf/tests/text_encoding.rs
+++ b/src/render/pdf/tests/text_encoding.rs
@@ -35,13 +35,22 @@
         let prepared_fonts = PreparedCustomFonts::new();
         let mut ts_pdf_writer = PdfWriter::new();
         let mut ts_page_images = Vec::new();
-        let mut text_context = TextRenderContext::new(
-            TEST_PAGE_PAINT_BOX.height,
-            &fonts,
-            &prepared_fonts,
-            &mut annotations,
+        let mut ts_shadings = Vec::new();
+        let mut ts_shading_counter = 0usize;
+        let mut ts_ext_gstates = Vec::new();
+        let mut ts_alpha_counter = 0usize;
+        let mut text_context = PageRenderContext::new(
             &mut ts_pdf_writer,
             &mut ts_page_images,
+            &fonts,
+            &prepared_fonts,
+            &mut ts_shadings,
+            &mut ts_shading_counter,
+            &mut ts_ext_gstates,
+            &mut ts_alpha_counter,
+            &mut annotations,
+            TEST_PAGE_PAINT_BOX,
+            TEST_PAGE_PAINT_BOX.height,
         );
         render_cell_text(
             &mut content,


### PR DESCRIPTION
## Summary

The table inline-flow failure class from #254 — the code is unchanged from that review round; this round adds the requested pinned-Chromium parity fixture.

An inline-tagged `display:inline-block` inside a table cell (a form fill-in underline via `border-bottom`, a checkbox square via explicit width/height) painted correctly but dropped onto its own stacked line below the cell's text. `table_cell_child_should_flatten` now carves out inline-tagged inline-blocks with the same predicate as `InlineFormattingRole::uses_text_run_layout`, so the shared `InlineRunCollector` emits them as atomic `TextRun.inline_box` runs, and `render_cell_text` paints those runs through the same `render_inline_box` as the page-level line painter (taking `PageRenderContext` for the paint resources).

## Related issue

Split from #254 per review ("split this PR by failure class").

## Behavioral source

- CSS 2 §9.2.2: an inline-block is an inline-level box participating in its inline formatting context.
- New pinned-Chromium parity fixture `tables-cell-inline-block-inline-flow`: label, fill-in underline box, checkbox square, and trailing text share one line inside a bordered cell.
- Content-stream evidence in the commit message: before, the cell text at y=757.14 with the border rect ~16 pt lower; after, label, box, and trailing text share one baseline — matching Chrome.

## Verification

- `cargo fmt --check` — clean
- `cargo +1.88.0 clippy -- -D warnings` — clean (pre-existing newer-clippy lints reproduce identically on clean `upstream/main`)
- `cargo test --lib` — 3330 passed, 0 failed (includes the `inline_block_in_table_cell_flows_inline_with_text` regression test)
- `cargo +1.88.0 check --target wasm32-unknown-unknown --no-default-features --features wasm` — clean

- [x] Tests cover the changed behavior
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

## Visual parity

- [x] Relevant parity fixtures and reports were updated — new fixture `tables-cell-inline-block-inline-flow`
- [x] Any new oracle PDF was generated with the pinned Chromium launcher — via the repository's own `scripts/parity-gen-refs.sh` + `scripts/chromium-fontations.sh`, unmodified, driving snap Chromium on Ubuntu 24.04 (`refs.lock` carries the provenance)

## Bindings and documentation

- [x] The C, .NET, Java, Python, Ruby, and WebAssembly impact was considered — no binding surface changes
- [x] Public API or behavior changes are documented (changelog)
- [x] User-visible changes have a changelog entry

## Final checks

- [x] The change is focused and contains no unrelated cleanup
- [x] No secrets, generated scratch files, or local artifacts are included
- [x] I agree to follow the [Ironpress Code of Conduct](https://github.com/gastongouron/ironpress/blob/main/CODE_OF_CONDUCT.md)
