### PR TITLE
perf(table): per-cell auto-sizing memo owned by the layout pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Conan 2 and vcpkg source recipes package the existing C and C++ bindings and
   verify static and shared consumers across the native platform matrix.
 
+### Changed
+
+- Auto table layout memoizes each cell's intrinsic widths within a layout,
+  collapsing the exponential re-measurement of nested tables (a depth-6 nest
+  converts about twice as fast) with byte-identical output.
+
 ## [1.6.0] — 2026-08-26
 
 ### Added

--- a/src/layout/context.rs
+++ b/src/layout/context.rs
@@ -5,6 +5,7 @@ use crate::style::font_metrics::FontMetrics;
 use std::collections::HashMap;
 
 use super::engine::CounterState;
+use super::table::TableCellSizingMemo;
 
 /// Shared mutable environment for the layout traversal.
 ///
@@ -22,6 +23,12 @@ pub(crate) struct LayoutEnv<'a> {
     /// Rasterization DPI for layout-time filter bitmaps such as replaced-image
     /// `filter: blur()` and `filter: drop-shadow()`.
     pub filter_dpi: f32,
+    /// Measurements already taken by the table auto-sizing pass, owned by the
+    /// current top-level layout. Auto table layout re-measures a cell once per
+    /// sizing pass at every nesting level, so a deeply nested cell is otherwise
+    /// measured exponentially often; borrowing the memo from here keeps it alive
+    /// exactly as long as the DOM it describes.
+    pub table_cell_sizing: &'a mut TableCellSizingMemo,
 }
 
 impl<'a> LayoutEnv<'a> {

--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -2159,6 +2159,10 @@ pub(crate) fn layout_with_rules_and_fonts_raster_quality(
     // element regardless of where in the tree it lives.
     let mut filter_defs: HashMap<String, ElementNode> = HashMap::new();
     collect_id_defs(nodes, &mut filter_defs);
+    // Owned by this layout and dropped with it, so the DOM addresses the table
+    // auto-sizing pass records as keys stay valid for exactly as long as the
+    // memo can be consulted.
+    let mut table_cell_sizing = super::table::TableCellSizingMemo::default();
     let mut env = LayoutEnv {
         rules,
         fonts: custom_fonts,
@@ -2166,6 +2170,7 @@ pub(crate) fn layout_with_rules_and_fonts_raster_quality(
         resources,
         filter_defs: &filter_defs,
         filter_dpi: raster_quality.filter_dpi,
+        table_cell_sizing: &mut table_cell_sizing,
     };
     if let Some(root) =
         RootFormattingContext::from_projected_body(nodes, &body_style, available_width)

--- a/src/layout/table.rs
+++ b/src/layout/table.rs
@@ -40,7 +40,10 @@ use super::text::{
     text_run_line_height_factor, used_font_size, wrap_text_runs,
 };
 
+mod cell_sizing_memo;
 mod collapsed_borders;
+pub(crate) use cell_sizing_memo::TableCellSizingMemo;
+use cell_sizing_memo::{CellContentWidths, CellSizingKey};
 use collapsed_borders::{
     CollapsedBorderSources, CollapsedBorderTrack, resolve_collapsed_border_grid,
 };
@@ -1328,15 +1331,11 @@ fn measure_caption_min_width(
     section_count: usize,
     caption_style: &ComputedStyle,
     table_ancestors: &[AncestorInfo],
-    rules: &[CssRule],
-    fonts: &HashMap<String, TtfFont>,
-    filter_defs: &HashMap<String, ElementNode>,
-    filter_dpi: f32,
-    counter_state: &mut CounterState,
-    resources: &mut crate::security::resources::ResourceLoader,
+    env: &mut LayoutEnv,
     available_width: f32,
     descendant_layout: TableDescendantLayout,
 ) -> f32 {
+    let fonts = env.fonts;
     let mut caption_ancestors = table_ancestors.to_vec();
     caption_ancestors.push(AncestorInfo {
         element: caption_el,
@@ -1348,28 +1347,18 @@ fn measure_caption_min_width(
     });
     let mut runs = Vec::new();
     let mut nested = Vec::new();
-    {
-        let mut flow_env = LayoutEnv {
-            rules,
-            fonts,
-            counter_state,
-            resources,
-            filter_defs,
-            filter_dpi,
-        };
-        layout_table_cell_flow(
-            &caption_el.children,
-            &mut runs,
-            &mut nested,
-            TableCellFlowContext {
-                style: caption_style,
-                ancestors: &caption_ancestors,
-                available_width: available_width.max(0.0),
-                descendant_layout,
-            },
-            &mut flow_env,
-        );
-    }
+    layout_table_cell_flow(
+        &caption_el.children,
+        &mut runs,
+        &mut nested,
+        TableCellFlowContext {
+            style: caption_style,
+            ancestors: &caption_ancestors,
+            available_width: available_width.max(0.0),
+            descendant_layout,
+        },
+        env,
+    );
     let text_width: f32 = runs
         .iter()
         .map(|run| {
@@ -1789,6 +1778,7 @@ pub(crate) fn flatten_table(
     let filter_dpi = env.filter_dpi;
     let counter_state = &mut *env.counter_state;
     let resources = &mut *env.resources;
+    let table_cell_sizing = &mut *env.table_cell_sizing;
     let mut measurement_counter_state = counter_state.clone();
     let table_border = LayoutBorder::from_computed(&style.border, style.color);
     let effective_border_spacing = style.border_spacing;
@@ -2013,18 +2003,22 @@ pub(crate) fn flatten_table(
         .iter()
         .zip(&caption_styles_for_layout)
         .map(|((caption_el, caption_child_idx), caption_style)| {
+            let mut caption_env = LayoutEnv {
+                rules,
+                fonts,
+                counter_state: &mut measurement_counter_state,
+                resources: &mut *resources,
+                filter_defs,
+                filter_dpi,
+                table_cell_sizing: &mut *table_cell_sizing,
+            };
             measure_caption_min_width(
                 caption_el,
                 *caption_child_idx,
                 section_count,
                 caption_style,
                 &table_ancestors,
-                rules,
-                fonts,
-                filter_defs,
-                filter_dpi,
-                &mut measurement_counter_state,
-                &mut *resources,
+                &mut caption_env,
                 inner_width,
                 descendant_layout,
             )
@@ -2391,156 +2385,193 @@ pub(crate) fn flatten_table(
                         }
                         let colspan = parse_cell_colspan(cell_el);
                         let span = colspan.min(num_cols - col_pos);
-                        let cell_classes = cell_el.class_list();
-                        let mut cell_sizing_ancestors = sizing_row_ctx.ancestors.clone();
-                        push_table_dom_ancestor(
-                            &mut cell_sizing_ancestors,
-                            row,
-                            ElementSiblingContext::new(
-                                row_section_indices[sizing_row_idx],
-                                row_section_sizes[sizing_row_idx],
-                            ),
-                        );
-                        let cell_sizing_ctx = cell_siblings
-                            .selector_context(&cell_sizing_ancestors, element_is_empty(cell_el));
-                        let cell_style = anonymous_table_box_style(cell_el, &row_style)
-                            .unwrap_or_else(|| {
-                                compute_style_with_context_with_font_metrics(
-                                    cell_el.tag,
-                                    cell_el.style_attr(),
-                                    &row_style,
-                                    rules,
-                                    cell_el.tag_name(),
-                                    &cell_classes,
-                                    cell_el.id(),
-                                    &cell_el.attributes,
-                                    &cell_sizing_ctx,
-                                    FontMetrics::new(fonts),
-                                )
-                            });
-                        let cell_counter_scope =
-                            measurement_counter_state.enter_element(&cell_style);
-                        let authored_generated = GeneratedContentStyles::resolve(
-                            cell_el,
-                            &cell_style,
-                            rules,
-                            &cell_sizing_ctx,
-                            fonts,
-                        );
-                        let authored_generated = authored_generated.boxes(cell_el);
-                        let mut runs = Vec::new();
-                        let mut nested_rows = Vec::new();
-                        let mut text_ancestors = cell_sizing_ctx.ancestors.clone();
-                        push_table_dom_ancestor(&mut text_ancestors, cell_el, cell_siblings);
-                        generated_cell_content.append_before_measurement(
-                            &mut runs,
-                            fonts,
-                            &mut measurement_counter_state,
-                            &mut *resources,
-                        );
-                        authored_generated.append_before_measurement(
-                            &mut runs,
-                            fonts,
-                            &mut measurement_counter_state,
-                            &mut *resources,
-                        );
-                        {
-                            let mut measurement_env = LayoutEnv {
-                                rules,
-                                fonts,
-                                counter_state: &mut measurement_counter_state,
-                                resources: &mut *resources,
-                                filter_defs,
-                                filter_dpi,
-                            };
-                            layout_table_cell_flow(
-                                &cell_el.children,
-                                &mut runs,
-                                &mut nested_rows,
-                                TableCellFlowContext {
-                                    style: &cell_style,
-                                    ancestors: &text_ancestors,
-                                    available_width: inner_width,
-                                    descendant_layout,
-                                },
-                                &mut measurement_env,
+                        // Reuse this cell's measurement when it has already been
+                        // taken against the same inner width: a hit skips the
+                        // cell's compute_style and the entire nested flatten
+                        // below. An entry is only trusted while no counter or
+                        // quote context is live, because an empty state cannot
+                        // influence the measurement, and an empty-to-empty
+                        // measurement cannot have left any behind.
+                        let sizing_key = CellSizingKey::new(cell_el, inner_width);
+                        let counters_empty_before = measurement_counter_state.stacks.is_empty()
+                            && measurement_counter_state.quote_depth == 0;
+                        let measured = 'cell_sizing: {
+                            if counters_empty_before
+                                && let Some(widths) = table_cell_sizing.get(&sizing_key)
+                            {
+                                break 'cell_sizing widths;
+                            }
+                            let cell_classes = cell_el.class_list();
+                            let mut cell_sizing_ancestors = sizing_row_ctx.ancestors.clone();
+                            push_table_dom_ancestor(
+                                &mut cell_sizing_ancestors,
+                                row,
+                                ElementSiblingContext::new(
+                                    row_section_indices[sizing_row_idx],
+                                    row_section_sizes[sizing_row_idx],
+                                ),
                             );
-                        }
-                        generated_cell_content.append_after_measurement(
-                            &mut runs,
-                            fonts,
-                            &mut measurement_counter_state,
-                            &mut *resources,
-                        );
-                        authored_generated.append_after_measurement(
-                            &mut runs,
-                            fonts,
-                            &mut measurement_counter_state,
-                            &mut *resources,
-                        );
-                        runs.as_mut_slice().resolve_unclaimed_boundaries(
-                            crate::layout::elements::TextSpacing::from_style(&cell_style),
-                        );
-                        measurement_counter_state.leave_element(cell_counter_scope);
-                        // Measure the same prepared styled tokens and the same
-                        // ordered advances that the final line wrapper consumes.
-                        // This makes max-content an actual exact fit: no point- or
-                        // pixel-based slack is added to table geometry.
-                        let text_options =
-                            table_cell_text_wrap_options(&cell_style, inner_width, fonts);
-                        let intrinsic = measure_text_intrinsic_widths(
-                            runs,
-                            text_options,
-                            table_cell_allows_soft_wrap(&cell_style),
-                            fonts,
-                        );
-                        let content_width = intrinsic.max_content;
-                        let content_min_width = intrinsic.min_content;
-                        // Nested block descendants (e.g. a fixed-width <div>) and
-                        // nested tables both contribute a minimum content width so
-                        // a shrink-to-fit cell does not crush them narrower than
-                        // their own declared/intrinsic width.
-                        let nested_width = nested_rows
-                            .iter()
-                            .map(|element| nested_element_preferred_width(element.as_ref()))
-                            .fold(0.0f32, f32::max);
-                        // An explicit width on the cell (CSS or `width` attribute)
-                        // seeds the column's preferred width: the column is at least
-                        // as wide as the declared width, taken as the track width
-                        // (consistent with the fixed-layout path).
-                        let explicit_cell_width =
-                            resolve_cell_track_width(cell_el, &cell_style, inner_width)
-                                .unwrap_or(0.0);
-                        // Content-box → border-box: the column track must hold the
-                        // content plus the cell's horizontal padding AND border
-                        // (borders paint inside the cell box). Under
-                        // `border-collapse: collapse` adjacent borders merge onto a
-                        // shared grid line and each cell owns only HALF of a
-                        // collapsed border, so the track contribution scales the
-                        // border by the same half factor used by the paint inset
-                        // (see `border_inset_factor` below); `separate` keeps the
-                        // full border. Without this the track is sized for the full
-                        // border but painted center-to-center on the grid line,
-                        // making each collapsed column ~half-a-border too wide.
-                        let cell_border =
-                            LayoutBorder::from_computed(&cell_style.border, cell_style.color);
-                        let cell_insets = table_cell_content_insets(
-                            &cell_style,
-                            &cell_border,
-                            style.border_collapse,
-                        );
-                        let cell_padding_x = cell_insets.horizontal();
-                        let total_preferred =
-                            required_outer_width(content_width.max(nested_width), cell_padding_x)
-                                .max(explicit_cell_width);
-                        // Min-content includes padding and is floored by an explicit
-                        // cell width (an explicit `width` makes the column at least
-                        // that wide even for shrinking).
-                        let total_min = required_outer_width(
-                            content_min_width.max(nested_width),
-                            cell_padding_x,
-                        )
-                        .max(explicit_cell_width);
+                            let cell_sizing_ctx = cell_siblings.selector_context(
+                                &cell_sizing_ancestors,
+                                element_is_empty(cell_el),
+                            );
+                            let cell_style = anonymous_table_box_style(cell_el, &row_style)
+                                .unwrap_or_else(|| {
+                                    compute_style_with_context_with_font_metrics(
+                                        cell_el.tag,
+                                        cell_el.style_attr(),
+                                        &row_style,
+                                        rules,
+                                        cell_el.tag_name(),
+                                        &cell_classes,
+                                        cell_el.id(),
+                                        &cell_el.attributes,
+                                        &cell_sizing_ctx,
+                                        FontMetrics::new(fonts),
+                                    )
+                                });
+                            let cell_counter_scope =
+                                measurement_counter_state.enter_element(&cell_style);
+                            let authored_generated = GeneratedContentStyles::resolve(
+                                cell_el,
+                                &cell_style,
+                                rules,
+                                &cell_sizing_ctx,
+                                fonts,
+                            );
+                            let authored_generated = authored_generated.boxes(cell_el);
+                            let mut runs = Vec::new();
+                            let mut nested_rows = Vec::new();
+                            let mut text_ancestors = cell_sizing_ctx.ancestors.clone();
+                            push_table_dom_ancestor(&mut text_ancestors, cell_el, cell_siblings);
+                            generated_cell_content.append_before_measurement(
+                                &mut runs,
+                                fonts,
+                                &mut measurement_counter_state,
+                                &mut *resources,
+                            );
+                            authored_generated.append_before_measurement(
+                                &mut runs,
+                                fonts,
+                                &mut measurement_counter_state,
+                                &mut *resources,
+                            );
+                            {
+                                let mut measurement_env = LayoutEnv {
+                                    rules,
+                                    fonts,
+                                    counter_state: &mut measurement_counter_state,
+                                    resources: &mut *resources,
+                                    filter_defs,
+                                    filter_dpi,
+                                    table_cell_sizing: &mut *table_cell_sizing,
+                                };
+                                layout_table_cell_flow(
+                                    &cell_el.children,
+                                    &mut runs,
+                                    &mut nested_rows,
+                                    TableCellFlowContext {
+                                        style: &cell_style,
+                                        ancestors: &text_ancestors,
+                                        available_width: inner_width,
+                                        descendant_layout,
+                                    },
+                                    &mut measurement_env,
+                                );
+                            }
+                            generated_cell_content.append_after_measurement(
+                                &mut runs,
+                                fonts,
+                                &mut measurement_counter_state,
+                                &mut *resources,
+                            );
+                            authored_generated.append_after_measurement(
+                                &mut runs,
+                                fonts,
+                                &mut measurement_counter_state,
+                                &mut *resources,
+                            );
+                            runs.as_mut_slice().resolve_unclaimed_boundaries(
+                                crate::layout::elements::TextSpacing::from_style(&cell_style),
+                            );
+                            measurement_counter_state.leave_element(cell_counter_scope);
+                            // Measure the same prepared styled tokens and the same
+                            // ordered advances that the final line wrapper consumes.
+                            // This makes max-content an actual exact fit: no point- or
+                            // pixel-based slack is added to table geometry.
+                            let text_options =
+                                table_cell_text_wrap_options(&cell_style, inner_width, fonts);
+                            let intrinsic = measure_text_intrinsic_widths(
+                                runs,
+                                text_options,
+                                table_cell_allows_soft_wrap(&cell_style),
+                                fonts,
+                            );
+                            let content_width = intrinsic.max_content;
+                            let content_min_width = intrinsic.min_content;
+                            // Nested block descendants (e.g. a fixed-width <div>) and
+                            // nested tables both contribute a minimum content width so
+                            // a shrink-to-fit cell does not crush them narrower than
+                            // their own declared/intrinsic width.
+                            let nested_width = nested_rows
+                                .iter()
+                                .map(|element| nested_element_preferred_width(element.as_ref()))
+                                .fold(0.0f32, f32::max);
+                            // An explicit width on the cell (CSS or `width` attribute)
+                            // seeds the column's preferred width: the column is at least
+                            // as wide as the declared width, taken as the track width
+                            // (consistent with the fixed-layout path).
+                            let explicit_cell_width =
+                                resolve_cell_track_width(cell_el, &cell_style, inner_width)
+                                    .unwrap_or(0.0);
+                            // Content-box → border-box: the column track must hold the
+                            // content plus the cell's horizontal padding AND border
+                            // (borders paint inside the cell box). Under
+                            // `border-collapse: collapse` adjacent borders merge onto a
+                            // shared grid line and each cell owns only HALF of a
+                            // collapsed border, so the track contribution scales the
+                            // border by the same half factor used by the paint inset
+                            // (see `border_inset_factor` below); `separate` keeps the
+                            // full border. Without this the track is sized for the full
+                            // border but painted center-to-center on the grid line,
+                            // making each collapsed column ~half-a-border too wide.
+                            let cell_border =
+                                LayoutBorder::from_computed(&cell_style.border, cell_style.color);
+                            let cell_insets = table_cell_content_insets(
+                                &cell_style,
+                                &cell_border,
+                                style.border_collapse,
+                            );
+                            let cell_padding_x = cell_insets.horizontal();
+                            let total_preferred = required_outer_width(
+                                content_width.max(nested_width),
+                                cell_padding_x,
+                            )
+                            .max(explicit_cell_width);
+                            // Min-content includes padding and is floored by an explicit
+                            // cell width (an explicit `width` makes the column at least
+                            // that wide even for shrinking).
+                            let total_min = required_outer_width(
+                                content_min_width.max(nested_width),
+                                cell_padding_x,
+                            )
+                            .max(explicit_cell_width);
+                            let measured = CellContentWidths {
+                                preferred: total_preferred,
+                                min: total_min,
+                            };
+                            if counters_empty_before
+                                && measurement_counter_state.stacks.is_empty()
+                                && measurement_counter_state.quote_depth == 0
+                            {
+                                table_cell_sizing.insert(sizing_key, measured);
+                            }
+                            measured
+                        };
+                        let CellContentWidths {
+                            preferred: total_preferred,
+                            min: total_min,
+                        } = measured;
                         if span == 1 {
                             if col_pos < num_cols {
                                 preferred_widths[col_pos] =
@@ -3131,6 +3162,7 @@ pub(crate) fn flatten_table(
                     resources: &mut *resources,
                     filter_defs,
                     filter_dpi,
+                    table_cell_sizing: &mut *table_cell_sizing,
                 };
                 layout_table_cell_flow(
                     &cell_el.children,
@@ -3553,6 +3585,7 @@ pub(crate) fn flatten_table(
                 resources: &mut *resources,
                 filter_defs,
                 filter_dpi,
+                table_cell_sizing: &mut *table_cell_sizing,
             };
             layout_table_cell_flow(
                 &caption_el.children,
@@ -4573,5 +4606,151 @@ mod border_tests {
         assert!(used_height > 68.0 * 0.75);
         assert!(!is_definite, "table height is a minimum, not a hard cap");
         assert!(estimate_element_height(table_root) >= used_height);
+    }
+}
+
+#[cfg(test)]
+mod nested_table_sizing_tests {
+    use super::*;
+    use crate::layout::elements::visit_layout_tree;
+    use crate::layout::engine::layout_with_rules;
+    use crate::parser::css::parse_stylesheet;
+    use crate::parser::html::parse_html_with_styles;
+    use crate::types::{Margin, PageSize};
+
+    const PAGE: PageSize = PageSize {
+        width: 400.0,
+        height: 400.0,
+    };
+    /// Explicit width on the innermost cell. Every enclosing column has to hold
+    /// it, so it is the floor the whole nest is measured against.
+    const SEED_WIDTH_PX: f32 = 20.0;
+    /// The same length in the points layout resolves to. css-values-4 § 5.2
+    /// pins `1px` to `1/96in` and `1pt` to `1/72in`.
+    const SEED_WIDTH_PT: f32 = SEED_WIDTH_PX * 72.0 / 96.0;
+
+    /// Strips every padding, border, and spacing contribution from the nest, so
+    /// the only width any of the three tables can report is the one its content
+    /// asks for.
+    fn reset() -> String {
+        format!(
+            "<style>
+                table {{ table-layout: auto; border-collapse: separate;
+                         border-spacing: 0; margin: 0; width: auto }}
+                td {{ padding: 0; border: 0 }}
+                .seed {{ width: {SEED_WIDTH_PX}px }}
+            </style>"
+        )
+    }
+
+    /// Three tables nested one inside the other, ending in a single cell that
+    /// carries `label` at an explicit width.
+    fn nested_tables(label: &str) -> String {
+        format!(
+            "<table><tr><td>\
+               <table><tr><td>\
+                 <table><tr><td class=\"seed\">{label}</td></tr></table>\
+               </td></tr></table>\
+             </td></tr></table>"
+        )
+    }
+
+    /// Lay `body` out and report each table row's used column widths, outermost
+    /// row first. The parsed document dies with this call, which is what lets a
+    /// later layout reuse its addresses.
+    fn column_widths(body: &str) -> Vec<Vec<f32>> {
+        #[derive(Default)]
+        struct ColumnWidths(Vec<Vec<f32>>);
+
+        impl LayoutVisitor for ColumnWidths {
+            fn visit_table_row(&mut self, row: &TableRow) {
+                self.0.push(row.content.column_widths.clone());
+            }
+        }
+
+        let document = parse_html_with_styles(&format!("{}{body}", reset()))
+            .expect("valid nested table fixture");
+        let rules = document
+            .stylesheets
+            .iter()
+            .flat_map(|stylesheet| parse_stylesheet(stylesheet))
+            .collect::<Vec<_>>();
+        let pages = layout_with_rules(&document.nodes, PAGE, Margin::uniform(0.0), &rules);
+        let mut widths = ColumnWidths::default();
+        for page in &pages {
+            for (_, element) in &page.elements {
+                visit_layout_tree(element.as_ref(), &mut widths);
+            }
+        }
+        widths.0
+    }
+
+    /// CSS 2.1 § 17.5.2.2: a cell is never narrower than its content, and the
+    /// content of each enclosing cell here is the whole table below it. With no
+    /// padding, border, or spacing anywhere in the nest there is nothing for a
+    /// level to add, so every level reports the same width — the innermost
+    /// declared width once the label fits inside it.
+    #[test]
+    fn a_nest_carries_the_innermost_width_out_to_every_level() {
+        for label in ["i", "mmmmmmmmmmmmmmmm"] {
+            let widths = column_widths(&nested_tables(label));
+
+            assert_eq!(widths.len(), 3, "one row per nesting level: {widths:?}");
+            for level in &widths {
+                assert_eq!(level.len(), 1, "one column per level: {widths:?}");
+                assert!(
+                    level[0] >= SEED_WIDTH_PT,
+                    "a column narrower than the innermost cell it contains: {widths:?}"
+                );
+            }
+            assert!(
+                widths.windows(2).all(|pair| pair[0] == pair[1]),
+                "a level widened or narrowed content it only passes through: {widths:?}"
+            );
+        }
+        assert_eq!(
+            column_widths(&nested_tables("i")),
+            vec![vec![SEED_WIDTH_PT]; 3],
+            "a label narrower than the declared width leaves that width used"
+        );
+    }
+
+    /// A table's used column widths follow from its own content and its own
+    /// containing block, so putting two differently sized nests in one document
+    /// must size each exactly as it is sized on its own.
+    #[test]
+    fn sibling_nests_are_sized_from_their_own_content() {
+        let narrow = nested_tables("i");
+        let wide = nested_tables("mmmmmmmmmmmmmmmm");
+        let narrow_alone = column_widths(&narrow);
+        let wide_alone = column_widths(&wide);
+        assert_ne!(
+            narrow_alone, wide_alone,
+            "the two nests must differ for this to prove anything"
+        );
+
+        let together = column_widths(&format!("{narrow}{wide}"));
+
+        assert_eq!(together, [narrow_alone, wide_alone].concat());
+    }
+
+    /// Layout is a function of the document alone: what was rendered before it
+    /// in this process cannot show through. A per-cell measurement keyed by DOM
+    /// address must therefore die with the layout that took it, well before a
+    /// later document can be handed the same addresses.
+    #[test]
+    fn a_nest_is_sized_the_same_after_an_earlier_document_is_freed() {
+        let narrow = nested_tables("i");
+        let wide = nested_tables("mmmmmmmmmmmmmmmm");
+        let narrow_alone = column_widths(&narrow);
+        let wide_alone = column_widths(&wide);
+        assert_ne!(
+            narrow_alone, wide_alone,
+            "the two nests must differ for this to prove anything"
+        );
+
+        assert_eq!(column_widths(&narrow), narrow_alone, "narrow after narrow");
+        assert_eq!(column_widths(&wide), wide_alone, "wide after narrow");
+        assert_eq!(column_widths(&narrow), narrow_alone, "narrow after wide");
     }
 }

--- a/src/layout/table/cell_sizing_memo.rs
+++ b/src/layout/table/cell_sizing_memo.rs
@@ -1,0 +1,155 @@
+//! Memoization of the table auto-sizing pass's per-cell measurements.
+//!
+//! Auto table layout walks every cell twice — once to size the columns and once
+//! to place the content — and measuring a cell that contains a nested table
+//! flattens that entire nested table just to read its width. The two walks
+//! therefore compound with nesting: a cell `d` tables deep is re-measured on the
+//! order of `2^d` times, all of it redundant because the measurement is a pure
+//! function of the cell subtree and the width it is measured against. This memo
+//! reduces that to one measurement per `(cell, table inner width)`.
+
+use std::collections::HashMap;
+
+use crate::parser::dom::ElementNode;
+
+/// The two intrinsic widths the auto-sizing pass derives for one cell.
+///
+/// Both are already grown from the content box to the cell's border box, so a
+/// column track consumes them without knowing how the cell was measured.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct CellContentWidths {
+    /// Max-content contribution: the width at which the cell's content takes
+    /// its preferred number of lines.
+    pub(crate) preferred: f32,
+    /// Min-content contribution: the narrowest track the cell tolerates before
+    /// its content overflows.
+    pub(crate) min: f32,
+}
+
+/// Identity of one cell measurement.
+///
+/// The measured widths depend on the cell subtree and on the table inner width
+/// the cell was measured against — that width bounds wrapping inside the cell —
+/// so both take part in the key.
+///
+/// The cell is identified by its address rather than by its markup. Structure
+/// is not identity here: sibling cells are routinely identical as markup yet
+/// select different rules through `:nth-child` and inherit different styles from
+/// their position, so only the node itself distinguishes them.
+///
+/// Addresses are sound as keys because a [`TableCellSizingMemo`] is owned by one
+/// top-level layout call and dropped with it, while the DOM it indexes outlives
+/// that call. An address recorded during a layout therefore always names a live
+/// node of that same DOM, and an address freed after a layout can never be
+/// looked up again, because the memo that held it is already gone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct CellSizingKey {
+    cell: usize,
+    /// The table inner width as raw bits. `f32` is neither `Eq` nor `Hash`, and
+    /// bit identity is the conservative reading of "the same width": widths that
+    /// differ in any bit — `0.0` and `-0.0` among them — simply miss and are
+    /// measured again.
+    inner_width: u32,
+}
+
+impl CellSizingKey {
+    pub(crate) fn new(cell: &ElementNode, inner_width: f32) -> Self {
+        Self {
+            cell: std::ptr::from_ref(cell) as usize,
+            inner_width: inner_width.to_bits(),
+        }
+    }
+}
+
+/// Per-layout memo of the table auto-sizing pass's cell measurements.
+///
+/// The top-level layout entry point owns one instance and lends it to the
+/// traversal through the layout environment, which ties the memo's lifetime to
+/// the lifetime of the DOM whose addresses it records.
+///
+/// The auto-sizing pass stores and trusts an entry only while no CSS counter or
+/// quote context is live around the measurement. A measurement that reads
+/// counters is not a function of the cell and the width alone, and one that
+/// writes them has an effect a cache hit would silently drop.
+#[derive(Debug, Default)]
+pub(crate) struct TableCellSizingMemo {
+    measured: HashMap<CellSizingKey, CellContentWidths>,
+}
+
+impl TableCellSizingMemo {
+    pub(crate) fn get(&self, key: &CellSizingKey) -> Option<CellContentWidths> {
+        self.measured.get(key).copied()
+    }
+
+    pub(crate) fn insert(&mut self, key: CellSizingKey, widths: CellContentWidths) {
+        self.measured.insert(key, widths);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::dom::HtmlTag;
+
+    const WIDTHS: CellContentWidths = CellContentWidths {
+        preferred: 120.0,
+        min: 40.0,
+    };
+
+    #[test]
+    fn an_unmeasured_cell_misses() {
+        let cell = ElementNode::new(HtmlTag::Td);
+        let memo = TableCellSizingMemo::default();
+
+        assert_eq!(memo.get(&CellSizingKey::new(&cell, 300.0)), None);
+    }
+
+    #[test]
+    fn a_measured_cell_hits_at_the_width_it_was_measured_against() {
+        let cell = ElementNode::new(HtmlTag::Td);
+        let mut memo = TableCellSizingMemo::default();
+
+        memo.insert(CellSizingKey::new(&cell, 300.0), WIDTHS);
+
+        assert_eq!(memo.get(&CellSizingKey::new(&cell, 300.0)), Some(WIDTHS));
+    }
+
+    #[test]
+    fn a_second_inner_width_is_measured_separately() {
+        let cell = ElementNode::new(HtmlTag::Td);
+        let mut memo = TableCellSizingMemo::default();
+
+        memo.insert(CellSizingKey::new(&cell, 300.0), WIDTHS);
+
+        assert_eq!(memo.get(&CellSizingKey::new(&cell, 150.0)), None);
+    }
+
+    #[test]
+    fn structurally_identical_cells_are_measured_separately() {
+        let measured = ElementNode::new(HtmlTag::Td);
+        let twin = ElementNode::new(HtmlTag::Td);
+        let mut memo = TableCellSizingMemo::default();
+
+        memo.insert(CellSizingKey::new(&measured, 300.0), WIDTHS);
+
+        assert_eq!(memo.get(&CellSizingKey::new(&twin, 300.0)), None);
+    }
+
+    #[test]
+    fn a_later_measurement_replaces_an_earlier_one() {
+        let cell = ElementNode::new(HtmlTag::Td);
+        let remeasured = CellContentWidths {
+            preferred: 80.0,
+            min: 20.0,
+        };
+        let mut memo = TableCellSizingMemo::default();
+
+        memo.insert(CellSizingKey::new(&cell, 300.0), WIDTHS);
+        memo.insert(CellSizingKey::new(&cell, 300.0), remeasured);
+
+        assert_eq!(
+            memo.get(&CellSizingKey::new(&cell, 300.0)),
+            Some(remeasured)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The table auto-sizing failure class from #254, reworked per review: the per-cell memo is now **owned by the layout pass**, with no thread-locals and no interior mutability.

The auto-sizing pass measures every cell — flattening a nested table just to read its width — and an ancestor table is re-flattened once per pass (sizing + placement) at every nesting level, so nested cells were re-measured on the order of 2^depth times.

- `TableCellSizingMemo` is created by the top-level layout entry point and lent to the traversal through `LayoutEnv`, so it lives exactly as long as one layout of one DOM ("pass an owned per-layout memo through the layout context", review comment on `src/layout/table.rs`).
- `CellSizingKey` (cell identity + measured inner width) and `CellContentWidths { preferred, min }` replace the raw `(usize, u32)` / `(f32, f32)` tuples. Cell identity is the node address — sibling cells are routinely identical as markup yet select different `:nth-child` rules, so only the node distinguishes them — and the memo dying with the layout while the DOM outlives it is what makes addresses sound; `nested_table_sizing_tests` pins that lifecycle across repeated documents.
- An entry is stored, and trusted, only while counter stacks and quote depth are empty around the measurement, unchanged from the review round.
- `measure_caption_min_width` takes the same `LayoutEnv` instead of five loose parameters.

Depth-6 nested-table document, release CLI, 5 runs (Apple silicon): upstream `main` best 897 ms / mean 1076 ms → this branch best 514 ms / mean 729 ms, with **byte-identical PDF output**.

## Related issue

Split from #254 per review ("split this PR by failure class").

## Behavioral source

Perf-only; the memoized measurement is a pure function of the cell subtree and the width measured against. `nested_table_sizing_tests` establishes the CSS 2.1 §17.5.2.2 expectations independently (a column is never narrower than its content; sibling nests size from their own content; repeated documents lay out identically), and the full suite plus the parity corpus are unchanged.

## Verification

- `cargo fmt --check` — clean
- `cargo +1.88.0 clippy -- -D warnings` — clean (pre-existing newer-clippy lints reproduce identically on clean `upstream/main`)
- `cargo test --lib` — 3337 passed, 0 failed
- `cargo +1.88.0 check --target wasm32-unknown-unknown --no-default-features --features wasm` — clean

- [x] Tests cover the changed behavior
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

## Visual parity

- [x] This change does not affect rendered output

## Bindings and documentation

- [x] The C, .NET, Java, Python, Ruby, and WebAssembly impact was considered — no binding surface changes; wasm target checked
- [x] Public API or behavior changes are documented (doc comments; perf change noted in the changelog)
- [x] User-visible changes have a changelog entry

## Final checks

- [x] The change is focused and contains no unrelated cleanup
- [x] No secrets, generated scratch files, or local artifacts are included
- [x] I agree to follow the [Ironpress Code of Conduct](https://github.com/gastongouron/ironpress/blob/main/CODE_OF_CONDUCT.md)
